### PR TITLE
Use `stream: impl AsRef<Stream>` instead of `stream: StreamOrDevice` in fn args

### DIFF
--- a/src/ops/arithmetic.rs
+++ b/src/ops/arithmetic.rs
@@ -2,7 +2,7 @@ use crate::array::Array;
 use crate::error::{DataStoreError, MlxError, OperationError};
 use crate::stream::StreamOrDevice;
 use crate::utils::is_broadcastable;
-use crate::Dtype;
+use crate::{Dtype, Stream};
 use mlx_macros::default_device;
 
 impl Array {
@@ -11,7 +11,7 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let array = Array::from_slice(&[1i32, 2, -3, -4, -5], &[5]);
     /// let mut result = array.abs();
     ///
@@ -23,8 +23,8 @@ impl Array {
     ///
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn abs_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_abs(self.c_array, stream.as_ptr())) }
+    pub fn abs_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_abs(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise addition.
@@ -33,10 +33,10 @@ impl Array {
     ///
     /// # Example
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.add_device(&b, Default::default());
+    /// let mut c = a.add_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [5.0, 7.0, 9.0]
@@ -46,7 +46,7 @@ impl Array {
     ///
     /// - other: array to add
     /// - stream: stream or device to evaluate on
-    pub fn add_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn add_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_add_device(other, stream).unwrap()
     }
 
@@ -56,10 +56,10 @@ impl Array {
     ///
     /// # Example
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.add_device(&b, Default::default());
+    /// let mut c = a.add_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [5.0, 7.0, 9.0]
@@ -74,12 +74,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the arrays have the same shape.
     #[default_device]
-    pub unsafe fn add_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn add_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_add(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -90,10 +90,10 @@ impl Array {
     ///
     /// # Example
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.add_device(&b, Default::default());
+    /// let mut c = a.add_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [5.0, 7.0, 9.0]
@@ -107,7 +107,7 @@ impl Array {
     pub fn try_add_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -123,10 +123,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.sub_device(&b, Default::default());
+    /// let mut c = a.sub_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [-3.0, -3.0, -3.0]
@@ -136,7 +136,7 @@ impl Array {
     ///
     /// - other: array to subtract
     /// - stream: stream or device to evaluate on
-    pub fn sub_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn sub_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_sub_device(other, stream).unwrap()
     }
 
@@ -147,10 +147,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.sub_device(&b, Default::default());
+    /// let mut c = a.sub_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [-3.0, -3.0, -3.0]
@@ -165,12 +165,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the arrays have the same shape.
     #[default_device]
-    pub unsafe fn sub_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn sub_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_subtract(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -182,10 +182,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.sub_device(&b, Default::default());
+    /// let mut c = a.sub_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [-3.0, -3.0, -3.0]
@@ -199,7 +199,7 @@ impl Array {
     pub fn try_sub_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -215,7 +215,7 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = a.neg();
     ///
@@ -227,7 +227,7 @@ impl Array {
     ///
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn neg_device(&self, stream: StreamOrDevice) -> Array {
+    pub fn neg_device(&self, stream: impl AsRef<Stream>) -> Array {
         self.try_neg_device(stream).unwrap()
     }
 
@@ -238,7 +238,7 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = unsafe { a.neg_unchecked() };
     ///
@@ -254,8 +254,13 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the array is not a boolean array.
     #[default_device]
-    pub unsafe fn neg_device_unchecked(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_negative(self.c_array, stream.as_ptr())) }
+    pub unsafe fn neg_device_unchecked(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe {
+            Array::from_ptr(mlx_sys::mlx_negative(
+                self.c_array,
+                stream.as_ref().as_ptr(),
+            ))
+        }
     }
 
     /// Unary element-wise negation.
@@ -265,7 +270,7 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let mut b = a.try_neg().unwrap();
     ///
@@ -281,7 +286,7 @@ impl Array {
     ///
     /// Returns an error if the array is of type bool.
     #[default_device]
-    pub fn try_neg_device(&self, stream: StreamOrDevice) -> Result<Array, OperationError> {
+    pub fn try_neg_device(&self, stream: impl AsRef<Stream>) -> Result<Array, OperationError> {
         if self.dtype() == Dtype::Bool {
             return Err(OperationError::NotSupported(
                 "Negation not supported for bool, use logical_not() instead".to_string(),
@@ -296,9 +301,9 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a: Array = false.into();
-    /// let mut b = a.logical_not_device(Default::default());
+    /// let mut b = a.logical_not_device(StreamOrDevice::default());
     ///
     /// let b_data: &[bool] = b.as_slice();
     /// // b_data == [true]
@@ -308,8 +313,13 @@ impl Array {
     ///
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn logical_not_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_logical_not(self.c_array, stream.as_ptr())) }
+    pub fn logical_not_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe {
+            Array::from_ptr(mlx_sys::mlx_logical_not(
+                self.c_array,
+                stream.as_ref().as_ptr(),
+            ))
+        }
     }
 
     /// Element-wise multiplication.
@@ -319,15 +329,15 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.mul_device(&b, Default::default());
+    /// let mut c = a.mul_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [4.0, 10.0, 18.0]
     /// ```
-    pub fn mul_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn mul_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_mul_device(other, stream).unwrap()
     }
 
@@ -338,10 +348,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.mul_device(&b, Default::default());
+    /// let mut c = a.mul_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [4.0, 10.0, 18.0]
@@ -351,12 +361,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn mul_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn mul_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_multiply(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -368,10 +378,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.mul_device(&b, Default::default());
+    /// let mut c = a.mul_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [4.0, 10.0, 18.0]
@@ -380,7 +390,7 @@ impl Array {
     pub fn try_mul_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -396,10 +406,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.div_device(&b, Default::default());
+    /// let mut c = a.div_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
@@ -409,7 +419,7 @@ impl Array {
     ///
     /// - other: array to divide
     /// - stream: stream or device to evaluate on
-    pub fn div_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn div_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_div_device(other, stream).unwrap()
     }
 
@@ -420,10 +430,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.div_device(&b, Default::default());
+    /// let mut c = a.div_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
@@ -438,12 +448,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn div_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn div_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_divide(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -455,10 +465,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.div_device(&b, Default::default());
+    /// let mut c = a.div_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
@@ -472,7 +482,7 @@ impl Array {
     pub fn try_div_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -488,10 +498,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
-    /// let mut c = a.pow_device(&b, Default::default());
+    /// let mut c = a.pow_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 8.0, 81.0]
@@ -501,7 +511,7 @@ impl Array {
     ///
     /// - other: array to raise to the power of
     /// - stream: stream or device to evaluate on
-    pub fn pow_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn pow_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_pow_device(other, stream).unwrap()
     }
 
@@ -512,10 +522,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
-    /// let mut c = a.pow_device(&b, Default::default());
+    /// let mut c = a.pow_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 8.0, 81.0]
@@ -530,12 +540,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the arrays are broadcastable if they have different shapes.
     #[default_device]
-    pub unsafe fn pow_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn pow_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_power(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -547,10 +557,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
-    /// let mut c = a.pow_device(&b, Default::default());
+    /// let mut c = a.pow_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 8.0, 81.0]
@@ -564,7 +574,7 @@ impl Array {
     pub fn try_pow_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if self.shape() != other.shape() && !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -580,10 +590,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[10.0, 11.0, 12.0], &[3]);
     /// let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
-    /// let mut c = a.rem_device(&b, Default::default());
+    /// let mut c = a.rem_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 3.0, 2.0]
@@ -593,7 +603,7 @@ impl Array {
     ///
     /// - other: array to divide
     /// - stream: stream or device to evaluate on
-    pub fn rem_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn rem_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_rem_device(other, stream).unwrap()
     }
 
@@ -604,10 +614,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[10.0, 11.0, 12.0], &[3]);
     /// let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
-    /// let mut c = a.rem_device(&b, Default::default());
+    /// let mut c = a.rem_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 3.0, 2.0]
@@ -622,12 +632,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn rem_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn rem_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_remainder(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -639,10 +649,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[10.0, 11.0, 12.0], &[3]);
     /// let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
-    /// let mut c = a.rem_device(&b, Default::default());
+    /// let mut c = a.rem_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [1.0, 3.0, 2.0]
@@ -656,7 +666,7 @@ impl Array {
     pub fn try_rem_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -670,16 +680,16 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 4.0, 9.0], &[3]);
-    /// let mut b = a.sqrt_device(Default::default());
+    /// let mut b = a.sqrt_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 2.0, 3.0]
     /// ```
     #[default_device]
-    pub fn sqrt_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_sqrt(self.c_array, stream.as_ptr())) }
+    pub fn sqrt_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_sqrt(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise cosine
@@ -687,16 +697,16 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
-    /// let mut b = a.cos_device(Default::default());
+    /// let mut b = a.cos_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 0.54030234, -0.41614687]
     /// ```
     #[default_device]
-    pub fn cos_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_cos(self.c_array, stream.as_ptr())) }
+    pub fn cos_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_cos(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise exponential.
@@ -704,18 +714,18 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     ///
     /// let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
     /// let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
-    /// let mut b = a.exp_device(Default::default());
+    /// let mut b = a.exp_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 2.7182817, 7.389056]
     /// ```
     #[default_device]
-    pub fn exp_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_exp(self.c_array, stream.as_ptr())) }
+    pub fn exp_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_exp(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise floor.
@@ -723,15 +733,15 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
-    /// let mut b = a.floor_device(Default::default());
+    /// let mut b = a.floor_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
     /// ```
     #[default_device]
-    pub fn floor_device(&self, stream: StreamOrDevice) -> Array {
+    pub fn floor_device(&self, stream: impl AsRef<Stream>) -> Array {
         self.try_floor_device(stream).unwrap()
     }
 
@@ -740,9 +750,9 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
-    /// let mut b = a.floor_device(Default::default());
+    /// let mut b = a.floor_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
@@ -752,8 +762,8 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the array is not of type complex64.
     #[default_device]
-    pub unsafe fn floor_device_unchecked(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_floor(self.c_array, stream.as_ptr())) }
+    pub unsafe fn floor_device_unchecked(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_floor(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise floor returning an error if the array is of type complex64.
@@ -761,15 +771,15 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
-    /// let mut b = a.floor_device(Default::default());
+    /// let mut b = a.floor_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
     /// ```
     #[default_device]
-    pub fn try_floor_device(&self, stream: StreamOrDevice) -> Result<Array, OperationError> {
+    pub fn try_floor_device(&self, stream: impl AsRef<Stream>) -> Result<Array, OperationError> {
         if self.dtype() == Dtype::Complex64 {
             return Err(OperationError::NotSupported(
                 "Floor not supported for complex64".to_string(),
@@ -790,10 +800,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.floor_divide_device(&b, Default::default());
+    /// let mut c = a.floor_divide_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
@@ -804,7 +814,7 @@ impl Array {
     /// - other: array to divide
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn floor_divide_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn floor_divide_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_floor_divide_device(other, stream).unwrap()
     }
 
@@ -819,10 +829,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.floor_divide_device(&b, Default::default());
+    /// let mut c = a.floor_divide_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
@@ -841,13 +851,13 @@ impl Array {
     pub unsafe fn floor_divide_device_unchecked(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_floor_divide(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -863,10 +873,10 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
     /// let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-    /// let mut c = a.floor_divide_device(&b, Default::default());
+    /// let mut c = a.floor_divide_device(&b, StreamOrDevice::default());
     ///
     /// let c_data: &[f32] = c.as_slice();
     /// // c_data == [0.25, 0.4, 0.5]
@@ -880,7 +890,7 @@ impl Array {
     pub fn try_floor_divide_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, MlxError> {
         if self.dtype() == Dtype::Complex64 {
             return Err(OperationError::NotSupported(
@@ -901,16 +911,16 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-    /// let mut b = a.log_device(Default::default());
+    /// let mut b = a.log_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 0.6931472, 1.0986123]
     /// ```
     #[default_device]
-    pub fn log_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_log(self.c_array, stream.as_ptr())) }
+    pub fn log_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_log(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise base-2 logarithm.
@@ -918,16 +928,16 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 4.0, 8.0], &[4]);
-    /// let mut b = a.log2_device(Default::default());
+    /// let mut b = a.log2_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0, 3.0]
     /// ```
     #[default_device]
-    pub fn log2_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_log2(self.c_array, stream.as_ptr())) }
+    pub fn log2_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_log2(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise base-10 logarithm.
@@ -935,16 +945,16 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 10.0, 100.0], &[3]);
-    /// let mut b = a.log10_device(Default::default());
+    /// let mut b = a.log10_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.0, 1.0, 2.0]
     /// ```
     #[default_device]
-    pub fn log10_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_log10(self.c_array, stream.as_ptr())) }
+    pub fn log10_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_log10(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise natural log of one plus the array.
@@ -952,16 +962,16 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-    /// let mut b = a.log1p_device(Default::default());
+    /// let mut b = a.log1p_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [0.6931472, 1.0986123, 1.3862944]
     /// ```
     #[default_device]
-    pub fn log1p_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_log1p(self.c_array, stream.as_ptr())) }
+    pub fn log1p_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_log1p(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Matrix multiplication.
@@ -981,12 +991,12 @@ impl Array {
     ///
     /// # Example
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
     /// let b = Array::from_slice(&[-5.0, 37.5, 4., 7., 1., 0.], &[2, 3]);
     ///
     /// // produces a [2, 3] result
-    /// let mut c = a.matmul_device(&b, Default::default());
+    /// let mut c = a.matmul_device(&b, StreamOrDevice::default());
     /// ```
     ///
     /// # Params
@@ -994,7 +1004,7 @@ impl Array {
     /// - other: array to multiply
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn matmul_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn matmul_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_matmul_device(other, stream).unwrap()
     }
 
@@ -1015,12 +1025,12 @@ impl Array {
     ///
     /// # Example
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
     /// let b = Array::from_slice(&[-5.0, 37.5, 4., 7., 1., 0.], &[2, 3]);
     ///
     /// // produces a [2, 3] result
-    /// let mut c = a.matmul_device(&b, Default::default());
+    /// let mut c = a.matmul_device(&b, StreamOrDevice::default());
     /// ```
     ///
     /// # Params
@@ -1032,12 +1042,16 @@ impl Array {
     ///
     /// This function is unsafe because it does not check that the inputs are valid for matrix multiplication.
     #[default_device]
-    pub unsafe fn matmul_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn matmul_device_unchecked(
+        &self,
+        other: &Array,
+        stream: impl AsRef<Stream>,
+    ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_matmul(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -1059,12 +1073,12 @@ impl Array {
     ///
     /// # Example
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
     /// let b = Array::from_slice(&[-5.0, 37.5, 4., 7., 1., 0.], &[2, 3]);
     ///
     /// // produces a [2, 3] result
-    /// let mut c = a.matmul_device(&b, Default::default());
+    /// let mut c = a.matmul_device(&b, StreamOrDevice::default());
     /// ```
     ///
     /// # Params
@@ -1075,7 +1089,7 @@ impl Array {
     pub fn try_matmul_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         if self.ndim() == 0 || other.ndim() == 0 {
             return Err(OperationError::WrongInput(
@@ -1122,16 +1136,21 @@ impl Array {
     /// # Example
     ///
     /// ```rust
-    /// use mlx_rs::Array;
+    /// use mlx_rs::prelude::*;
     /// let a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
-    /// let mut b = a.reciprocal_device(Default::default());
+    /// let mut b = a.reciprocal_device(StreamOrDevice::default());
     ///
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [1.0, 0.5, 0.25]
     /// ```
     #[default_device]
-    pub fn reciprocal_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_reciprocal(self.c_array, stream.as_ptr())) }
+    pub fn reciprocal_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe {
+            Array::from_ptr(mlx_sys::mlx_reciprocal(
+                self.c_array,
+                stream.as_ref().as_ptr(),
+            ))
+        }
     }
 
     /// Round to the given number of decimals.
@@ -1141,32 +1160,36 @@ impl Array {
     /// - decimals: number of decimals to round to - default is 0 if not provided
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn round_device(&self, decimals: impl Into<Option<i32>>, stream: StreamOrDevice) -> Array {
+    pub fn round_device(
+        &self,
+        decimals: impl Into<Option<i32>>,
+        stream: impl AsRef<Stream>,
+    ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_round(
                 self.c_array,
                 decimals.into().unwrap_or(0),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
 
     /// Element-wise reciprocal and square root.
     #[default_device]
-    pub fn rsqrt_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_rsqrt(self.c_array, stream.as_ptr())) }
+    pub fn rsqrt_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_rsqrt(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise sine.
     #[default_device]
-    pub fn sin_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_sin(self.c_array, stream.as_ptr())) }
+    pub fn sin_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_sin(self.c_array, stream.as_ref().as_ptr())) }
     }
 
     /// Element-wise square.
     #[default_device]
-    pub fn square_device(&self, stream: StreamOrDevice) -> Array {
-        unsafe { Array::from_ptr(mlx_sys::mlx_square(self.c_array, stream.as_ptr())) }
+    pub fn square_device(&self, stream: impl AsRef<Stream>) -> Array {
+        unsafe { Array::from_ptr(mlx_sys::mlx_square(self.c_array, stream.as_ref().as_ptr())) }
     }
 }
 
@@ -1432,7 +1455,7 @@ mod tests {
     fn test_floor_complex64() {
         let val = complex64::new(1.0, 2.0);
         let a = Array::from_complex(val);
-        let b = a.try_floor_device(Default::default());
+        let b = a.try_floor_device(StreamOrDevice::default());
         assert!(b.is_err());
     }
 
@@ -1459,7 +1482,7 @@ mod tests {
         let val = complex64::new(1.0, 2.0);
         let a = Array::from_complex(val);
         let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
-        let c = a.try_floor_divide_device(&b, Default::default());
+        let c = a.try_floor_divide_device(&b, StreamOrDevice::default());
         assert!(c.is_err());
     }
 
@@ -1467,7 +1490,7 @@ mod tests {
     fn test_floor_divide_invalid_broadcast() {
         let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
         let b = Array::from_slice(&[4.0, 5.0], &[2]);
-        let c = a.try_floor_divide_device(&b, Default::default());
+        let c = a.try_floor_divide_device(&b, StreamOrDevice::default());
         assert!(c.is_err());
     }
 

--- a/src/ops/conversion.rs
+++ b/src/ops/conversion.rs
@@ -1,6 +1,6 @@
 use mlx_macros::default_device;
 
-use crate::{Array, ArrayElement, Dtype, StreamOrDevice};
+use crate::{Array, ArrayElement, Dtype, Stream, StreamOrDevice};
 
 impl Array {
     /// Cast the array to a specified type.
@@ -19,14 +19,15 @@ impl Array {
     /// assert_eq!(new_array.as_slice::<f32>(), &[1.0,2.0,3.0]);
     /// ```
     #[default_device]
-    pub fn as_type_device<T: ArrayElement>(&self, stream: StreamOrDevice) -> Array {
+    pub fn as_type_device<T: ArrayElement>(&self, stream: impl AsRef<Stream>) -> Array {
         self.as_dtype_device(T::DTYPE, stream)
     }
 
     #[default_device]
-    pub fn as_dtype_device(&self, dtype: Dtype, stream: StreamOrDevice) -> Array {
+    pub fn as_dtype_device(&self, dtype: Dtype, stream: impl AsRef<Stream>) -> Array {
         unsafe {
-            let new_array = mlx_sys::mlx_astype(self.c_array, dtype.into(), stream.as_ptr());
+            let new_array =
+                mlx_sys::mlx_astype(self.c_array, dtype.into(), stream.as_ref().as_ptr());
             Array::from_ptr(new_array)
         }
     }

--- a/src/ops/convolution.rs
+++ b/src/ops/convolution.rs
@@ -1,5 +1,5 @@
 use crate::error::OperationError;
-use crate::{Array, StreamOrDevice};
+use crate::{Array, Stream, StreamOrDevice};
 use mlx_macros::default_device;
 
 #[inline]
@@ -14,7 +14,7 @@ fn conv_general_device_inner(
     input_dilation: &[i32],
     groups: i32,
     flip: bool,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     unsafe {
         Array::from_ptr(mlx_sys::mlx_conv_general(
@@ -32,7 +32,7 @@ fn conv_general_device_inner(
             input_dilation.len(),
             groups,
             flip,
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 }
@@ -65,7 +65,7 @@ pub fn conv_general_device<'a>(
     input_dilation: impl Into<Option<&'a [i32]>>,
     groups: impl Into<Option<i32>>,
     flip: impl Into<Option<bool>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     try_conv_general_device(
         array,
@@ -118,7 +118,7 @@ pub unsafe fn conv_general_device_unchecked<'a>(
     input_dilation: impl Into<Option<&'a [i32]>>,
     groups: impl Into<Option<i32>>,
     flip: impl Into<Option<bool>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     let strides = strides.into().unwrap_or(&[1]);
     let padding = padding.into().unwrap_or(&[0]);
@@ -169,7 +169,7 @@ pub fn try_conv_general_device<'a>(
     input_dilation: impl Into<Option<&'a [i32]>>,
     groups: impl Into<Option<i32>>,
     flip: impl Into<Option<bool>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, OperationError> {
     let strides = strides.into().unwrap_or(&[1]);
     let padding = padding.into().unwrap_or(&[0]);
@@ -257,7 +257,7 @@ pub fn conv1d_device(
     padding: impl Into<Option<i32>>,
     dilation: impl Into<Option<i32>>,
     groups: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     try_conv1d_device(array, weight, stride, padding, dilation, groups, stream).unwrap()
 }
@@ -282,7 +282,7 @@ pub fn try_conv1d_device(
     padding: impl Into<Option<i32>>,
     dilation: impl Into<Option<i32>>,
     groups: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, OperationError> {
     let stride = stride.into().unwrap_or(1);
     let padding = padding.into().unwrap_or(0);
@@ -322,7 +322,7 @@ pub fn conv2d_device(
     padding: impl Into<Option<(i32, i32)>>,
     dilation: impl Into<Option<(i32, i32)>>,
     groups: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     try_conv2d_device(array, weight, stride, padding, dilation, groups, stream).unwrap()
 }
@@ -347,7 +347,7 @@ pub fn try_conv2d_device(
     padding: impl Into<Option<(i32, i32)>>,
     dilation: impl Into<Option<(i32, i32)>>,
     groups: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, OperationError> {
     let stride = stride.into().unwrap_or((1, 1));
     let padding = padding.into().unwrap_or((0, 0));

--- a/src/ops/cumulative.rs
+++ b/src/ops/cumulative.rs
@@ -1,5 +1,5 @@
 use crate::error::OperationError;
-use crate::{Array, StreamOrDevice};
+use crate::{Array, Stream, StreamOrDevice};
 use mlx_macros::default_device;
 
 impl Array {
@@ -24,7 +24,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_cummax_device(axis, reverse, inclusive, stream)
             .unwrap()
@@ -56,7 +56,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             match axis.into() {
@@ -65,20 +65,20 @@ impl Array {
                     axis,
                     reverse.into().unwrap_or(false),
                     inclusive.into().unwrap_or(true),
-                    stream.as_ptr(),
+                    stream.as_ref().as_ptr(),
                 )),
                 None => {
                     // we make this an array instead of using the pointer directly
                     // so that Rust will drop it when it goes out of scope
                     let shape = &[-1];
-                    let flat = self.reshape_device_unchecked(shape, stream.clone());
+                    let flat = self.reshape_device_unchecked(shape, &stream);
 
                     Array::from_ptr(mlx_sys::mlx_cummax(
                         flat.c_array,
                         0,
                         reverse.into().unwrap_or(false),
                         inclusive.into().unwrap_or(true),
-                        stream.as_ptr(),
+                        stream.as_ref().as_ptr(),
                     ))
                 }
             }
@@ -106,7 +106,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axis = axis.into();
         self.validate_axis_in_bounds(axis)?;
@@ -134,7 +134,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_cummin_device(axis, reverse, inclusive, stream)
             .unwrap()
@@ -166,7 +166,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             match axis.into() {
@@ -175,20 +175,20 @@ impl Array {
                     axis,
                     reverse.into().unwrap_or(false),
                     inclusive.into().unwrap_or(true),
-                    stream.as_ptr(),
+                    stream.as_ref().as_ptr(),
                 )),
                 None => {
                     // we make this an array instead of using the pointer directly
                     // so that Rust will drop it when it goes out of scope
                     let shape = &[-1];
-                    let flat = self.reshape_device_unchecked(shape, stream.clone());
+                    let flat = self.reshape_device_unchecked(shape, &stream);
 
                     Array::from_ptr(mlx_sys::mlx_cummin(
                         flat.c_array,
                         0,
                         reverse.into().unwrap_or(false),
                         inclusive.into().unwrap_or(true),
-                        stream.as_ptr(),
+                        stream.as_ref().as_ptr(),
                     ))
                 }
             }
@@ -216,7 +216,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axis = axis.into();
         self.validate_axis_in_bounds(axis)?;
@@ -244,7 +244,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_cumprod_device(axis, reverse, inclusive, stream)
             .unwrap()
@@ -276,7 +276,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             match axis.into() {
@@ -285,20 +285,20 @@ impl Array {
                     axis,
                     reverse.into().unwrap_or(false),
                     inclusive.into().unwrap_or(true),
-                    stream.as_ptr(),
+                    stream.as_ref().as_ptr(),
                 )),
                 None => {
                     // we make this an array instead of using the pointer directly
                     // so that Rust will drop it when it goes out of scope
                     let shape = &[-1];
-                    let flat = self.reshape_device_unchecked(shape, stream.clone());
+                    let flat = self.reshape_device_unchecked(shape, &stream);
 
                     Array::from_ptr(mlx_sys::mlx_cumprod(
                         flat.c_array,
                         0,
                         reverse.into().unwrap_or(false),
                         inclusive.into().unwrap_or(true),
-                        stream.as_ptr(),
+                        stream.as_ref().as_ptr(),
                     ))
                 }
             }
@@ -326,7 +326,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axis = axis.into();
         self.validate_axis_in_bounds(axis)?;
@@ -354,7 +354,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_cumsum_device(axis, reverse, inclusive, stream)
             .unwrap()
@@ -386,7 +386,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             match axis.into() {
@@ -395,20 +395,20 @@ impl Array {
                     axis,
                     reverse.into().unwrap_or(false),
                     inclusive.into().unwrap_or(true),
-                    stream.as_ptr(),
+                    stream.as_ref().as_ptr(),
                 )),
                 None => {
                     // we make this an array instead of using the pointer directly
                     // so that Rust will drop it when it goes out of scope
                     let shape = &[-1];
-                    let flat = self.reshape_device_unchecked(shape, stream.clone());
+                    let flat = self.reshape_device_unchecked(shape, &stream);
 
                     Array::from_ptr(mlx_sys::mlx_cumsum(
                         flat.c_array,
                         0,
                         reverse.into().unwrap_or(false),
                         inclusive.into().unwrap_or(true),
-                        stream.as_ptr(),
+                        stream.as_ref().as_ptr(),
                     ))
                 }
             }
@@ -436,7 +436,7 @@ impl Array {
         axis: impl Into<Option<i32>>,
         reverse: impl Into<Option<bool>>,
         inclusive: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axis = axis.into();
         self.validate_axis_in_bounds(axis)?;

--- a/src/ops/factory.rs
+++ b/src/ops/factory.rs
@@ -1,5 +1,6 @@
 use crate::array::ArrayElement;
 use crate::error::DataStoreError;
+use crate::Stream;
 use crate::{array::Array, stream::StreamOrDevice};
 use mlx_macros::default_device;
 use num_traits::NumCast;
@@ -19,7 +20,7 @@ impl Array {
     /// - shape: Desired shape
     /// - stream: Stream or device to evaluate on
     #[default_device]
-    pub fn zeros_device<T: ArrayElement>(shape: &[i32], stream: StreamOrDevice) -> Array {
+    pub fn zeros_device<T: ArrayElement>(shape: &[i32], stream: impl AsRef<Stream>) -> Array {
         // TODO: Can we make use of full() here?
         Self::try_zeros_device::<T>(shape, stream).unwrap()
     }
@@ -44,7 +45,7 @@ impl Array {
     #[default_device]
     pub unsafe fn zeros_device_unchecked<T: ArrayElement>(
         shape: &[i32],
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         // TODO: Can we make use of full() here?
         unsafe {
@@ -52,7 +53,7 @@ impl Array {
                 shape.as_ptr(),
                 shape.len(),
                 T::DTYPE.into(),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -73,7 +74,7 @@ impl Array {
     #[default_device]
     pub fn try_zeros_device<T: ArrayElement>(
         shape: &[i32],
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         // TODO: Can we make use of full() here?
         if shape.iter().any(|&i| i < 0) {
@@ -99,7 +100,7 @@ impl Array {
     /// - shape: Desired shape
     /// - stream: Stream or device to evaluate on
     #[default_device]
-    pub fn ones_device<T: ArrayElement>(shape: &[i32], stream: StreamOrDevice) -> Array {
+    pub fn ones_device<T: ArrayElement>(shape: &[i32], stream: impl AsRef<Stream>) -> Array {
         // TODO: Can we make use of full() here?
         Array::try_ones_device::<T>(shape, stream).unwrap()
     }
@@ -124,14 +125,14 @@ impl Array {
     #[default_device]
     pub unsafe fn ones_device_unchecked<T: ArrayElement>(
         shape: &[i32],
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         // TODO: Can we make use of full() here?
         Array::from_ptr(mlx_sys::mlx_ones(
             shape.as_ptr(),
             shape.len(),
             T::DTYPE.into(),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -150,7 +151,7 @@ impl Array {
     /// - stream: Stream or device to evaluate on
     pub fn try_ones_device<T: ArrayElement>(
         shape: &[i32],
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         // TODO: Can we make use of full() here?
         if shape.iter().any(|&i| i < 0) {
@@ -183,7 +184,7 @@ impl Array {
         n: i32,
         m: Option<i32>,
         k: Option<i32>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         Self::try_eye_device::<T>(n, m, k, stream).unwrap()
     }
@@ -213,7 +214,7 @@ impl Array {
         n: i32,
         m: Option<i32>,
         k: Option<i32>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_eye(
@@ -221,7 +222,7 @@ impl Array {
                 m.unwrap_or(n),
                 k.unwrap_or(0),
                 T::DTYPE.into(),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -247,7 +248,7 @@ impl Array {
         n: i32,
         m: Option<i32>,
         k: Option<i32>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if n < 0 || m.unwrap_or(n) < 0 {
             return Err(DataStoreError::NegativeInteger(format!(
@@ -282,7 +283,7 @@ impl Array {
     pub fn full_device<T: ArrayElement>(
         shape: &[i32],
         values: Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         Self::try_full_device::<T>(shape, values, stream).unwrap()
     }
@@ -313,7 +314,7 @@ impl Array {
     pub unsafe fn full_device_unchecked<T: ArrayElement>(
         shape: &[i32],
         values: Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_full(
@@ -321,7 +322,7 @@ impl Array {
                 shape.len(),
                 values.c_array,
                 T::DTYPE.into(),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -348,7 +349,7 @@ impl Array {
     pub fn try_full_device<T: ArrayElement>(
         shape: &[i32],
         values: Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if shape.iter().any(|&i| i < 0) {
             return Err(DataStoreError::NegativeDimensions(
@@ -374,7 +375,7 @@ impl Array {
     /// - n: number of rows and columns in the output
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn identity_device<T: ArrayElement>(n: i32, stream: StreamOrDevice) -> Array {
+    pub fn identity_device<T: ArrayElement>(n: i32, stream: impl AsRef<Stream>) -> Array {
         Self::eye_device::<T>(n, Some(n), None, stream)
     }
 
@@ -398,7 +399,7 @@ impl Array {
     /// The caller must ensure that n is positive.
     pub unsafe fn identity_device_unchecked<T: ArrayElement>(
         n: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe { Self::eye_device_unchecked::<T>(n, Some(n), None, stream) }
     }
@@ -419,7 +420,7 @@ impl Array {
     /// - stream: stream or device to evaluate on
     pub fn try_identity_device<T: ArrayElement>(
         n: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         Self::try_eye_device::<T>(n, Some(n), None, stream)
     }
@@ -445,7 +446,7 @@ impl Array {
         start: U,
         stop: U,
         count: Option<i32>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array
     where
         T: ArrayElement,
@@ -479,7 +480,7 @@ impl Array {
         start: U,
         stop: U,
         count: Option<i32>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array
     where
         T: ArrayElement,
@@ -494,7 +495,7 @@ impl Array {
                 stop_f32,
                 count.unwrap_or(50),
                 T::DTYPE.into(),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -520,7 +521,7 @@ impl Array {
         start: U,
         stop: U,
         count: Option<i32>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError>
     where
         T: ArrayElement,
@@ -559,7 +560,7 @@ impl Array {
         array: Array,
         count: i32,
         axis: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         Self::try_repeat_device::<T>(array, count, axis, stream).unwrap()
     }
@@ -590,14 +591,14 @@ impl Array {
         array: Array,
         count: i32,
         axis: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_repeat(
                 array.c_array,
                 count,
                 axis,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -624,7 +625,7 @@ impl Array {
         array: Array,
         count: i32,
         axis: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if count < 0 {
             return Err(DataStoreError::NegativeInteger(format!(
@@ -656,7 +657,7 @@ impl Array {
     pub fn repeat_all_device<T: ArrayElement>(
         array: Array,
         count: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         Self::try_repeat_all_device::<T>(array, count, stream).unwrap()
     }
@@ -685,13 +686,13 @@ impl Array {
     pub unsafe fn repeat_all_device_unchecked<T: ArrayElement>(
         array: Array,
         count: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_repeat_all(
                 array.c_array,
                 count,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -716,7 +717,7 @@ impl Array {
     pub fn try_repeat_all_device<T: ArrayElement>(
         array: Array,
         count: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if count < 0 {
             return Err(DataStoreError::NegativeInteger(format!(
@@ -749,7 +750,7 @@ impl Array {
         n: i32,
         m: Option<i32>,
         k: Option<i32>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_tri(
@@ -757,7 +758,7 @@ impl Array {
                 m.unwrap_or(n),
                 k.unwrap_or(0),
                 T::DTYPE.into(),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }

--- a/src/ops/logical.rs
+++ b/src/ops/logical.rs
@@ -2,6 +2,7 @@ use crate::array::Array;
 use crate::error::{DataStoreError, OperationError};
 use crate::stream::StreamOrDevice;
 use crate::utils::{axes_or_default_to_all, can_reduce_shape, is_broadcastable};
+use crate::Stream;
 use mlx_macros::default_device;
 
 impl Array {
@@ -27,7 +28,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn eq_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn eq_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_eq_device(other, stream).unwrap()
     }
 
@@ -57,12 +58,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check if the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn eq_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn eq_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_equal(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -92,7 +93,7 @@ impl Array {
     pub fn try_eq_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -123,7 +124,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn le_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn le_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_le_device(other, stream).unwrap()
     }
 
@@ -153,12 +154,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check if the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn le_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn le_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_less_equal(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -188,7 +189,7 @@ impl Array {
     pub fn try_le_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -219,7 +220,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn ge_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn ge_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_ge_device(other, stream).unwrap()
     }
 
@@ -248,12 +249,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check if the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn ge_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn ge_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_greater_equal(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -283,7 +284,7 @@ impl Array {
     pub fn try_ge_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -314,7 +315,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn ne_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn ne_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_ne_device(other, stream).unwrap()
     }
 
@@ -344,12 +345,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check if the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn ne_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn ne_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_not_equal(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -379,7 +380,7 @@ impl Array {
     pub fn try_ne_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -409,7 +410,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn lt_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn lt_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_lt_device(other, stream).unwrap()
     }
 
@@ -439,12 +440,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check if the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn lt_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn lt_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_less(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -473,7 +474,7 @@ impl Array {
     pub fn try_lt_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -503,7 +504,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn gt_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn gt_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_gt_device(other, stream).unwrap()
     }
 
@@ -532,12 +533,12 @@ impl Array {
     ///
     /// This function is unsafe because it does not check if the arrays are broadcastable.
     #[default_device]
-    pub unsafe fn gt_device_unchecked(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub unsafe fn gt_device_unchecked(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_greater(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -566,7 +567,7 @@ impl Array {
     pub fn try_gt_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -596,7 +597,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn logical_and_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn logical_and_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_logical_and_device(other, stream).unwrap()
     }
 
@@ -628,13 +629,13 @@ impl Array {
     pub unsafe fn logical_and_device_unchecked(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_logical_and(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -663,7 +664,7 @@ impl Array {
     pub fn try_logical_and_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -693,7 +694,7 @@ impl Array {
     /// - other: array to compare
     /// - stream: stream or device to evaluate on
     #[default_device]
-    pub fn logical_or_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
+    pub fn logical_or_device(&self, other: &Array, stream: impl AsRef<Stream>) -> Array {
         self.try_logical_or_device(other, stream).unwrap()
     }
 
@@ -725,13 +726,13 @@ impl Array {
     pub unsafe fn logical_or_device_unchecked(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_logical_or(
                 self.c_array,
                 other.c_array,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -760,7 +761,7 @@ impl Array {
     pub fn try_logical_or_device(
         &self,
         other: &Array,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         if !is_broadcastable(self.shape(), other.shape()) {
             return Err(DataStoreError::BroadcastError);
@@ -804,7 +805,7 @@ impl Array {
         rtol: impl Into<Option<f64>>,
         atol: impl Into<Option<f64>>,
         equal_nan: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_all_close_device(other, rtol, atol, equal_nan, stream)
             .unwrap()
@@ -849,7 +850,7 @@ impl Array {
         rtol: impl Into<Option<f64>>,
         atol: impl Into<Option<f64>>,
         equal_nan: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_allclose(
@@ -858,7 +859,7 @@ impl Array {
                 rtol.into().unwrap_or(1e-5),
                 atol.into().unwrap_or(1e-8),
                 equal_nan.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -898,9 +899,9 @@ impl Array {
         rtol: impl Into<Option<f64>>,
         atol: impl Into<Option<f64>>,
         equal_nan: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
-        let is_close = self.try_is_close_device(other, rtol, atol, equal_nan, stream.clone());
+        let is_close = self.try_is_close_device(other, rtol, atol, equal_nan, &stream);
         is_close.map(|is_close| is_close.all_device(None, None, stream))
     }
 
@@ -923,7 +924,7 @@ impl Array {
         rtol: impl Into<Option<f64>>,
         atol: impl Into<Option<f64>>,
         equal_nan: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_is_close_device(other, rtol, atol, equal_nan, stream)
             .unwrap()
@@ -952,7 +953,7 @@ impl Array {
         rtol: impl Into<Option<f64>>,
         atol: impl Into<Option<f64>>,
         equal_nan: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_isclose(
@@ -961,7 +962,7 @@ impl Array {
                 rtol.into().unwrap_or(1e-5),
                 atol.into().unwrap_or(1e-8),
                 equal_nan.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -985,7 +986,7 @@ impl Array {
         rtol: impl Into<Option<f64>>,
         atol: impl Into<Option<f64>>,
         equal_nan: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, DataStoreError> {
         // represents atol and rtol being broadcasted to operate on other
         if !is_broadcastable(&[], other.shape()) {
@@ -1026,14 +1027,14 @@ impl Array {
         &self,
         other: &Array,
         equal_nan: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe {
             Array::from_ptr(mlx_sys::mlx_array_equal(
                 self.c_array,
                 other.c_array,
                 equal_nan.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -1062,7 +1063,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_any_device(axes, keep_dims, stream).unwrap()
     }
@@ -1095,7 +1096,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -1105,7 +1106,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         }
     }
@@ -1134,7 +1135,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -1149,7 +1150,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -1166,7 +1167,7 @@ impl Array {
 /// - b: input selected from where condition is zero or `false`
 /// - stream: stream or device to evaluate on
 #[default_device]
-pub fn which_device(condition: &Array, a: &Array, b: &Array, stream: StreamOrDevice) -> Array {
+pub fn which_device(condition: &Array, a: &Array, b: &Array, stream: impl AsRef<Stream>) -> Array {
     try_which_device(condition, a, b, stream).unwrap()
 }
 
@@ -1189,14 +1190,14 @@ pub unsafe fn which_device_unchecked(
     condition: &Array,
     a: &Array,
     b: &Array,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     unsafe {
         Array::from_ptr(mlx_sys::mlx_where(
             condition.c_array,
             a.c_array,
             b.c_array,
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 }
@@ -1216,7 +1217,7 @@ pub fn try_which_device(
     condition: &Array,
     a: &Array,
     b: &Array,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, DataStoreError> {
     if !is_broadcastable(condition.shape(), a.shape())
         || !is_broadcastable(condition.shape(), b.shape())

--- a/src/ops/reduction.rs
+++ b/src/ops/reduction.rs
@@ -2,6 +2,7 @@ use crate::array::Array;
 use crate::error::OperationError;
 use crate::stream::StreamOrDevice;
 use crate::utils::{axes_or_default_to_all, can_reduce_shape};
+use crate::Stream;
 use mlx_macros::default_device;
 
 impl Array {
@@ -28,7 +29,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_all_device(axes, keep_dims, stream).unwrap()
     }
@@ -60,7 +61,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -69,7 +70,7 @@ impl Array {
             axes.as_ptr(),
             axes.len(),
             keep_dims.into().unwrap_or(false),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -96,7 +97,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -111,7 +112,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -138,7 +139,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_prod_device(axes, keep_dims, stream).unwrap()
     }
@@ -169,7 +170,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -178,7 +179,7 @@ impl Array {
             axes.as_ptr(),
             axes.len(),
             keep_dims.into().unwrap_or(false),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -204,7 +205,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -219,7 +220,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -246,7 +247,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_max_device(axes, keep_dims, stream).unwrap()
     }
@@ -278,7 +279,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -287,7 +288,7 @@ impl Array {
             axes.as_ptr(),
             axes.len(),
             keep_dims.into().unwrap_or(false),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -313,7 +314,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         if self.size() == 0 {
             return Err(OperationError::NotSupported(
@@ -334,7 +335,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -361,7 +362,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_sum_device(axes, keep_dims, stream).unwrap()
     }
@@ -392,7 +393,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -401,7 +402,7 @@ impl Array {
             axes.as_ptr(),
             axes.len(),
             keep_dims.into().unwrap_or(false),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -427,7 +428,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -442,7 +443,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -469,7 +470,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_mean_device(axes, keep_dims, stream).unwrap()
     }
@@ -500,7 +501,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -509,7 +510,7 @@ impl Array {
             axes.as_ptr(),
             axes.len(),
             keep_dims.into().unwrap_or(false),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -535,7 +536,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -560,7 +561,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -586,7 +587,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_min_device(axes, keep_dims, stream).unwrap()
     }
@@ -617,7 +618,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -626,7 +627,7 @@ impl Array {
             axes.as_ptr(),
             axes.len(),
             keep_dims.into().unwrap_or(false),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -652,7 +653,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         if self.size() == 0 {
             return Err(OperationError::NotSupported(
@@ -673,7 +674,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -691,7 +692,7 @@ impl Array {
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
         ddof: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_variance_device(axes, keep_dims, ddof, stream)
             .unwrap()
@@ -715,7 +716,7 @@ impl Array {
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
         ddof: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -725,7 +726,7 @@ impl Array {
             axes.len(),
             keep_dims.into().unwrap_or(false),
             ddof.into().unwrap_or(0),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -743,7 +744,7 @@ impl Array {
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
         ddof: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -770,7 +771,7 @@ impl Array {
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
                 ddof.into().unwrap_or(0),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }
@@ -789,7 +790,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_log_sum_exp_device(axes, keep_dims, stream)
             .unwrap()
@@ -813,7 +814,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -822,7 +823,7 @@ impl Array {
             axes.as_ptr(),
             axes.len(),
             keep_dims.into().unwrap_or(false),
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         ))
     }
 
@@ -840,7 +841,7 @@ impl Array {
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
         keep_dims: impl Into<Option<bool>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, OperationError> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
 
@@ -855,7 +856,7 @@ impl Array {
                 axes.as_ptr(),
                 axes.len(),
                 keep_dims.into().unwrap_or(false),
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             ))
         })
     }

--- a/src/ops/shapes.rs
+++ b/src/ops/shapes.rs
@@ -9,7 +9,7 @@ use crate::{
         PadError, ReshapeError, SqueezeError, StackError, TransposeError,
     },
     utils::{all_unique, is_broadcastable, is_same_shape, resolve_index, VectorArray},
-    Array, StreamOrDevice,
+    Array, Stream, StreamOrDevice,
 };
 
 impl Array {
@@ -22,7 +22,7 @@ impl Array {
     pub unsafe fn expand_dims_device_unchecked(
         &self,
         axes: &[i32],
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe { expand_dims_device_unchecked(self, axes, stream) }
     }
@@ -32,14 +32,14 @@ impl Array {
     pub fn try_expand_dims_device(
         &self,
         axes: &[i32],
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, ExpandDimsError> {
         try_expand_dims_device(self, axes, stream)
     }
 
     /// See [`expand_dims`].
     #[default_device]
-    pub fn expand_dims_device(&self, axes: &[i32], stream: StreamOrDevice) -> Array {
+    pub fn expand_dims_device(&self, axes: &[i32], stream: impl AsRef<Stream>) -> Array {
         self.try_expand_dims_device(axes, stream).unwrap()
     }
 
@@ -53,7 +53,7 @@ impl Array {
         &self,
         start_axis: impl Into<Option<i32>>,
         end_axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe { flatten_device_unchecked(self, start_axis, end_axis, stream) }
     }
@@ -64,7 +64,7 @@ impl Array {
         &self,
         start_axis: impl Into<Option<i32>>,
         end_axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, FlattenError> {
         unsafe { Ok(flatten_device_unchecked(self, start_axis, end_axis, stream)) }
     }
@@ -75,7 +75,7 @@ impl Array {
         &self,
         start_axis: impl Into<Option<i32>>,
         end_axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_flatten_device(start_axis, end_axis, stream)
             .unwrap()
@@ -87,7 +87,11 @@ impl Array {
     ///
     /// The function is unsafe because it does not check if the shapes are valid.
     #[default_device]
-    pub unsafe fn reshape_device_unchecked(&self, shape: &[i32], stream: StreamOrDevice) -> Array {
+    pub unsafe fn reshape_device_unchecked(
+        &self,
+        shape: &[i32],
+        stream: impl AsRef<Stream>,
+    ) -> Array {
         unsafe { reshape_device_unchecked(self, shape, stream) }
     }
 
@@ -96,14 +100,14 @@ impl Array {
     pub fn try_reshape_device<'a>(
         &self,
         shape: &'a [i32],
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, ReshapeError<'a>> {
         try_reshape_device(self, shape, stream)
     }
 
     /// See [`reshape`].
     #[default_device]
-    pub fn reshape_device(&self, shape: &[i32], stream: StreamOrDevice) -> Array {
+    pub fn reshape_device(&self, shape: &[i32], stream: impl AsRef<Stream>) -> Array {
         self.try_reshape_device(shape, stream).unwrap()
     }
 
@@ -116,7 +120,7 @@ impl Array {
     pub unsafe fn squeeze_device_unchecked<'a>(
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         squeeze_device_unchecked(self, axes, stream)
     }
@@ -126,7 +130,7 @@ impl Array {
     pub fn try_squeeze_device<'a>(
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, SqueezeError> {
         try_squeeze_device(self, axes, stream)
     }
@@ -136,7 +140,7 @@ impl Array {
     pub fn squeeze_device<'a>(
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_squeeze_device(axes, stream).unwrap()
     }
@@ -148,26 +152,26 @@ impl Array {
         shape: impl Into<Option<&'a [i32]>>,
         strides: impl Into<Option<&'a [usize]>>,
         offset: impl Into<Option<usize>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         as_strided_device(self, shape, strides, offset, stream)
     }
 
     /// See [`at_least_1d`]
     #[default_device]
-    pub fn at_least_1d_device(&self, stream: StreamOrDevice) -> Array {
+    pub fn at_least_1d_device(&self, stream: impl AsRef<Stream>) -> Array {
         at_least_1d_device(self, stream)
     }
 
     /// See [`at_least_2d`]
     #[default_device]
-    pub fn at_least_2d_device(&self, stream: StreamOrDevice) -> Array {
+    pub fn at_least_2d_device(&self, stream: impl AsRef<Stream>) -> Array {
         at_least_2d_device(self, stream)
     }
 
     /// See [`at_least_3d`]
     #[default_device]
-    pub fn at_least_3d_device(&self, stream: StreamOrDevice) -> Array {
+    pub fn at_least_3d_device(&self, stream: impl AsRef<Stream>) -> Array {
         at_least_3d_device(self, stream)
     }
 
@@ -181,7 +185,7 @@ impl Array {
         &self,
         src: i32,
         dst: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe { move_axis_device_unchecked(self, src, dst, stream) }
     }
@@ -192,14 +196,14 @@ impl Array {
         &self,
         src: i32,
         dst: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, InvalidAxisError> {
         try_move_axis_device(self, src, dst, stream)
     }
 
     /// See [`move_axis`]
     #[default_device]
-    pub fn move_axis_device(&self, src: i32, dst: i32, stream: StreamOrDevice) -> Array {
+    pub fn move_axis_device(&self, src: i32, dst: i32, stream: impl AsRef<Stream>) -> Array {
         self.try_move_axis_device(src, dst, stream).unwrap()
     }
 
@@ -213,7 +217,7 @@ impl Array {
         &self,
         indices: &[i32],
         axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Vec<Array> {
         split_device_unchecked(self, indices, axis, stream)
     }
@@ -224,7 +228,7 @@ impl Array {
         &self,
         indices: &[i32],
         axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Vec<Array>, InvalidAxisError> {
         try_split_device(self, indices, axis, stream)
     }
@@ -235,7 +239,7 @@ impl Array {
         &self,
         indices: &[i32],
         axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Vec<Array> {
         self.try_split_device(indices, axis, stream).unwrap()
     }
@@ -250,7 +254,7 @@ impl Array {
         &self,
         num_parts: i32,
         axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Vec<Array> {
         unsafe { split_equal_device_unchecked(self, num_parts, axis, stream) }
     }
@@ -261,7 +265,7 @@ impl Array {
         &self,
         num_parts: i32,
         axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Vec<Array>, InvalidAxisError> {
         try_split_equal_device(self, num_parts, axis, stream)
     }
@@ -272,7 +276,7 @@ impl Array {
         &self,
         num_parts: i32,
         axis: impl Into<Option<i32>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Vec<Array> {
         self.try_split_equal_device(num_parts, axis, stream)
             .unwrap()
@@ -288,7 +292,7 @@ impl Array {
         &self,
         axis1: i32,
         axis2: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe { swap_axes_device_unchecked(self, axis1, axis2, stream) }
     }
@@ -299,13 +303,13 @@ impl Array {
         &self,
         axis1: i32,
         axis2: i32,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, InvalidAxisError> {
         try_swap_axes_device(self, axis1, axis2, stream)
     }
 
     #[default_device]
-    pub fn swap_axes_device(&self, axis1: i32, axis2: i32, stream: StreamOrDevice) -> Array {
+    pub fn swap_axes_device(&self, axis1: i32, axis2: i32, stream: impl AsRef<Stream>) -> Array {
         self.try_swap_axes_device(axis1, axis2, stream).unwrap()
     }
 
@@ -318,7 +322,7 @@ impl Array {
     pub unsafe fn transpose_device_unchecked<'a>(
         &'a self,
         axes: impl Into<Option<&'a [i32]>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         unsafe { transpose_device_unchecked(self, axes, stream) }
     }
@@ -328,7 +332,7 @@ impl Array {
     pub fn try_transpose_device<'a>(
         &self,
         axes: impl Into<Option<&'a [i32]>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Result<Array, TransposeError> {
         try_transpose_device(self, axes, stream)
     }
@@ -338,7 +342,7 @@ impl Array {
     pub fn transpose_device<'a>(
         &self,
         axes: impl Into<Option<&'a [i32]>>,
-        stream: StreamOrDevice,
+        stream: impl AsRef<Stream>,
     ) -> Array {
         self.try_transpose_device(axes, stream).unwrap()
     }
@@ -397,7 +401,7 @@ pub fn as_strided_device<'a>(
     shape: impl Into<Option<&'a [i32]>>,
     strides: impl Into<Option<&'a [usize]>>,
     offset: impl Into<Option<usize>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     let shape = shape.into().unwrap_or(a.shape());
     let resolved_strides = resolve_strides(shape, strides.into());
@@ -411,7 +415,7 @@ pub fn as_strided_device<'a>(
             resolved_strides.as_ptr(),
             resolved_strides.len(),
             offset,
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         );
         Array::from_ptr(c_array)
     }
@@ -440,11 +444,15 @@ pub fn as_strided_device<'a>(
 pub unsafe fn broadcast_to_device_unchecked(
     a: &Array,
     shape: &[i32],
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     unsafe {
-        let c_array =
-            mlx_sys::mlx_broadcast_to(a.c_array, shape.as_ptr(), shape.len(), stream.as_ptr());
+        let c_array = mlx_sys::mlx_broadcast_to(
+            a.c_array,
+            shape.as_ptr(),
+            shape.len(),
+            stream.as_ref().as_ptr(),
+        );
         Array::from_ptr(c_array)
     }
 }
@@ -468,7 +476,7 @@ pub unsafe fn broadcast_to_device_unchecked(
 pub fn try_broadcast_to_device<'a>(
     a: &'a Array,
     shape: &'a [i32],
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, BroadcastError<'a>> {
     if !is_broadcastable(a.shape(), shape) {
         return Err(BroadcastError {
@@ -499,14 +507,18 @@ pub fn try_broadcast_to_device<'a>(
 /// let y = broadcast_to(&x, &[1, 1]);
 /// ```
 #[default_device]
-pub fn broadcast_to_device<'a>(a: &'a Array, shape: &'a [i32], stream: StreamOrDevice) -> Array {
+pub fn broadcast_to_device<'a>(
+    a: &'a Array,
+    shape: &'a [i32],
+    stream: impl AsRef<Stream>,
+) -> Array {
     try_broadcast_to_device(a, shape, stream).unwrap()
 }
 
-fn concatenate_inner(arrays: &[impl AsRef<Array>], axis: i32, stream: StreamOrDevice) -> Array {
+fn concatenate_inner(arrays: &[impl AsRef<Array>], axis: i32, stream: impl AsRef<Stream>) -> Array {
     unsafe {
         let c_arrays = VectorArray::from_iter(arrays.iter());
-        let c_array = mlx_sys::mlx_concatenate(c_arrays.as_ptr(), axis, stream.as_ptr());
+        let c_array = mlx_sys::mlx_concatenate(c_arrays.as_ptr(), axis, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -535,7 +547,7 @@ fn concatenate_inner(arrays: &[impl AsRef<Array>], axis: i32, stream: StreamOrDe
 pub unsafe fn concatenate_device_unchecked(
     arrays: &[impl AsRef<Array>],
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     let axis = axis.into().unwrap_or(0);
     concatenate_inner(arrays, axis, stream)
@@ -561,7 +573,7 @@ pub unsafe fn concatenate_device_unchecked(
 pub fn try_concatenate_device(
     arrays: &[impl AsRef<Array>],
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, ConcatenateError> {
     let axis = axis.into().unwrap_or(0);
 
@@ -626,7 +638,7 @@ pub fn try_concatenate_device(
 pub fn concatenate_device(
     arrays: &[impl AsRef<Array>],
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     try_concatenate_device(arrays, axis, stream).unwrap()
 }
@@ -654,11 +666,15 @@ pub fn concatenate_device(
 pub unsafe fn expand_dims_device_unchecked(
     a: &Array,
     axes: &[i32],
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     unsafe {
-        let c_array =
-            mlx_sys::mlx_expand_dims(a.c_array, axes.as_ptr(), axes.len(), stream.as_ptr());
+        let c_array = mlx_sys::mlx_expand_dims(
+            a.c_array,
+            axes.as_ptr(),
+            axes.len(),
+            stream.as_ref().as_ptr(),
+        );
         Array::from_ptr(c_array)
     }
 }
@@ -682,7 +698,7 @@ pub unsafe fn expand_dims_device_unchecked(
 pub fn try_expand_dims_device(
     a: &Array,
     axes: &[i32],
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, ExpandDimsError> {
     // Check for valid axes
     // TODO: what is a good default capacity for SmallVec?
@@ -730,7 +746,7 @@ pub fn try_expand_dims_device(
 /// let y = expand_dims(&x, &[0]);
 /// ```
 #[default_device]
-pub fn expand_dims_device(a: &Array, axes: &[i32], stream: StreamOrDevice) -> Array {
+pub fn expand_dims_device(a: &Array, axes: &[i32], stream: impl AsRef<Stream>) -> Array {
     a.expand_dims_device(axes, stream)
 }
 
@@ -763,13 +779,14 @@ pub unsafe fn flatten_device_unchecked(
     a: &Array,
     start_axis: impl Into<Option<i32>>,
     end_axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     let start_axis = start_axis.into().unwrap_or(0);
     let end_axis = end_axis.into().unwrap_or(-1);
 
     unsafe {
-        let c_array = mlx_sys::mlx_flatten(a.c_array, start_axis, end_axis, stream.as_ptr());
+        let c_array =
+            mlx_sys::mlx_flatten(a.c_array, start_axis, end_axis, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -799,7 +816,7 @@ pub fn try_flatten_device(
     a: &Array,
     start_axis: impl Into<Option<i32>>,
     end_axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, FlattenError> {
     let ndim = a.ndim();
 
@@ -874,7 +891,7 @@ pub fn flatten_device(
     a: &Array,
     start_axis: impl Into<Option<i32>>,
     end_axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     a.flatten_device(start_axis, end_axis, stream)
 }
@@ -899,9 +916,18 @@ pub fn flatten_device(
 /// let y = unsafe { reshape_unchecked(&x, &[4]) };
 /// ```
 #[default_device]
-pub unsafe fn reshape_device_unchecked(a: &Array, shape: &[i32], stream: StreamOrDevice) -> Array {
+pub unsafe fn reshape_device_unchecked(
+    a: &Array,
+    shape: &[i32],
+    stream: impl AsRef<Stream>,
+) -> Array {
     unsafe {
-        let c_array = mlx_sys::mlx_reshape(a.c_array, shape.as_ptr(), shape.len(), stream.as_ptr());
+        let c_array = mlx_sys::mlx_reshape(
+            a.c_array,
+            shape.as_ptr(),
+            shape.len(),
+            stream.as_ref().as_ptr(),
+        );
         Array::from_ptr(c_array)
     }
 }
@@ -925,7 +951,7 @@ pub unsafe fn reshape_device_unchecked(a: &Array, shape: &[i32], stream: StreamO
 pub fn try_reshape_device<'a>(
     a: &Array,
     shape: &'a [i32],
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, ReshapeError<'a>> {
     a.can_reshape_to(shape)?;
     unsafe { Ok(reshape_device_unchecked(a, shape, stream)) }
@@ -951,7 +977,7 @@ pub fn try_reshape_device<'a>(
 /// let y = reshape(&x, &[4]);
 /// ```
 #[default_device]
-pub fn reshape_device(a: &Array, shape: &[i32], stream: StreamOrDevice) -> Array {
+pub fn reshape_device(a: &Array, shape: &[i32], stream: impl AsRef<Stream>) -> Array {
     a.reshape_device(shape, stream)
 }
 
@@ -978,12 +1004,17 @@ pub fn reshape_device(a: &Array, shape: &[i32], stream: StreamOrDevice) -> Array
 pub unsafe fn squeeze_device_unchecked<'a>(
     a: &'a Array,
     axes: impl Into<Option<&'a [i32]>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     // All size 1 axes are removed if axes is None
     let axes = axes_or_default_to_all_size_one_axes(axes, a.shape());
     unsafe {
-        let c_array = mlx_sys::mlx_squeeze(a.c_array, axes.as_ptr(), axes.len(), stream.as_ptr());
+        let c_array = mlx_sys::mlx_squeeze(
+            a.c_array,
+            axes.as_ptr(),
+            axes.len(),
+            stream.as_ref().as_ptr(),
+        );
         Array::from_ptr(c_array)
     }
 }
@@ -1007,7 +1038,7 @@ pub unsafe fn squeeze_device_unchecked<'a>(
 pub fn try_squeeze_device<'a>(
     a: &'a Array,
     axes: impl Into<Option<&'a [i32]>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, SqueezeError> {
     let axes = axes_or_default_to_all_size_one_axes(axes, a.shape());
     let mut unique_axes = HashSet::new();
@@ -1040,7 +1071,12 @@ pub fn try_squeeze_device<'a>(
     }
 
     unsafe {
-        let c_array = mlx_sys::mlx_squeeze(a.c_array, axes.as_ptr(), axes.len(), stream.as_ptr());
+        let c_array = mlx_sys::mlx_squeeze(
+            a.c_array,
+            axes.as_ptr(),
+            axes.len(),
+            stream.as_ref().as_ptr(),
+        );
         Ok(Array::from_ptr(c_array))
     }
 }
@@ -1068,7 +1104,7 @@ pub fn try_squeeze_device<'a>(
 pub fn squeeze_device<'a>(
     a: &'a Array,
     axes: impl Into<Option<&'a [i32]>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     a.squeeze_device(axes, stream)
 }
@@ -1088,9 +1124,9 @@ pub fn squeeze_device<'a>(
 /// let out = at_least_1d(&x);
 /// ```
 #[default_device]
-pub fn at_least_1d_device(a: &Array, stream: StreamOrDevice) -> Array {
+pub fn at_least_1d_device(a: &Array, stream: impl AsRef<Stream>) -> Array {
     unsafe {
-        let c_array = mlx_sys::mlx_atleast_1d(a.c_array, stream.as_ptr());
+        let c_array = mlx_sys::mlx_atleast_1d(a.c_array, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -1110,9 +1146,9 @@ pub fn at_least_1d_device(a: &Array, stream: StreamOrDevice) -> Array {
 /// let out = at_least_2d(&x);
 /// ```
 #[default_device]
-pub fn at_least_2d_device(a: &Array, stream: StreamOrDevice) -> Array {
+pub fn at_least_2d_device(a: &Array, stream: impl AsRef<Stream>) -> Array {
     unsafe {
-        let c_array = mlx_sys::mlx_atleast_2d(a.c_array, stream.as_ptr());
+        let c_array = mlx_sys::mlx_atleast_2d(a.c_array, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -1132,9 +1168,9 @@ pub fn at_least_2d_device(a: &Array, stream: StreamOrDevice) -> Array {
 /// let out = at_least_3d(&x);
 /// ```
 #[default_device]
-pub fn at_least_3d_device(a: &Array, stream: StreamOrDevice) -> Array {
+pub fn at_least_3d_device(a: &Array, stream: impl AsRef<Stream>) -> Array {
     unsafe {
-        let c_array = mlx_sys::mlx_atleast_3d(a.c_array, stream.as_ptr());
+        let c_array = mlx_sys::mlx_atleast_3d(a.c_array, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -1164,10 +1200,10 @@ pub unsafe fn move_axis_device_unchecked(
     a: &Array,
     src: i32,
     dst: i32,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     unsafe {
-        let c_array = mlx_sys::mlx_moveaxis(a.c_array, src, dst, stream.as_ptr());
+        let c_array = mlx_sys::mlx_moveaxis(a.c_array, src, dst, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -1193,7 +1229,7 @@ pub fn try_move_axis_device(
     a: &Array,
     src: i32,
     dst: i32,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, InvalidAxisError> {
     let ndim = a.ndim();
     let src = resolve_index(src, ndim).ok_or(InvalidAxisError { axis: src, ndim })? as i32;
@@ -1223,7 +1259,7 @@ pub fn try_move_axis_device(
 /// let result = move_axis(&a, 0, 2);
 /// ```
 #[default_device]
-pub fn move_axis_device(a: &Array, src: i32, dst: i32, stream: StreamOrDevice) -> Array {
+pub fn move_axis_device(a: &Array, src: i32, dst: i32, stream: impl AsRef<Stream>) -> Array {
     a.move_axis_device(src, dst, stream)
 }
 
@@ -1252,7 +1288,7 @@ pub unsafe fn split_device_unchecked(
     a: &Array,
     indices: &[i32],
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Vec<Array> {
     let axis = axis.into().unwrap_or(0);
     unsafe {
@@ -1262,7 +1298,7 @@ pub unsafe fn split_device_unchecked(
                 indices.as_ptr(),
                 indices.len(),
                 axis,
-                stream.as_ptr(),
+                stream.as_ref().as_ptr(),
             )
         });
         c_vec.into_values()
@@ -1290,7 +1326,7 @@ pub fn try_split_device(
     a: &Array,
     indices: &[i32],
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Vec<Array>, InvalidAxisError> {
     let axis = axis.into().unwrap_or(0);
     let ndim = a.ndim();
@@ -1323,7 +1359,7 @@ pub fn split_device(
     a: &Array,
     indices: &[i32],
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Vec<Array> {
     a.split_device(indices, axis, stream)
 }
@@ -1353,11 +1389,11 @@ pub unsafe fn split_equal_device_unchecked(
     a: &Array,
     num_parts: i32,
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Vec<Array> {
     let axis = axis.into().unwrap_or(0);
     let c_vec = VectorArray::from_op(|| {
-        mlx_sys::mlx_split_equal_parts(a.c_array, num_parts, axis, stream.as_ptr())
+        mlx_sys::mlx_split_equal_parts(a.c_array, num_parts, axis, stream.as_ref().as_ptr())
     });
     c_vec.into_values()
 }
@@ -1384,7 +1420,7 @@ pub fn try_split_equal_device(
     a: &Array,
     num_parts: i32,
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Vec<Array>, InvalidAxisError> {
     let ndim = a.ndim();
     let axis = axis.into().unwrap_or(0);
@@ -1429,7 +1465,7 @@ pub fn split_equal_device(
     a: &Array,
     num_parts: i32,
     axis: impl Into<Option<i32>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Vec<Array> {
     a.split_equal_device(num_parts, axis, stream)
 }
@@ -1508,7 +1544,7 @@ pub unsafe fn pad_device_unchecked<'a>(
     array: &'a Array,
     width: impl Into<PadWidth<'a>>,
     value: impl Into<Option<Array>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     let width = width.into();
     let ndim = array.ndim();
@@ -1529,7 +1565,7 @@ pub unsafe fn pad_device_unchecked<'a>(
             high_pads.as_ptr(),
             high_pads.len(),
             value.c_array,
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         );
         Array::from_ptr(c_array)
     }
@@ -1559,7 +1595,7 @@ pub fn try_pad_device<'a>(
     array: &'a Array,
     width: impl Into<PadWidth<'a>>,
     value: impl Into<Option<Array>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, PadError> {
     let width = width.into();
     let ndim = array.ndim();
@@ -1594,7 +1630,7 @@ pub fn try_pad_device<'a>(
             high_pads.as_ptr(),
             high_pads.len(),
             value.c_array,
-            stream.as_ptr(),
+            stream.as_ref().as_ptr(),
         );
         Ok(Array::from_ptr(c_array))
     }
@@ -1628,15 +1664,15 @@ pub fn pad_device<'a>(
     array: &'a Array,
     width: impl Into<PadWidth<'a>>,
     value: impl Into<Option<Array>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     try_pad_device(array, width, value, stream).unwrap()
 }
 
-fn stack_inner(arrays: &[impl AsRef<Array>], axis: i32, stream: StreamOrDevice) -> Array {
+fn stack_inner(arrays: &[impl AsRef<Array>], axis: i32, stream: impl AsRef<Stream>) -> Array {
     unsafe {
         let c_vec = VectorArray::from_iter(arrays.iter());
-        let c_array = mlx_sys::mlx_stack(c_vec.as_ptr(), axis, stream.as_ptr());
+        let c_array = mlx_sys::mlx_stack(c_vec.as_ptr(), axis, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -1665,7 +1701,7 @@ fn stack_inner(arrays: &[impl AsRef<Array>], axis: i32, stream: StreamOrDevice) 
 pub unsafe fn stack_device_unchecked(
     arrays: &[impl AsRef<Array>],
     axis: i32,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     stack_inner(arrays, axis, stream)
 }
@@ -1674,7 +1710,7 @@ pub unsafe fn stack_device_unchecked(
 pub fn try_stack_device(
     arrays: &[impl AsRef<Array>],
     axis: i32,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, StackError> {
     if arrays.is_empty() {
         return Err(StackError::NoInputArray);
@@ -1708,14 +1744,14 @@ pub fn try_stack_device(
 /// let result = stack(&[&a, &b], 0);
 /// ```
 #[default_device]
-pub fn stack_device(arrays: &[impl AsRef<Array>], axis: i32, stream: StreamOrDevice) -> Array {
+pub fn stack_device(arrays: &[impl AsRef<Array>], axis: i32, stream: impl AsRef<Stream>) -> Array {
     try_stack_device(arrays, axis, stream).unwrap()
 }
 
-fn stack_all_inner(arrays: &[impl AsRef<Array>], stream: StreamOrDevice) -> Array {
+fn stack_all_inner(arrays: &[impl AsRef<Array>], stream: impl AsRef<Stream>) -> Array {
     unsafe {
         let c_vec = VectorArray::from_iter(arrays.iter());
-        let c_array = mlx_sys::mlx_stack_all(c_vec.as_ptr(), stream.as_ptr());
+        let c_array = mlx_sys::mlx_stack_all(c_vec.as_ptr(), stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -1742,7 +1778,7 @@ fn stack_all_inner(arrays: &[impl AsRef<Array>], stream: StreamOrDevice) -> Arra
 #[default_device]
 pub unsafe fn stack_all_device_unchecked(
     arrays: &[impl AsRef<Array>],
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     stack_all_inner(arrays, stream)
 }
@@ -1765,7 +1801,7 @@ pub unsafe fn stack_all_device_unchecked(
 #[default_device]
 pub fn try_stack_all_device(
     arrays: &[impl AsRef<Array>],
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, StackError> {
     if arrays.is_empty() {
         return Err(StackError::NoInputArray);
@@ -1798,7 +1834,7 @@ pub fn try_stack_all_device(
 /// let result = stack_all(&[&a, &b]);
 /// ```
 #[default_device]
-pub fn stack_all_device(arrays: &[impl AsRef<Array>], stream: StreamOrDevice) -> Array {
+pub fn stack_all_device(arrays: &[impl AsRef<Array>], stream: impl AsRef<Stream>) -> Array {
     try_stack_all_device(arrays, stream).unwrap()
 }
 
@@ -1827,10 +1863,10 @@ pub unsafe fn swap_axes_device_unchecked(
     a: &Array,
     axis1: i32,
     axis2: i32,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     unsafe {
-        let c_array = mlx_sys::mlx_swapaxes(a.c_array, axis1, axis2, stream.as_ptr());
+        let c_array = mlx_sys::mlx_swapaxes(a.c_array, axis1, axis2, stream.as_ref().as_ptr());
         Array::from_ptr(c_array)
     }
 }
@@ -1856,7 +1892,7 @@ pub fn try_swap_axes_device(
     a: &Array,
     axis1: i32,
     axis2: i32,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, InvalidAxisError> {
     let ndim = a.ndim();
     let resolved_axis1 =
@@ -1888,7 +1924,7 @@ pub fn try_swap_axes_device(
 /// let result = swap_axes(&a, 0, 1);
 /// ```
 #[default_device]
-pub fn swap_axes_device(a: &Array, axis1: i32, axis2: i32, stream: StreamOrDevice) -> Array {
+pub fn swap_axes_device(a: &Array, axis1: i32, axis2: i32, stream: impl AsRef<Stream>) -> Array {
     a.swap_axes_device(axis1, axis2, stream)
 }
 
@@ -1908,9 +1944,14 @@ pub fn swap_axes_device(a: &Array, axis1: i32, axis2: i32, stream: StreamOrDevic
 /// let y = tile(&x, &[2]);
 /// ```
 #[default_device]
-pub fn tile_device(a: &Array, reps: &[i32], stream: StreamOrDevice) -> Array {
+pub fn tile_device(a: &Array, reps: &[i32], stream: impl AsRef<Stream>) -> Array {
     unsafe {
-        let c_array = mlx_sys::mlx_tile(a.c_array, reps.as_ptr(), reps.len(), stream.as_ptr());
+        let c_array = mlx_sys::mlx_tile(
+            a.c_array,
+            reps.as_ptr(),
+            reps.len(),
+            stream.as_ref().as_ptr(),
+        );
         Array::from_ptr(c_array)
     }
 }
@@ -1939,14 +1980,17 @@ pub fn tile_device(a: &Array, reps: &[i32], stream: StreamOrDevice) -> Array {
 pub unsafe fn transpose_device_unchecked<'a>(
     a: &'a Array,
     axes: impl Into<Option<&'a [i32]>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     unsafe {
         let c_array = match axes.into() {
-            Some(axes) => {
-                mlx_sys::mlx_transpose(a.c_array, axes.as_ptr(), axes.len(), stream.as_ptr())
-            }
-            None => mlx_sys::mlx_transpose_all(a.c_array, stream.as_ptr()),
+            Some(axes) => mlx_sys::mlx_transpose(
+                a.c_array,
+                axes.as_ptr(),
+                axes.len(),
+                stream.as_ref().as_ptr(),
+            ),
+            None => mlx_sys::mlx_transpose_all(a.c_array, stream.as_ref().as_ptr()),
         };
         Array::from_ptr(c_array)
     }
@@ -1972,7 +2016,7 @@ pub unsafe fn transpose_device_unchecked<'a>(
 pub fn try_transpose_device<'a>(
     a: &Array,
     axes: impl Into<Option<&'a [i32]>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Result<Array, TransposeError> {
     unsafe {
         let c_array = match axes.into() {
@@ -2004,9 +2048,14 @@ pub fn try_transpose_device<'a>(
                     }
                 }
 
-                mlx_sys::mlx_transpose(a.c_array, axes.as_ptr(), axes.len(), stream.as_ptr())
+                mlx_sys::mlx_transpose(
+                    a.c_array,
+                    axes.as_ptr(),
+                    axes.len(),
+                    stream.as_ref().as_ptr(),
+                )
             }
-            None => mlx_sys::mlx_transpose_all(a.c_array, stream.as_ptr()),
+            None => mlx_sys::mlx_transpose_all(a.c_array, stream.as_ref().as_ptr()),
         };
 
         Ok(Array::from_ptr(c_array))
@@ -2037,7 +2086,7 @@ pub fn try_transpose_device<'a>(
 pub fn transpose_device<'a>(
     a: &Array,
     axes: impl Into<Option<&'a [i32]>>,
-    stream: StreamOrDevice,
+    stream: impl AsRef<Stream>,
 ) -> Array {
     try_transpose_device(a, axes, stream).unwrap()
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -55,6 +55,12 @@ impl Default for StreamOrDevice {
     }
 }
 
+impl AsRef<Stream> for StreamOrDevice {
+    fn as_ref(&self) -> &Stream {
+        &self.stream
+    }
+}
+
 impl std::fmt::Debug for StreamOrDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.stream)
@@ -94,6 +100,10 @@ impl Stream {
     pub fn default_stream_on_device(device: &Device) -> Stream {
         let default_stream = unsafe { mlx_sys::mlx_default_stream(device.c_device) };
         Stream::new_with_mlx_mlx_stream(default_stream)
+    }
+
+    pub fn as_ptr(&self) -> mlx_sys::mlx_stream {
+        self.c_stream
     }
 }
 


### PR DESCRIPTION
This PR changes all functions that take `stream: StreamOrDevice` as arg to use `stream: impl AsRef<Stream>` instead. This would allow user to use both `&stream` and `stream` as argument