### PR TITLE
feat(api): eval related updates

### DIFF
--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -3,11 +3,11 @@ use std::ops::Add;
 
 fn scalar_basics() {
     // create a scalar array
-    let x: Array = 1.0.into();
+    let mut x: Array = 1.0.into();
 
     // the datatype is .float32
     let dtype = x.dtype();
-    assert_eq!(dtype, mlx::Dtype::Float32);
+    assert_eq!(dtype, Dtype::Float32);
 
     // get the value
     let s = x.item::<f32>();

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -239,7 +239,8 @@ impl Array {
         Ok(T::array_item(self))
     }
 
-    /// Returns a slice of the array data.
+    /// Returns a slice of the array data without validating the dtype.
+    /// This method requires a mutable reference (`&mut self`) because it evaluates the array.
     ///
     /// # Safety
     ///
@@ -269,7 +270,8 @@ impl Array {
         }
     }
 
-    /// Returns a slice of the array data.
+    /// Returns a slice of the array data returning an error if the dtype does not match the actual dtype.
+    /// This method requires a mutable reference (`&mut self`) because it evaluates the array.
     ///
     /// # Example
     ///
@@ -304,6 +306,7 @@ impl Array {
     }
 
     /// Returns a slice of the array data.
+    /// This method requires a mutable reference (`&mut self`) because it evaluates the array.
     ///
     /// # Panics
     ///

--- a/src/array/operators.rs
+++ b/src/array/operators.rs
@@ -87,7 +87,6 @@ mod tests {
         let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
         a += &b;
-        a.eval();
 
         assert_eq!(a.as_slice::<f32>(), &[5.0, 7.0, 9.0]);
     }
@@ -97,7 +96,6 @@ mod tests {
         let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
         a -= &b;
-        a.eval();
 
         assert_eq!(a.as_slice::<f32>(), &[-3.0, -3.0, -3.0]);
     }
@@ -107,7 +105,6 @@ mod tests {
         let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
         a *= &b;
-        a.eval();
 
         assert_eq!(a.as_slice::<f32>(), &[4.0, 10.0, 18.0]);
     }
@@ -117,7 +114,6 @@ mod tests {
         let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
         a /= &b;
-        a.eval();
 
         assert_eq!(a.as_slice::<f32>(), &[0.25, 0.4, 0.5]);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,9 @@ pub enum DataStoreError {
 
     #[error("broadcast error")]
     BroadcastError,
+
+    #[error("not a scalar array")]
+    NotScalar,
 }
 
 #[derive(Error, PartialEq, Debug)]

--- a/src/fft/fftn.rs
+++ b/src/fft/fftn.rs
@@ -464,15 +464,13 @@ mod tests {
             complex64::new(-2.0, -2.0),
         ];
 
-        let array = Array::from_slice(FFT_DATA, FFT_SHAPE);
+        let mut array = Array::from_slice(FFT_DATA, FFT_SHAPE);
         let mut fft = fft(&array, None, None);
-        fft.eval();
 
         assert_eq!(fft.dtype(), Dtype::Complex64);
         assert_eq!(fft.as_slice::<complex64>(), FFT_EXPECTED);
 
         let mut ifft = ifft(&fft, None, None);
-        ifft.eval();
 
         assert_eq!(ifft.dtype(), Dtype::Complex64);
         assert_eq!(
@@ -499,15 +497,13 @@ mod tests {
             complex64::new(0.0, 0.0),
         ];
 
-        let array = Array::from_slice(FFT2_DATA, FFT2_SHAPE);
+        let mut array = Array::from_slice(FFT2_DATA, FFT2_SHAPE);
         let mut fft2 = fft2(&array, None, None);
-        fft2.eval();
 
         assert_eq!(fft2.dtype(), Dtype::Complex64);
         assert_eq!(fft2.as_slice::<complex64>(), FFT2_EXPECTED);
 
         let mut ifft2 = ifft2(&fft2, None, None);
-        ifft2.eval();
 
         assert_eq!(ifft2.dtype(), Dtype::Complex64);
         assert_eq!(
@@ -538,15 +534,13 @@ mod tests {
             complex64::new(0.0, 0.0),
         ];
 
-        let array = Array::from_slice(FFTN_DATA, FFTN_SHAPE);
+        let mut array = Array::from_slice(FFTN_DATA, FFTN_SHAPE);
         let mut fftn = fftn(&array, None, None);
-        fftn.eval();
 
         assert_eq!(fftn.dtype(), Dtype::Complex64);
         assert_eq!(fftn.as_slice::<complex64>(), FFTN_EXPECTED);
 
         let mut ifftn = ifftn(&fftn, None, None);
-        ifftn.eval();
 
         assert_eq!(ifftn.dtype(), Dtype::Complex64);
         assert_eq!(

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -65,7 +65,8 @@
 //! assert_eq!(irfft_result.as_slice::<f32>(), &src[..]);
 //!
 //! // The original array is not modified
-//! assert_eq!(array.as_slice(), &src[..]);
+//! let data: &[f32] = array.as_slice();
+//! assert_eq!(data, &src[..]);
 //! ```
 //!
 //! ## Two dimensions
@@ -113,7 +114,8 @@
 //! assert_eq!(irfft2_result.as_slice::<f32>(), &src[..]);
 //!
 //! // The original array is not modified
-//! assert_eq!(array.as_slice(), &[1.0, 1.0, 1.0, 1.0]);
+//! let data: &[f32] = array.as_slice();
+//! assert_eq!(data, &[1.0, 1.0, 1.0, 1.0]);
 //! ```
 //!
 //! ## `N` dimensions
@@ -121,7 +123,7 @@
 //! ```rust
 //! use mlx::{Dtype, Array, StreamOrDevice, complex64, fft::*};
 //!
-//! let array = Array::ones::<f32>(&[2, 2, 2]);
+//! let mut array = Array::ones::<f32>(&[2, 2, 2]);
 //! let mut fftn_result = fftn(&array, None, None);
 //! assert_eq!(fftn_result.dtype(), Dtype::Complex64);
 //!

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -26,10 +26,9 @@
 //! use mlx::{Dtype, Array, StreamOrDevice, complex64, fft::*};
 //!
 //! let src = [1.0f32, 2.0, 3.0, 4.0];
-//! let array = Array::from_slice(&src[..], &[4]);
+//! let mut array = Array::from_slice(&src[..], &[4]);
 //!
 //! let mut fft_result = fft(&array, 4, 0);
-//! fft_result.eval();
 //! assert_eq!(fft_result.dtype(), Dtype::Complex64);
 //!
 //! let expected = &[
@@ -41,7 +40,6 @@
 //! assert_eq!(fft_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut ifft_result = ifft(&fft_result, 4, 0);
-//! ifft_result.eval();
 //! assert_eq!(ifft_result.dtype(), Dtype::Complex64);
 //!
 //! let expected = &[
@@ -53,7 +51,6 @@
 //! assert_eq!(ifft_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut rfft_result = rfft(&array, 4, 0);
-//! rfft_result.eval();
 //! assert_eq!(rfft_result.dtype(), Dtype::Complex64);
 //!
 //! let expected = &[
@@ -64,13 +61,11 @@
 //! assert_eq!(rfft_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut irfft_result = irfft(&rfft_result, 4, 0);
-//! irfft_result.eval();
 //! assert_eq!(irfft_result.dtype(), Dtype::Float32);
 //! assert_eq!(irfft_result.as_slice::<f32>(), &src[..]);
 //!
 //! // The original array is not modified
-//! let data: &[f32] = array.as_slice();
-//! assert_eq!(data, &src[..]);
+//! assert_eq!(array.as_slice(), &src[..]);
 //! ```
 //!
 //! ## Two dimensions
@@ -79,10 +74,9 @@
 //! use mlx::{Dtype, Array, StreamOrDevice, complex64, fft::*};
 //!
 //! let src = [1.0f32, 1.0, 1.0, 1.0];
-//! let array = Array::from_slice(&src[..], &[2, 2]);
+//! let mut array = Array::from_slice(&src[..], &[2, 2]);
 //!
 //! let mut fft2_result = fft2(&array, None, None);
-//! fft2_result.eval();
 //! assert_eq!(fft2_result.dtype(), Dtype::Complex64);
 //! let expected = &[
 //!     complex64::new(4.0, 0.0),
@@ -93,7 +87,6 @@
 //! assert_eq!(fft2_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut ifft2_result = ifft2(&fft2_result, None, None);
-//! ifft2_result.eval();
 //! assert_eq!(ifft2_result.dtype(), Dtype::Complex64);
 //!
 //! let expected = &[
@@ -105,7 +98,6 @@
 //! assert_eq!(ifft2_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut rfft2_result = rfft2(&array, None, None);
-//! rfft2_result.eval();
 //! assert_eq!(rfft2_result.dtype(), Dtype::Complex64);
 //!
 //! let expected = &[
@@ -117,13 +109,11 @@
 //! assert_eq!(rfft2_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut irfft2_result = irfft2(&rfft2_result, None, None);
-//! irfft2_result.eval();
 //! assert_eq!(irfft2_result.dtype(), Dtype::Float32);
 //! assert_eq!(irfft2_result.as_slice::<f32>(), &src[..]);
 //!
 //! // The original array is not modified
-//! let data: &[f32] = array.as_slice();
-//! assert_eq!(data, &[1.0, 1.0, 1.0, 1.0]);
+//! assert_eq!(array.as_slice(), &[1.0, 1.0, 1.0, 1.0]);
 //! ```
 //!
 //! ## `N` dimensions
@@ -133,7 +123,6 @@
 //!
 //! let array = Array::ones::<f32>(&[2, 2, 2]);
 //! let mut fftn_result = fftn(&array, None, None);
-//! fftn_result.eval();
 //! assert_eq!(fftn_result.dtype(), Dtype::Complex64);
 //!
 //! let mut expected = [complex64::new(0.0, 0.0); 8];
@@ -141,14 +130,12 @@
 //! assert_eq!(fftn_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut ifftn_result = ifftn(&fftn_result, None, None);
-//! ifftn_result.eval();
 //! assert_eq!(ifftn_result.dtype(), Dtype::Complex64);
 //!
 //! let expected = [complex64::new(1.0, 0.0); 8];
 //! assert_eq!(ifftn_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut rfftn_result = rfftn(&array, None, None);
-//! rfftn_result.eval();
 //! assert_eq!(rfftn_result.dtype(), Dtype::Complex64);
 //!
 //! let mut expected = [complex64::new(0.0, 0.0); 8];
@@ -156,7 +143,6 @@
 //! assert_eq!(rfftn_result.as_slice::<complex64>(), &expected[..]);
 //!
 //! let mut irfftn_result = irfftn(&rfftn_result, None, None);
-//! irfftn_result.eval();
 //! assert_eq!(irfftn_result.dtype(), Dtype::Float32);
 //!
 //! let expected = [1.0; 8];

--- a/src/fft/rfftn.rs
+++ b/src/fft/rfftn.rs
@@ -543,12 +543,10 @@ mod tests {
 
         let a = Array::from_slice(RFFT_DATA, RFFT_SHAPE);
         let mut rfft = super::rfft(&a, RFFT_N, RFFT_AXIS);
-        rfft.eval();
         assert_eq!(rfft.dtype(), Dtype::Complex64);
         assert_eq!(rfft.as_slice::<complex64>(), RFFT_EXPECTED);
 
         let mut irfft = super::irfft(&rfft, RFFT_N, RFFT_AXIS);
-        irfft.eval();
         assert_eq!(irfft.dtype(), Dtype::Float32);
         assert_eq!(irfft.as_slice::<f32>(), RFFT_DATA);
     }
@@ -559,8 +557,7 @@ mod tests {
         const OUT_N: i32 = IN_N / 2 + 1;
 
         let a = Array::ones::<f32>(&[IN_N]);
-        let mut rfft = super::rfft(&a, None, None);
-        rfft.eval();
+        let rfft = super::rfft(&a, None, None);
         assert_eq!(rfft.shape(), &[OUT_N]);
     }
 
@@ -570,8 +567,7 @@ mod tests {
         const OUT_N: i32 = (IN_N - 1) * 2;
 
         let a = Array::ones::<f32>(&[IN_N]);
-        let mut irfft = super::irfft(&a, None, None);
-        irfft.eval();
+        let irfft = super::irfft(&a, None, None);
         assert_eq!(irfft.shape(), &[OUT_N]);
     }
 
@@ -588,12 +584,10 @@ mod tests {
 
         let a = Array::from_slice(RFFT2_DATA, RFFT2_SHAPE);
         let mut rfft2 = super::rfft2(&a, None, None);
-        rfft2.eval();
         assert_eq!(rfft2.dtype(), Dtype::Complex64);
         assert_eq!(rfft2.as_slice::<complex64>(), RFFT2_EXPECTED);
 
         let mut irfft2 = super::irfft2(&rfft2, None, None);
-        irfft2.eval();
         assert_eq!(irfft2.dtype(), Dtype::Float32);
         assert_eq!(irfft2.as_slice::<f32>(), RFFT2_DATA);
     }
@@ -604,8 +598,7 @@ mod tests {
         const OUT_SHAPE: &[i32] = &[6, 6 / 2 + 1];
 
         let a = Array::ones::<f32>(IN_SHAPE);
-        let mut rfft2 = super::rfft2(&a, None, None);
-        rfft2.eval();
+        let rfft2 = super::rfft2(&a, None, None);
         assert_eq!(rfft2.shape(), OUT_SHAPE);
     }
 
@@ -615,8 +608,7 @@ mod tests {
         const OUT_SHAPE: &[i32] = &[6, (6 - 1) * 2];
 
         let a = Array::ones::<f32>(IN_SHAPE);
-        let mut irfft2 = super::irfft2(&a, None, None);
-        irfft2.eval();
+        let irfft2 = super::irfft2(&a, None, None);
         assert_eq!(irfft2.shape(), OUT_SHAPE);
     }
 
@@ -637,12 +629,10 @@ mod tests {
 
         let a = Array::from_slice(RFFTN_DATA, RFFTN_SHAPE);
         let mut rfftn = super::rfftn(&a, None, None);
-        rfftn.eval();
         assert_eq!(rfftn.dtype(), Dtype::Complex64);
         assert_eq!(rfftn.as_slice::<complex64>(), RFFTN_EXPECTED);
 
         let mut irfftn = super::irfftn(&rfftn, None, None);
-        irfftn.eval();
         assert_eq!(irfftn.dtype(), Dtype::Float32);
         assert_eq!(irfftn.as_slice::<f32>(), RFFTN_DATA);
     }
@@ -653,8 +643,7 @@ mod tests {
         const OUT_SHAPE: &[i32] = &[6, 6, 6 / 2 + 1];
 
         let a = Array::ones::<f32>(IN_SHAPE);
-        let mut rfftn = super::rfftn(&a, None, None);
-        rfftn.eval();
+        let rfftn = super::rfftn(&a, None, None);
         assert_eq!(rfftn.shape(), OUT_SHAPE);
     }
 
@@ -664,8 +653,7 @@ mod tests {
         const OUT_SHAPE: &[i32] = &[6, 6, (6 - 1) * 2];
 
         let a = Array::ones::<f32>(IN_SHAPE);
-        let mut irfftn = super::irfftn(&a, None, None);
-        irfftn.eval();
+        let irfftn = super::irfftn(&a, None, None);
         assert_eq!(irfftn.shape(), OUT_SHAPE);
     }
 }

--- a/src/ops/arithmetic.rs
+++ b/src/ops/arithmetic.rs
@@ -15,7 +15,6 @@ impl Array {
     /// let array = Array::from_slice(&[1i32, 2, -3, -4, -5], &[5]);
     /// let mut result = array.abs();
     ///
-    /// result.eval();
     /// let data: &[i32] = result.as_slice();
     /// // data == [1, 2, 3, 4, 5]
     /// ```
@@ -39,7 +38,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.add_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [5.0, 7.0, 9.0]
     /// ```
@@ -63,7 +61,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.add_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [5.0, 7.0, 9.0]
     /// ```
@@ -98,7 +95,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.add_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [5.0, 7.0, 9.0]
     /// ```
@@ -132,7 +128,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.sub_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [-3.0, -3.0, -3.0]
     /// ```
@@ -157,7 +152,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.sub_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [-3.0, -3.0, -3.0]
     /// ```
@@ -193,7 +187,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.sub_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [-3.0, -3.0, -3.0]
     /// ```
@@ -226,7 +219,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = a.neg();
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [-1.0, -2.0, -3.0]
     /// ```
@@ -250,7 +242,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = unsafe { a.neg_unchecked() };
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [-1.0, -2.0, -3.0]
     /// ```
@@ -278,7 +269,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = a.try_neg().unwrap();
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [-1.0, -2.0, -3.0]
     /// ```
@@ -310,7 +300,6 @@ impl Array {
     /// let a: Array = false.into();
     /// let mut b = a.logical_not_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[bool] = b.as_slice();
     /// // b_data == [true]
     /// ```
@@ -335,7 +324,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.mul_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [4.0, 10.0, 18.0]
     /// ```
@@ -355,7 +343,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.mul_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [4.0, 10.0, 18.0]
     /// ```
@@ -386,7 +373,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.mul_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [4.0, 10.0, 18.0]
     /// ```
@@ -415,7 +401,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.div_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
     /// ```
@@ -440,7 +425,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.div_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
     /// ```
@@ -476,7 +460,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.div_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
     /// ```
@@ -510,7 +493,6 @@ impl Array {
     /// let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
     /// let mut c = a.pow_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 8.0, 81.0]
     /// ```
@@ -535,7 +517,6 @@ impl Array {
     /// let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
     /// let mut c = a.pow_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 8.0, 81.0]
     /// ```
@@ -571,7 +552,6 @@ impl Array {
     /// let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
     /// let mut c = a.pow_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 8.0, 81.0]
     /// ```
@@ -605,7 +585,6 @@ impl Array {
     /// let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
     /// let mut c = a.rem_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 3.0, 2.0]
     /// ```
@@ -630,7 +609,6 @@ impl Array {
     /// let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
     /// let mut c = a.rem_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 3.0, 2.0]
     /// ```
@@ -666,7 +644,6 @@ impl Array {
     /// let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
     /// let mut c = a.rem_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 3.0, 2.0]
     /// ```
@@ -697,7 +674,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 4.0, 9.0], &[3]);
     /// let mut b = a.sqrt_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 2.0, 3.0]
     /// ```
@@ -715,7 +691,6 @@ impl Array {
     /// let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
     /// let mut b = a.cos_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 0.54030234, -0.41614687]
     /// ```
@@ -735,7 +710,6 @@ impl Array {
     /// let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
     /// let mut b = a.exp_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 2.7182817, 7.389056]
     /// ```
@@ -753,7 +727,6 @@ impl Array {
     /// let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
     /// let mut b = a.floor_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
     /// ```
@@ -771,7 +744,6 @@ impl Array {
     /// let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
     /// let mut b = a.floor_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
     /// ```
@@ -793,7 +765,6 @@ impl Array {
     /// let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
     /// let mut b = a.floor_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
     /// ```
@@ -822,7 +793,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.floor_divide_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
     /// ```
@@ -850,7 +820,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.floor_divide_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
     /// ```
@@ -892,7 +861,6 @@ impl Array {
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
     /// let mut c = a.floor_divide_device(&b, Default::default());
     ///
-    /// c.eval();
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
     /// ```
@@ -930,7 +898,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = a.log_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 0.6931472, 1.0986123]
     /// ```
@@ -948,7 +915,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 2.0, 4.0, 8.0], &[4]);
     /// let mut b = a.log2_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0, 3.0]
     /// ```
@@ -966,7 +932,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 10.0, 100.0], &[3]);
     /// let mut b = a.log10_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
     /// ```
@@ -984,7 +949,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = a.log1p_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.6931472, 1.0986123, 1.3862944]
     /// ```
@@ -1155,7 +1119,6 @@ impl Array {
     /// let a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
     /// let mut b = a.reciprocal_device(Default::default());
     ///
-    /// b.eval();
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 0.5, 0.25]
     /// ```
@@ -1210,10 +1173,9 @@ mod tests {
     #[test]
     fn test_abs() {
         let data = [1i32, 2, -3, -4, -5];
-        let array = Array::from_slice(&data, &[5]);
+        let mut array = Array::from_slice(&data, &[5]);
         let mut result = array.abs();
 
-        result.eval();
         let data: &[i32] = result.as_slice();
         assert_eq!(data, [1, 2, 3, 4, 5]);
 
@@ -1224,11 +1186,10 @@ mod tests {
 
     #[test]
     fn test_add() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
         let mut c = &a + &b;
-        c.eval();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[5.0, 7.0, 9.0]);
@@ -1251,11 +1212,10 @@ mod tests {
 
     #[test]
     fn test_sub() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
         let mut c = &a - &b;
-        c.eval();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[-3.0, -3.0, -3.0]);
@@ -1278,9 +1238,8 @@ mod tests {
 
     #[test]
     fn test_neg() {
-        let a = Array::from_slice::<f32>(&[1.0, 2.0, 3.0], &[3]);
+        let mut a = Array::from_slice::<f32>(&[1.0, 2.0, 3.0], &[3]);
         let mut b = a.neg();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[-1.0, -2.0, -3.0]);
@@ -1302,18 +1261,16 @@ mod tests {
         let a: Array = false.into();
         let mut b = a.logical_not();
 
-        b.eval();
         let b_data: &[bool] = b.as_slice();
         assert_eq!(b_data, [true]);
     }
 
     #[test]
     fn test_mul() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
         let mut c = &a * &b;
-        c.eval();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[4.0, 10.0, 18.0]);
@@ -1336,11 +1293,10 @@ mod tests {
 
     #[test]
     fn test_div() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
         let mut c = &a / &b;
-        c.eval();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[0.25, 0.4, 0.5]);
@@ -1363,11 +1319,10 @@ mod tests {
 
     #[test]
     fn test_pow() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
 
         let mut c = a.pow(&b);
-        c.eval();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[1.0, 8.0, 81.0]);
@@ -1390,11 +1345,10 @@ mod tests {
 
     #[test]
     fn test_rem() {
-        let a = Array::from_slice(&[10.0, 11.0, 12.0], &[3]);
-        let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
+        let mut a = Array::from_slice(&[10.0, 11.0, 12.0], &[3]);
+        let mut b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
 
         let mut c = &a % &b;
-        c.eval();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[1.0, 3.0, 2.0]);
@@ -1417,9 +1371,8 @@ mod tests {
 
     #[test]
     fn test_sqrt() {
-        let a = Array::from_slice(&[1.0, 4.0, 9.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 4.0, 9.0], &[3]);
         let mut b = a.sqrt();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 2.0, 3.0]);
@@ -1431,9 +1384,8 @@ mod tests {
 
     #[test]
     fn test_cos() {
-        let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
+        let mut a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
         let mut b = a.cos();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 0.54030234, -0.41614687]);
@@ -1445,9 +1397,8 @@ mod tests {
 
     #[test]
     fn test_exp() {
-        let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
+        let mut a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
         let mut b = a.exp();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 2.7182817, 7.389056]);
@@ -1459,9 +1410,8 @@ mod tests {
 
     #[test]
     fn test_floor() {
-        let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
+        let mut a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
         let mut b = a.floor();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 1.0, 2.0]);
@@ -1481,11 +1431,10 @@ mod tests {
 
     #[test]
     fn test_floor_divide() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
         let mut c = a.floor_divide(&b);
-        c.eval();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[0.0, 0.0, 0.0]);
@@ -1517,9 +1466,8 @@ mod tests {
 
     #[test]
     fn test_log() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let mut b = a.log();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 0.6931472, 1.0986123]);
@@ -1531,9 +1479,8 @@ mod tests {
 
     #[test]
     fn test_log2() {
-        let a = Array::from_slice(&[1.0, 2.0, 4.0, 8.0], &[4]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 4.0, 8.0], &[4]);
         let mut b = a.log2();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 1.0, 2.0, 3.0]);
@@ -1545,9 +1492,8 @@ mod tests {
 
     #[test]
     fn test_log10() {
-        let a = Array::from_slice(&[1.0, 10.0, 100.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 10.0, 100.0], &[3]);
         let mut b = a.log10();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 1.0, 2.0]);
@@ -1559,9 +1505,8 @@ mod tests {
 
     #[test]
     fn test_log1p() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let mut b = a.log1p();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.6931472, 1.0986123, 1.3862944]);
@@ -1573,11 +1518,10 @@ mod tests {
 
     #[test]
     fn test_matmul() {
-        let a = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
-        let b = Array::from_slice(&[-5.0, 37.5, 4., 7., 1., 0.], &[2, 3]);
+        let mut a = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
+        let mut b = Array::from_slice(&[-5.0, 37.5, 4., 7., 1., 0.], &[2, 3]);
 
         let mut c = a.matmul(&b);
-        c.eval();
 
         assert_eq!(c.shape(), &[2, 3]);
         let c_data: &[f32] = c.as_slice();
@@ -1626,9 +1570,8 @@ mod tests {
 
     #[test]
     fn test_reciprocal() {
-        let a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
         let mut b = a.reciprocal();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 0.5, 0.25]);
@@ -1640,9 +1583,8 @@ mod tests {
 
     #[test]
     fn test_round() {
-        let a = Array::from_slice(&[1.1, 2.9, 3.5], &[3]);
+        let mut a = Array::from_slice(&[1.1, 2.9, 3.5], &[3]);
         let mut b = a.round(None);
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 3.0, 4.0]);
@@ -1654,9 +1596,8 @@ mod tests {
 
     #[test]
     fn test_rsqrt() {
-        let a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
         let mut b = a.rsqrt();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 0.70710677, 0.5]);
@@ -1668,9 +1609,8 @@ mod tests {
 
     #[test]
     fn test_sin() {
-        let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
+        let mut a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
         let mut b = a.sin();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 0.841471, 0.9092974]);
@@ -1682,9 +1622,8 @@ mod tests {
 
     #[test]
     fn test_square() {
-        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let mut b = a.square();
-        b.eval();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 4.0, 9.0]);

--- a/src/ops/conversion.rs
+++ b/src/ops/conversion.rs
@@ -12,7 +12,6 @@ impl Array {
     ///
     /// let array = Array::from_slice(&[1i16,2,3], &[3]);
     /// let mut new_array = array.as_type::<f32>();
-    /// new_array.eval();
     ///
     /// assert_eq!(new_array.dtype(), mlx::Dtype::Float32);
     /// assert_eq!(new_array.shape(), &[3]);
@@ -42,9 +41,7 @@ mod tests {
                 #[test]
                 fn [<test_as_type_ $src_type _ $dst_type>]() {
                     let array = Array::from_slice(&[$src_val; $len], &[$len as i32]);
-
                     let mut new_array = array.as_type::<$dst_type>();
-                    new_array.eval();
 
                     assert_eq!(new_array.dtype(), $dst_type::DTYPE);
                     assert_eq!(new_array.shape(), &[3]);

--- a/src/ops/convolution.rs
+++ b/src/ops/convolution.rs
@@ -392,7 +392,6 @@ mod tests {
             Some(1), // groups
         );
 
-        result.eval();
         let expected_output = [12.0, 8.0, 17.0, 13.0, 22.0, 18.0];
         assert_eq!(result.shape(), &[1, 3, 2]);
         assert_eq!(result.as_slice::<f32>(), &expected_output);
@@ -420,7 +419,6 @@ mod tests {
             Some(1),      // groups
         );
 
-        result.eval();
         // Expected result is the convolution of a 2x2 filter over a 2x2 input with valid padding, resulting in a single output value
         let expected_output = 1.0 * 1.0 + 2.0 * 0.0 + 3.0 * 0.0 + 4.0 * 1.0; // = 1*1 + 4*1 = 5
         assert_eq!(result.as_slice::<f32>(), &[expected_output]);

--- a/src/ops/cumulative.rs
+++ b/src/ops/cumulative.rs
@@ -474,27 +474,22 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
         let mut result = array.cummax(0, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 5, 9]);
 
         let mut result = array.cummax(1, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 4, 9]);
 
         let mut result = array.cummax(None, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 8, 9]);
 
         let mut result = array.cummax(0, Some(true), None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 9, 4, 9]);
 
         let mut result = array.cummax(0, None, Some(true));
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 5, 9]);
     }
@@ -511,27 +506,22 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
         let mut result = array.cummin(0, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 4, 8]);
 
         let mut result = array.cummin(1, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 5, 4, 4]);
 
         let mut result = array.cummin(None, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 5, 4, 4]);
 
         let mut result = array.cummin(0, Some(true), None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[4, 8, 4, 9]);
 
         let mut result = array.cummin(0, None, Some(true));
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 4, 8]);
     }
@@ -548,27 +538,22 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
         let mut result = array.cumprod(0, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 20, 72]);
 
         let mut result = array.cumprod(1, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 40, 4, 36]);
 
         let mut result = array.cumprod(None, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 40, 160, 1440]);
 
         let mut result = array.cumprod(0, Some(true), None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[20, 72, 4, 9]);
 
         let mut result = array.cumprod(0, None, Some(true));
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 20, 72]);
     }
@@ -585,27 +570,22 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
         let mut result = array.cumsum(0, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 9, 17]);
 
         let mut result = array.cumsum(1, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 13, 4, 13]);
 
         let mut result = array.cumsum(None, None, None);
-        result.eval();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 13, 17, 26]);
 
         let mut result = array.cumsum(0, Some(true), None);
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[9, 17, 4, 9]);
 
         let mut result = array.cumsum(0, None, Some(true));
-        result.eval();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 9, 17]);
     }

--- a/src/ops/factory.rs
+++ b/src/ops/factory.rs
@@ -775,7 +775,6 @@ mod tests {
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         assert_eq!(data, &[0.0; 6]);
     }
@@ -795,7 +794,6 @@ mod tests {
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float16);
 
-        array.eval();
         let data: &[f16] = array.as_slice();
         assert_eq!(data, &[f16::from_f32(1.0); 6]);
     }
@@ -806,7 +804,6 @@ mod tests {
         assert_eq!(array.shape(), &[3, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         assert_eq!(data, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
     }
@@ -817,7 +814,6 @@ mod tests {
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         assert_eq!(data, &[7.0; 6]);
     }
@@ -829,7 +825,6 @@ mod tests {
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         float_eq::float_eq!(*data, [0.0; 6], abs <= [1e-6; 6]);
     }
@@ -851,7 +846,6 @@ mod tests {
         assert_eq!(array.shape(), &[3, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         assert_eq!(data, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]);
     }
@@ -862,7 +856,6 @@ mod tests {
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         let expected: Vec<f32> = (0..50).map(|x| x as f32 * (50.0 / 49.0)).collect();
         assert_eq!(data, expected.as_slice());
@@ -874,7 +867,6 @@ mod tests {
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         let expected: Vec<f32> = (0..50).map(|x| x as f32 * (50.0 / 49.0)).collect();
         assert_eq!(data, expected.as_slice());
@@ -896,7 +888,6 @@ mod tests {
         assert_eq!(array.shape(), &[2, 8]);
         assert_eq!(array.dtype(), Dtype::Int32);
 
-        array.eval();
         let data: &[i32] = array.as_slice();
         assert_eq!(data, [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]);
     }
@@ -919,7 +910,6 @@ mod tests {
         assert_eq!(array.shape(), &[16]);
         assert_eq!(array.dtype(), Dtype::Int32);
 
-        array.eval();
         let data: &[i32] = array.as_slice();
         assert_eq!(data, [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]);
     }
@@ -941,7 +931,6 @@ mod tests {
         assert_eq!(array.shape(), &[3, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        array.eval();
         let data: &[f32] = array.as_slice();
         assert_eq!(data, &[1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0]);
     }

--- a/src/ops/logical.rs
+++ b/src/ops/logical.rs
@@ -18,7 +18,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.eq(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -45,7 +44,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = unsafe { a.eq_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -82,7 +80,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.try_eq(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -117,7 +114,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.le(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -144,7 +140,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = unsafe { a.le_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -181,7 +176,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.try_le(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -216,7 +210,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.ge(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -242,7 +235,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = unsafe { a.ge_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -279,7 +271,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.try_ge(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -314,7 +305,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.ne(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -341,7 +331,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = unsafe { a.ne_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -378,7 +367,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.try_ne(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -412,7 +400,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.lt(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -439,7 +426,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = unsafe { a.lt_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -475,7 +461,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.try_lt(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -509,7 +494,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.gt(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -535,7 +519,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = unsafe { a.gt_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -571,7 +554,6 @@ impl Array {
     /// let b = Array::from_slice(&[1, 2, 3], &[3]);
     /// let mut c = a.try_gt(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [false, false, false]
     /// ```
@@ -605,7 +587,6 @@ impl Array {
     /// let b = Array::from_slice(&[true, true, false], &[3]);
     /// let mut c = a.logical_and(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, false, false]
     /// ```
@@ -631,7 +612,6 @@ impl Array {
     /// let b = Array::from_slice(&[true, true, false], &[3]);
     /// let mut c = unsafe { a.logical_and_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, false, false]
     /// ```
@@ -671,7 +651,6 @@ impl Array {
     /// let b = Array::from_slice(&[true, true, false], &[3]);
     /// let mut c = a.try_logical_and(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, false, false]
     /// ```
@@ -705,7 +684,6 @@ impl Array {
     /// let b = Array::from_slice(&[true, true, false], &[3]);
     /// let mut c = a.logical_or(&b);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -731,7 +709,6 @@ impl Array {
     /// let b = Array::from_slice(&[true, true, false], &[3]);
     /// let mut c = unsafe { a.logical_or_unchecked(&b) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -771,7 +748,6 @@ impl Array {
     /// let b = Array::from_slice(&[true, true, false], &[3]);
     /// let mut c = a.try_logical_or(&b).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true, true, true]
     /// ```
@@ -810,7 +786,6 @@ impl Array {
     /// let b = Array::from_slice(&[0., 1., 2., 3.], &[4]).pow(&(0.5.into()));
     /// let mut c = a.all_close(&b, None, None, None);
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true]
     /// ```
@@ -852,7 +827,6 @@ impl Array {
     /// let b = Array::from_slice(&[0., 1., 2., 3.], &[4]).pow(&(0.5.into()));
     /// let mut c = unsafe { a.all_close_unchecked(&b, None, None, None) };
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true]
     /// ```
@@ -906,7 +880,6 @@ impl Array {
     /// let b = Array::from_slice(&[0., 1., 2., 3.], &[4]).pow(&(0.5.into()));
     /// let mut c = a.try_all_close(&b, None, None, None).unwrap();
     ///
-    /// c.eval();
     /// let c_data: &[bool] = c.as_slice();
     /// // c_data == [true]
     /// ```
@@ -1261,11 +1234,10 @@ mod tests {
 
     #[test]
     fn test_eq() {
-        let a = Array::from_slice(&[1, 2, 3], &[3]);
-        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
         let mut c = a.eq(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
 
@@ -1287,11 +1259,10 @@ mod tests {
 
     #[test]
     fn test_le() {
-        let a = Array::from_slice(&[1, 2, 3], &[3]);
-        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
         let mut c = a.le(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
 
@@ -1313,11 +1284,10 @@ mod tests {
 
     #[test]
     fn test_ge() {
-        let a = Array::from_slice(&[1, 2, 3], &[3]);
-        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
         let mut c = a.ge(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
 
@@ -1339,11 +1309,10 @@ mod tests {
 
     #[test]
     fn test_ne() {
-        let a = Array::from_slice(&[1, 2, 3], &[3]);
-        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
         let mut c = a.ne(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, false, false]);
 
@@ -1365,11 +1334,10 @@ mod tests {
 
     #[test]
     fn test_lt() {
-        let a = Array::from_slice(&[1, 0, 3], &[3]);
-        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut a = Array::from_slice(&[1, 0, 3], &[3]);
+        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
         let mut c = a.lt(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, true, false]);
 
@@ -1391,11 +1359,10 @@ mod tests {
 
     #[test]
     fn test_gt() {
-        let a = Array::from_slice(&[1, 4, 3], &[3]);
-        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let mut a = Array::from_slice(&[1, 4, 3], &[3]);
+        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
         let mut c = a.gt(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, true, false]);
 
@@ -1417,11 +1384,10 @@ mod tests {
 
     #[test]
     fn test_logical_and() {
-        let a = Array::from_slice(&[true, false, true], &[3]);
-        let b = Array::from_slice(&[true, true, false], &[3]);
+        let mut a = Array::from_slice(&[true, false, true], &[3]);
+        let mut b = Array::from_slice(&[true, true, false], &[3]);
         let mut c = a.logical_and(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, false, false]);
 
@@ -1443,11 +1409,10 @@ mod tests {
 
     #[test]
     fn test_logical_or() {
-        let a = Array::from_slice(&[true, false, true], &[3]);
-        let b = Array::from_slice(&[true, true, false], &[3]);
+        let mut a = Array::from_slice(&[true, false, true], &[3]);
+        let mut b = Array::from_slice(&[true, true, false], &[3]);
         let mut c = a.logical_or(&b);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
 
@@ -1473,7 +1438,6 @@ mod tests {
         let b = Array::from_slice(&[0., 1., 2., 3.], &[4]).pow(&(0.5.into()));
         let mut c = a.all_close(&b, 1e-5, None, None);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true]);
     }
@@ -1492,7 +1456,6 @@ mod tests {
         let b = Array::from_slice(&[1.1, 2.2, 3.3], &[3]);
         let mut c = a.is_close(&b, None, None, false);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, false, false]);
     }
@@ -1503,7 +1466,6 @@ mod tests {
         let b = Array::from_slice(&[1.1, 2.2, 3.3], &[3]);
         let mut c = a.is_close(&b, 0.1, 0.2, true);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
     }
@@ -1522,7 +1484,6 @@ mod tests {
         let b = Array::from_slice(&[0., 1., 2., 3.], &[4]);
         let mut c = a.array_eq(&b, None);
 
-        c.eval();
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true]);
     }
@@ -1532,7 +1493,6 @@ mod tests {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
         let mut all = array.any(&[0][..], None);
 
-        all.eval();
         let results: &[bool] = all.as_slice();
         assert_eq!(results, &[true, true, true, true]);
     }
@@ -1542,7 +1502,6 @@ mod tests {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
         let mut all = array.any(&[][..], None);
 
-        all.eval();
         let results: &[bool] = all.as_slice();
         assert_eq!(
             results,
@@ -1571,7 +1530,6 @@ mod tests {
         let b = Array::from_slice(&[4, 5, 6], &[3]);
         let mut c = which(&condition, &a, &b);
 
-        c.eval();
         let c_data: &[i32] = c.as_slice();
         assert_eq!(c_data, [1, 5, 3]);
     }

--- a/src/ops/reduction.rs
+++ b/src/ops/reduction.rs
@@ -14,7 +14,6 @@ impl Array {
     /// let a = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
     /// let mut b = a.all(&[0][..], None);
     ///
-    /// b.eval();
     /// let results: &[bool] = b.as_slice();
     /// // results == [false, true, true, true]
     /// ```
@@ -43,7 +42,6 @@ impl Array {
     /// let a = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
     /// let mut b = unsafe { a.all_unchecked(&[0][..], None) };
     ///
-    /// b.eval();
     /// let results: &[bool] = b.as_slice();
     /// // results == [false, true, true, true]
     /// ```
@@ -84,7 +82,6 @@ impl Array {
     /// let a = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
     /// let mut b = a.try_all(&[0][..], None).unwrap();
     ///
-    /// b.eval();
     /// let results: &[bool] = b.as_slice();
     /// // results == [false, true, true, true]
     /// ```
@@ -878,11 +875,9 @@ mod tests {
         assert_eq!(array.all(&[0, 1][..], None).item::<bool>(), false);
 
         let mut result = array.all(&[0][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<bool>(), &[true, false]);
 
         let mut result = array.all(&[1][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<bool>(), &[false, false]);
     }
 
@@ -891,7 +886,6 @@ mod tests {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
         let mut all = array.all(&[][..], None);
 
-        all.eval();
         let results: &[bool] = all.as_slice();
         assert_eq!(
             results,
@@ -909,11 +903,9 @@ mod tests {
         assert_eq!(y.shape(), &[1, 1]);
 
         let mut result = x.prod(&[0][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<i32>(), &[3, 6]);
 
         let mut result = x.prod(&[1][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<i32>(), &[2, 9])
     }
 
@@ -922,7 +914,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.prod(&[][..], None);
 
-        result.eval();
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
     }
@@ -936,11 +927,9 @@ mod tests {
         assert_eq!(y.shape(), &[1, 1]);
 
         let mut result = x.max(&[0][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<i32>(), &[3, 4]);
 
         let mut result = x.max(&[1][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<i32>(), &[2, 4]);
     }
 
@@ -949,7 +938,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.max(&[][..], None);
 
-        result.eval();
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
     }
@@ -959,7 +947,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.sum(&[0][..], None);
 
-        result.eval();
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[9, 17]);
     }
@@ -969,7 +956,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.sum(&[][..], None);
 
-        result.eval();
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
     }
@@ -983,11 +969,9 @@ mod tests {
         assert_eq!(y.shape(), &[1, 1]);
 
         let mut result = x.mean(&[0][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<f32>(), &[2.0, 3.0]);
 
         let mut result = x.mean(&[1][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<f32>(), &[1.5, 3.5]);
     }
 
@@ -996,7 +980,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.mean(&[][..], None);
 
-        result.eval();
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.0, 8.0, 4.0, 9.0]);
     }
@@ -1017,11 +1000,9 @@ mod tests {
         assert_eq!(y.shape(), &[1, 1]);
 
         let mut result = x.min(&[0][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<i32>(), &[1, 2]);
 
         let mut result = x.min(&[1][..], None);
-        result.eval();
         assert_eq!(result.as_slice::<i32>(), &[1, 3]);
     }
 
@@ -1030,7 +1011,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.min(&[][..], None);
 
-        result.eval();
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
     }
@@ -1044,11 +1024,9 @@ mod tests {
         assert_eq!(y.shape(), &[1, 1]);
 
         let mut result = x.variance(&[0][..], None, None);
-        result.eval();
         assert_eq!(result.as_slice::<f32>(), &[1.0, 1.0]);
 
         let mut result = x.variance(&[1][..], None, None);
-        result.eval();
         assert_eq!(result.as_slice::<f32>(), &[0.25, 0.25]);
 
         let x = Array::from_slice(&[1.0, 2.0], &[2]);
@@ -1061,7 +1039,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.variance(&[][..], None, 0);
 
-        result.eval();
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[0.0, 0.0, 0.0, 0.0]);
     }
@@ -1071,7 +1048,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.log_sum_exp(&[0][..], None);
 
-        result.eval();
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.3132615, 9.313262]);
     }
@@ -1081,7 +1057,6 @@ mod tests {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
         let mut result = array.log_sum_exp(&[][..], None);
 
-        result.eval();
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.0, 8.0, 4.0, 9.0]);
     }

--- a/src/ops/reduction.rs
+++ b/src/ops/reduction.rs
@@ -904,7 +904,7 @@ mod tests {
         let x = Array::from_slice(&[1, 2, 3, 3], &[2, 2]);
         assert_eq!(x.prod(None, None).item::<i32>(), 18);
 
-        let y = x.prod(None, true);
+        let mut y = x.prod(None, true);
         assert_eq!(y.item::<i32>(), 18);
         assert_eq!(y.shape(), &[1, 1]);
 
@@ -931,7 +931,7 @@ mod tests {
     fn test_max() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.max(None, None).item::<i32>(), 4);
-        let y = x.max(None, true);
+        let mut y = x.max(None, true);
         assert_eq!(y.item::<i32>(), 4);
         assert_eq!(y.shape(), &[1, 1]);
 
@@ -978,7 +978,7 @@ mod tests {
     fn test_mean() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.mean(None, None).item::<f32>(), 2.5);
-        let y = x.mean(None, true);
+        let mut y = x.mean(None, true);
         assert_eq!(y.item::<f32>(), 2.5);
         assert_eq!(y.shape(), &[1, 1]);
 
@@ -1012,7 +1012,7 @@ mod tests {
     fn test_min() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.min(None, None).item::<i32>(), 1);
-        let y = x.min(None, true);
+        let mut y = x.min(None, true);
         assert_eq!(y.item::<i32>(), 1);
         assert_eq!(y.shape(), &[1, 1]);
 
@@ -1039,7 +1039,7 @@ mod tests {
     fn test_var() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.variance(None, None, None).item::<f32>(), 1.25);
-        let y = x.variance(None, true, None);
+        let mut y = x.variance(None, true, None);
         assert_eq!(y.item::<f32>(), 1.25);
         assert_eq!(y.shape(), &[1, 1]);
 
@@ -1052,7 +1052,7 @@ mod tests {
         assert_eq!(result.as_slice::<f32>(), &[0.25, 0.25]);
 
         let x = Array::from_slice(&[1.0, 2.0], &[2]);
-        let out = x.variance(None, None, Some(3));
+        let mut out = x.variance(None, None, Some(3));
         assert_eq!(out.item::<f32>(), f32::INFINITY);
     }
 


### PR DESCRIPTION
- add `try_` and `_unchecked` variants for `::item`
- makes `as_slice` take `&mut` and implicitly call `::eval()`