### PR TITLE
Link Accelerate framework

### DIFF
--- a/mlx-sys/build.rs
+++ b/mlx-sys/build.rs
@@ -37,6 +37,11 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=Metal");
     }
 
+    #[cfg(feature = "accelerate")]
+    {
+        println!("cargo:rustc-link-lib=framework=Accelerate");
+    }
+
     // generate bindings
     let bindings = bindgen::Builder::default()
         .header("src/mlx-c/mlx/c/mlx.h")


### PR DESCRIPTION
This PR fixes a bug in the build script that the `Accelerate` framework is not linked when the `accelerate` feature is enabled