### PR TITLE
remove stream from param section in docs

### DIFF
--- a/src/ops/arithmetic.rs
+++ b/src/ops/arithmetic.rs
@@ -18,10 +18,6 @@ impl Array {
     /// let data: &[i32] = result.as_slice();
     /// // data == [1, 2, 3, 4, 5]
     /// ```
-    ///
-    /// # Params
-    ///
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn abs_device(&self, stream: StreamOrDevice) -> Array {
         unsafe { Array::from_ptr(mlx_sys::mlx_abs(self.c_array, stream.as_ptr())) }
@@ -45,7 +41,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to add
-    /// - stream: stream or device to evaluate on
     pub fn add_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_add_device(other, stream).unwrap()
     }
@@ -68,7 +63,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to add
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -102,7 +96,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to add
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_add_device(
         &self,
@@ -135,7 +128,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to subtract
-    /// - stream: stream or device to evaluate on
     pub fn sub_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_sub_device(other, stream).unwrap()
     }
@@ -159,7 +151,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to subtract
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -194,7 +185,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to subtract
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_sub_device(
         &self,
@@ -222,10 +212,6 @@ impl Array {
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [-1.0, -2.0, -3.0]
     /// ```
-    ///
-    /// # Params
-    ///
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn neg_device(&self, stream: StreamOrDevice) -> Array {
         self.try_neg_device(stream).unwrap()
@@ -245,10 +231,6 @@ impl Array {
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [-1.0, -2.0, -3.0]
     /// ```
-    ///
-    /// # Params
-    ///
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -272,10 +254,6 @@ impl Array {
     /// let b_data: &[f32] = b.as_slice();
     /// // b_data == [-1.0, -2.0, -3.0]
     /// ```
-    ///
-    /// # Params
-    ///
-    /// - stream: stream or device to evaluate on
     ///
     /// # Errors
     ///
@@ -303,10 +281,6 @@ impl Array {
     /// let b_data: &[bool] = b.as_slice();
     /// // b_data == [true]
     /// ```
-    ///
-    /// # Params
-    ///
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn logical_not_device(&self, stream: StreamOrDevice) -> Array {
         unsafe { Array::from_ptr(mlx_sys::mlx_logical_not(self.c_array, stream.as_ptr())) }
@@ -408,7 +382,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     pub fn div_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_div_device(other, stream).unwrap()
     }
@@ -432,7 +405,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -467,7 +439,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_div_device(
         &self,
@@ -500,7 +471,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to raise to the power of
-    /// - stream: stream or device to evaluate on
     pub fn pow_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_pow_device(other, stream).unwrap()
     }
@@ -524,7 +494,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to raise to the power of
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -559,7 +528,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to raise to the power of
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_pow_device(
         &self,
@@ -592,7 +560,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     pub fn rem_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_rem_device(other, stream).unwrap()
     }
@@ -616,7 +583,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -651,7 +617,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_rem_device(
         &self,
@@ -802,7 +767,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn floor_divide_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_floor_divide_device(other, stream).unwrap()
@@ -831,7 +795,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -875,7 +838,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to divide
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_floor_divide_device(
         &self,
@@ -992,7 +954,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to multiply
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn matmul_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_matmul_device(other, stream).unwrap()
@@ -1026,7 +987,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to multiply
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -1070,7 +1030,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to multiply
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_matmul_device(
         &self,
@@ -1139,7 +1098,6 @@ impl Array {
     /// # Params
     ///
     /// - decimals: number of decimals to round to - default is 0 if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn round_device(&self, decimals: impl Into<Option<i32>>, stream: StreamOrDevice) -> Array {
         unsafe {

--- a/src/ops/convolution.rs
+++ b/src/ops/convolution.rs
@@ -53,7 +53,6 @@ fn conv_general_device_inner(
 /// - flip: Flip the order in which the spatial dimensions of the weights are processed.
 ///   Performs the cross-correlation operator when `flip` is `false` and the convolution
 ///   operator otherwise.
-/// - stream: stream or device to evaluate on
 #[default_device]
 #[allow(clippy::too_many_arguments)]
 pub fn conv_general_device<'a>(
@@ -97,7 +96,6 @@ pub fn conv_general_device<'a>(
 /// - flip: Flip the order in which the spatial dimensions of the weights are processed.
 ///   Performs the cross-correlation operator when `flip` is `false` and the convolution
 ///   operator otherwise.
-/// - stream: stream or device to evaluate on
 ///
 /// # Safety
 ///
@@ -157,7 +155,6 @@ pub unsafe fn conv_general_device_unchecked<'a>(
 /// - flip: Flip the order in which the spatial dimensions of the weights are processed.
 ///   Performs the cross-correlation operator when `flip` is `false` and the convolution
 ///   operator otherwise.
-/// - stream: stream or device to evaluate on
 #[default_device]
 #[allow(clippy::too_many_arguments)]
 pub fn try_conv_general_device<'a>(
@@ -248,7 +245,6 @@ pub fn try_conv_general_device<'a>(
 /// - padding: input padding
 /// - dilation: kernel dilation
 /// - groups: input feature groups
-/// - stream: stream or device to evaluate on
 #[default_device]
 pub fn conv1d_device(
     array: &Array,
@@ -273,7 +269,6 @@ pub fn conv1d_device(
 /// - padding: input padding
 /// - dilation: kernel dilation
 /// - groups: input feature groups
-/// - stream: stream or device to evaluate on
 #[default_device]
 pub fn try_conv1d_device(
     array: &Array,
@@ -313,7 +308,6 @@ pub fn try_conv1d_device(
 /// - padding: input padding
 /// - dilation: kernel dilation
 /// - groups: input feature groups
-/// - stream: stream or device to evaluate on
 #[default_device]
 pub fn conv2d_device(
     array: &Array,
@@ -338,7 +332,6 @@ pub fn conv2d_device(
 /// - padding: input padding
 /// - dilation: kernel dilation
 /// - groups: input feature groups
-/// - stream: stream or device to evaluate on
 #[default_device]
 pub fn try_conv2d_device(
     array: &Array,

--- a/src/ops/factory.rs
+++ b/src/ops/factory.rs
@@ -17,7 +17,6 @@ impl Array {
     /// # Params
     ///
     /// - shape: Desired shape
-    /// - stream: Stream or device to evaluate on
     #[default_device]
     pub fn zeros_device<T: ArrayElement>(shape: &[i32], stream: StreamOrDevice) -> Array {
         // TODO: Can we make use of full() here?
@@ -36,7 +35,6 @@ impl Array {
     /// # Params
     ///
     /// - shape: Desired shape
-    /// - stream: Stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -69,7 +67,6 @@ impl Array {
     /// # Params
     ///
     /// - shape: Desired shape
-    /// - stream: Stream or device to evaluate on
     #[default_device]
     pub fn try_zeros_device<T: ArrayElement>(
         shape: &[i32],
@@ -97,7 +94,6 @@ impl Array {
     /// # Params
     ///
     /// - shape: Desired shape
-    /// - stream: Stream or device to evaluate on
     #[default_device]
     pub fn ones_device<T: ArrayElement>(shape: &[i32], stream: StreamOrDevice) -> Array {
         // TODO: Can we make use of full() here?
@@ -116,7 +112,6 @@ impl Array {
     /// # Params
     ///
     /// - shape: Desired shape
-    /// - stream: Stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -147,7 +142,6 @@ impl Array {
     /// # Params
     ///
     /// - shape: Desired shape
-    /// - stream: Stream or device to evaluate on
     pub fn try_ones_device<T: ArrayElement>(
         shape: &[i32],
         stream: StreamOrDevice,
@@ -177,7 +171,6 @@ impl Array {
     /// - n: number of rows in the output
     /// - m: number of columns in the output -- equal to `n` if not specified
     /// - k: index of the diagonal - defaults to 0 if not specified
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn eye_device<T: ArrayElement>(
         n: i32,
@@ -203,7 +196,6 @@ impl Array {
     /// - n: number of rows in the output
     /// - m: number of columns in the output -- equal to `n` if not specified
     /// - k: index of the diagonal - defaults to 0 if not specified
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -241,7 +233,6 @@ impl Array {
     /// - n: number of rows in the output
     /// - m: number of columns in the output -- equal to `n` if not specified
     /// - k: index of the diagonal - defaults to 0 if not specified
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_eye_device<T: ArrayElement>(
         n: i32,
@@ -277,7 +268,6 @@ impl Array {
     ///
     /// - shape: shape of the output array
     /// - values: values to be broadcast into the array
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn full_device<T: ArrayElement>(
         shape: &[i32],
@@ -304,7 +294,6 @@ impl Array {
     ///
     /// - shape: shape of the output array
     /// - values: values to be broadcast into the array
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -343,7 +332,6 @@ impl Array {
     ///
     /// - shape: shape of the output array
     /// - values: values to be broadcast into the array
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_full_device<T: ArrayElement>(
         shape: &[i32],
@@ -372,7 +360,6 @@ impl Array {
     /// # Params
     ///
     /// - n: number of rows and columns in the output
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn identity_device<T: ArrayElement>(n: i32, stream: StreamOrDevice) -> Array {
         Self::eye_device::<T>(n, Some(n), None, stream)
@@ -391,7 +378,6 @@ impl Array {
     /// # Params
     ///
     /// - n: number of rows and columns in the output
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -416,7 +402,6 @@ impl Array {
     /// # Params
     ///
     /// - n: number of rows and columns in the output
-    /// - stream: stream or device to evaluate on
     pub fn try_identity_device<T: ArrayElement>(
         n: i32,
         stream: StreamOrDevice,
@@ -439,7 +424,6 @@ impl Array {
     /// - start: start value
     /// - stop: stop value
     /// - count: number of samples -- defaults to 50 if not specified
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn linspace_device<T, U>(
         start: U,
@@ -469,7 +453,6 @@ impl Array {
     /// - start: start value
     /// - stop: stop value
     /// - count: number of samples -- defaults to 50 if not specified
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -514,7 +497,6 @@ impl Array {
     /// - start: start value
     /// - stop: stop value
     /// - count: number of samples -- defaults to 50 if not specified
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_linspace_device<T, U>(
         start: U,
@@ -553,7 +535,6 @@ impl Array {
     /// - array: array to repeat
     /// - count: number of times to repeat
     /// - axis: axis to repeat along
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn repeat_device<T: ArrayElement>(
         array: Array,
@@ -580,7 +561,6 @@ impl Array {
     /// - array: array to repeat
     /// - count: number of times to repeat
     /// - axis: axis to repeat along
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -618,7 +598,6 @@ impl Array {
     /// - array: array to repeat
     /// - count: number of times to repeat
     /// - axis: axis to repeat along
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_repeat_device<T: ArrayElement>(
         array: Array,
@@ -651,7 +630,6 @@ impl Array {
     ///
     /// - array: array to repeat
     /// - count: number of times to repeat
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn repeat_all_device<T: ArrayElement>(
         array: Array,
@@ -676,7 +654,6 @@ impl Array {
     ///
     /// - array: array to repeat
     /// - count: number of times to repeat
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -711,7 +688,6 @@ impl Array {
     ///
     /// - array: array to repeat
     /// - count: number of times to repeat
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_repeat_all_device<T: ArrayElement>(
         array: Array,
@@ -743,7 +719,6 @@ impl Array {
     /// - n: number of rows in the output
     /// - m: number of columns in the output -- equal to `n` if not specified
     /// - k: index of the diagonal -- defaults to 0 if not specified
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn tri_device<T: ArrayElement>(
         n: i32,

--- a/src/ops/logical.rs
+++ b/src/ops/logical.rs
@@ -25,7 +25,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn eq_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_eq_device(other, stream).unwrap()
@@ -51,7 +50,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -87,7 +85,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_eq_device(
         &self,
@@ -121,7 +118,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn le_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_le_device(other, stream).unwrap()
@@ -147,7 +143,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -183,7 +178,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_le_device(
         &self,
@@ -217,7 +211,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn ge_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_ge_device(other, stream).unwrap()
@@ -242,7 +235,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -278,7 +270,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_ge_device(
         &self,
@@ -312,7 +303,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn ne_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_ne_device(other, stream).unwrap()
@@ -338,7 +328,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -374,7 +363,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_ne_device(
         &self,
@@ -407,7 +395,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn lt_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_lt_device(other, stream).unwrap()
@@ -433,7 +420,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -468,7 +454,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_lt_device(
         &self,
@@ -501,7 +486,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn gt_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_gt_device(other, stream).unwrap()
@@ -526,7 +510,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -561,7 +544,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_gt_device(
         &self,
@@ -594,7 +576,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn logical_and_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_logical_and_device(other, stream).unwrap()
@@ -619,7 +600,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -658,7 +638,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_logical_and_device(
         &self,
@@ -691,7 +670,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn logical_or_device(&self, other: &Array, stream: StreamOrDevice) -> Array {
         self.try_logical_or_device(other, stream).unwrap()
@@ -716,7 +694,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -755,7 +732,6 @@ impl Array {
     /// # Params
     ///
     /// - other: array to compare
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_logical_or_device(
         &self,
@@ -796,7 +772,6 @@ impl Array {
     /// - rtol: relative tolerance = defaults to 1e-5 when None
     /// - atol: absolute tolerance - defaults to 1e-8 when None
     /// - equal_nan: whether to consider NaNs equal -- default is false when None
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn all_close_device(
         &self,
@@ -837,7 +812,6 @@ impl Array {
     /// - rtol: relative tolerance = defaults to 1e-5 when None
     /// - atol: absolute tolerance - defaults to 1e-8 when None
     /// - equal_nan: whether to consider NaNs equal -- default is false when None
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -890,7 +864,6 @@ impl Array {
     /// - rtol: relative tolerance = defaults to 1e-5 when None
     /// - atol: absolute tolerance - defaults to 1e-8 when None
     /// - equal_nan: whether to consider NaNs equal -- default is false when None
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_all_close_device(
         &self,
@@ -1020,7 +993,6 @@ impl Array {
     ///
     /// - other: array to compare
     /// - equal_nan: whether to consider NaNs equal -- default is false when None
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn array_eq_device(
         &self,
@@ -1056,7 +1028,6 @@ impl Array {
     /// # Params
     /// - axes: axes to reduce over -- defaults to all axes if not provided
     /// - keep_dims: if `true` keep reduced axis as singleton dimension -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn any_device<'a>(
         &'a self,
@@ -1085,7 +1056,6 @@ impl Array {
     /// # Params
     /// - axes: axes to reduce over -- defaults to all axes if not provided
     /// - keep_dims: if `true` keep reduced axis as singleton dimension -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -1128,7 +1098,6 @@ impl Array {
     /// # Params
     /// - axes: axes to reduce over -- defaults to all axes if not provided
     /// - keep_dims: if `true` keep reduced axis as singleton dimension -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_any_device<'a>(
         &'a self,
@@ -1164,7 +1133,6 @@ impl Array {
 /// - condition: condition array
 /// - a: input selected from where condition is non-zero or `true`
 /// - b: input selected from where condition is zero or `false`
-/// - stream: stream or device to evaluate on
 #[default_device]
 pub fn which_device(condition: &Array, a: &Array, b: &Array, stream: StreamOrDevice) -> Array {
     try_which_device(condition, a, b, stream).unwrap()
@@ -1179,7 +1147,6 @@ pub fn which_device(condition: &Array, a: &Array, b: &Array, stream: StreamOrDev
 /// - condition: condition array
 /// - a: input selected from where condition is non-zero or `true`
 /// - b: input selected from where condition is zero or `false`
-/// - stream: stream or device to evaluate on
 ///
 /// # Safety
 ///
@@ -1210,7 +1177,6 @@ pub unsafe fn which_device_unchecked(
 /// - condition: condition array
 /// - a: input selected from where condition is non-zero or `true`
 /// - b: input selected from where condition is zero or `false`
-/// - stream: stream or device to evaluate on
 #[default_device]
 pub fn try_which_device(
     condition: &Array,

--- a/src/ops/reduction.rs
+++ b/src/ops/reduction.rs
@@ -22,7 +22,6 @@ impl Array {
     ///
     /// - axes: The axes to reduce over -- defaults to all axes if not provided
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: The stream to execute the operation on
     #[default_device]
     pub fn all_device<'a>(
         &'a self,
@@ -50,7 +49,6 @@ impl Array {
     ///
     /// - axes: The axes to reduce over -- defaults to all axes if not provided
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: The stream to execute the operation on
     ///
     /// # Safety
     ///
@@ -90,7 +88,6 @@ impl Array {
     ///
     /// - axes: The axes to reduce over -- defaults to all axes if not provided
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: The stream to execute the operation on
     #[default_device]
     pub fn try_all_device<'a>(
         &'a self,
@@ -132,7 +129,6 @@ impl Array {
     ///
     /// - axes: The axes to reduce over -- defaults to all axes if not provided
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: The stream to execute the operation on
     #[default_device]
     pub fn prod_device<'a>(
         &'a self,
@@ -159,7 +155,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -198,7 +193,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_prod_device<'a>(
         &'a self,
@@ -240,7 +234,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn max_device<'a>(
         &'a self,
@@ -268,7 +261,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -307,7 +299,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_max_device<'a>(
         &'a self,
@@ -355,7 +346,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: if `true`, keep the reduces axes as singleton dimensions
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn sum_device<'a>(
         &'a self,
@@ -382,7 +372,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: if `true`, keep the reduces axes as singleton dimensions
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -421,7 +410,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: if `true`, keep the reduces axes as singleton dimensions
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_sum_device<'a>(
         &'a self,
@@ -463,7 +451,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn mean_device<'a>(
         &'a self,
@@ -490,7 +477,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -529,7 +515,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_mean_device<'a>(
         &'a self,
@@ -580,7 +565,6 @@ impl Array {
     /// # Params
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn min_device<'a>(
         &'a self,
@@ -607,7 +591,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -646,7 +629,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_min_device<'a>(
         &'a self,
@@ -684,7 +666,6 @@ impl Array {
     /// - axes: axes to reduce over
     /// - keep_dims: if `true`, keep the reduces axes as singleton dimensions
     /// - ddof: the divisor to compute the variance is `N - ddof`
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn variance_device<'a>(
         &'a self,
@@ -704,7 +685,6 @@ impl Array {
     /// - axes: axes to reduce over
     /// - keep_dims: if `true`, keep the reduces axes as singleton dimensions
     /// - ddof: the divisor to compute the variance is `N - ddof`
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -736,7 +716,6 @@ impl Array {
     /// - axes: axes to reduce over
     /// - keep_dims: if `true`, keep the reduces axes as singleton dimensions
     /// - ddof: the divisor to compute the variance is `N - ddof`
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_variance_device<'a>(
         &'a self,
@@ -783,7 +762,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn log_sum_exp_device<'a>(
         &'a self,
@@ -803,7 +781,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     ///
     /// # Safety
     ///
@@ -834,7 +811,6 @@ impl Array {
     ///
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
-    /// - stream: stream or device to evaluate on
     #[default_device]
     pub fn try_log_sum_exp_device<'a>(
         &'a self,


### PR DESCRIPTION
This PR removes the `stream` param from the Params section in the docs.

The same doc is generated for both `_device` and non`_device` variants, and the latter is likely the most commonly used ones. Having `stream` in the docs for the latter would be confusing