### PR TITLE
feat(api): impl Clone and Debug for Device and Stream

### DIFF
--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -29,6 +29,7 @@ fn scalar_basics() {
     assert_eq!(shape, vec![]);
 }
 
+#[allow(unused_variables)]
 fn array_basics() {
     // make a multidimensional array.
     let x: Array = Array::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
@@ -40,10 +41,10 @@ fn array_basics() {
     let y = Array::ones::<f32>(&[2, 2]);
 
     // Pointwise add x and y:
-    let mut z = x.add(&y);
+    let z = x.add(&y);
 
     // Same thing:
-    z = &x + &y;
+    let mut z = &x + &y;
 
     // mlx is lazy by default. At this point `z` only
     // has a shape and a type but no actual data:

--- a/src/array.rs
+++ b/src/array.rs
@@ -137,6 +137,14 @@ pub struct Array {
     pub(crate) c_array: mlx_array,
 }
 
+impl std::fmt::Debug for Array {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let description = crate::utils::mlx_describe(self.c_array as *mut c_void)
+            .unwrap_or_else(|| "Array".to_string());
+        write!(f, "{:?}", description)
+    }
+}
+
 impl std::fmt::Display for Array {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let description = crate::utils::mlx_describe(self.c_array as *mut c_void)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(unused_unsafe)]
+#![deny(unused_unsafe, missing_debug_implementations)]
 
 mod array;
 mod device;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -55,6 +55,12 @@ impl Default for StreamOrDevice {
     }
 }
 
+impl std::fmt::Debug for StreamOrDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.stream)
+    }
+}
+
 impl std::fmt::Display for StreamOrDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.stream)
@@ -92,7 +98,7 @@ impl Stream {
 }
 
 /// The `Stream` is a simple struct on the c++ side
-/// 
+///
 /// ```cpp
 /// struct Stream {
 ///     int index;
@@ -101,7 +107,7 @@ impl Stream {
 ///     // ... constructor
 /// };
 /// ```
-/// 
+///
 /// There is no function that mutates the stream, so we can implement `Clone` for it.
 impl Clone for Stream {
     fn clone(&self) -> Self {
@@ -124,6 +130,14 @@ impl Drop for Stream {
 impl Default for Stream {
     fn default() -> Self {
         Stream::new()
+    }
+}
+
+impl std::fmt::Debug for Stream {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let description = mlx_describe(self.c_stream as *mut std::os::raw::c_void);
+        let description = description.unwrap_or_else(|| "Stream".to_string());
+        write!(f, "{}", description)
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -7,6 +7,7 @@ use crate::utils::mlx_describe;
 ///
 /// If omitted it will use the [default()], which will be [Device::gpu()] unless
 /// set otherwise.
+#[derive(Clone)]
 pub struct StreamOrDevice {
     stream: Stream,
 }
@@ -87,6 +88,30 @@ impl Stream {
     pub fn default_stream(device: &Device) -> Stream {
         let default_stream = unsafe { mlx_sys::mlx_default_stream(device.c_device) };
         Stream::new_with_mlx_mlx_stream(default_stream)
+    }
+}
+
+/// The `Stream` is a simple struct on the c++ side
+/// 
+/// ```cpp
+/// struct Stream {
+///     int index;
+///     Device device;
+///
+///     // ... constructor
+/// };
+/// ```
+/// 
+/// There is no function that mutates the stream, so we can implement `Clone` for it.
+impl Clone for Stream {
+    fn clone(&self) -> Self {
+        unsafe {
+            // Increment the reference count.
+            mlx_sys::mlx_retain(self.c_stream as *mut std::ffi::c_void);
+            Stream {
+                c_stream: self.c_stream,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
1. Added `Clone` impl for `Device`, `Stream`, and `StreamOrDevice`
2. Deny `missing_debug_implementations` (pub types that don't have `Debug` impl will give an compile error`)