### PR TITLE
added traits and macro to help create 1d, 2d, and 3d arrays

### DIFF
--- a/src/array/macros.rs
+++ b/src/array/macros.rs
@@ -1,31 +1,31 @@
 //! Macros for creating arrays.
-//! 
+//!
 //! TODO: This will be moved to the `crate::macros::array` module in the future.
 
 /// A helper macro to create an array with up to 3 dimensions.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```rust
 /// use mlx_rs::array;
-/// 
+///
 /// // Create a 1D array
 /// let a1 = array![1, 2, 3];
-/// 
+///
 /// // Create a 2D array
 /// let a2 = array![
-///     [1, 2, 3], 
+///     [1, 2, 3],
 ///     [4, 5, 6]
 /// ];
-/// 
+///
 /// // Create a 3D array
 /// let a3 = array![
 ///     [
-///         [1, 2, 3], 
+///         [1, 2, 3],
 ///         [4, 5, 6]
-///     ], 
+///     ],
 ///     [
-///         [7, 8, 9], 
+///         [7, 8, 9],
 ///         [10, 11, 12]
 ///     ]
 /// ];

--- a/src/array/macros.rs
+++ b/src/array/macros.rs
@@ -1,0 +1,103 @@
+//! Macros for creating arrays.
+//! 
+//! TODO: This will be moved to the `crate::macros::array` module in the future.
+
+/// A helper macro to create an array with up to 3 dimensions.
+/// 
+/// # Examples
+/// 
+/// ```rust
+/// use mlx_rs::array;
+/// 
+/// // Create a 1D array
+/// let a1 = array![1, 2, 3];
+/// 
+/// // Create a 2D array
+/// let a2 = array![
+///     [1, 2, 3], 
+///     [4, 5, 6]
+/// ];
+/// 
+/// // Create a 3D array
+/// let a3 = array![
+///     [
+///         [1, 2, 3], 
+///         [4, 5, 6]
+///     ], 
+///     [
+///         [7, 8, 9], 
+///         [10, 11, 12]
+///     ]
+/// ];
+/// ```
+#[macro_export]
+macro_rules! array {
+    ($([$([$($x:expr),*]),*]),*) => {
+        {
+            let arr = [$([$([$($x,)*],)*],)*];
+            <$crate::Array as $crate::FromNested<_>>::from_nested(arr)
+        }
+    };
+    ($([$($x:expr),*]),*) => {
+        {
+            let arr = [$([$($x,)*],)*];
+            <$crate::Array as $crate::FromNested<_>>::from_nested(arr)
+        }
+    };
+    ($($x:expr),*) => {
+        {
+            let arr = [$($x,)*];
+            <$crate::Array as $crate::FromNested<_>>::from_nested(arr)
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ops::indexing::IndexOp;
+
+    #[test]
+    fn test_array_1d() {
+        let arr = array![1, 2, 3];
+
+        assert!(arr.ndim() == 1);
+        assert_eq!(arr.shape(), &[3]);
+        assert_eq!(arr.index(0).item::<i32>(), 1);
+        assert_eq!(arr.index(1).item::<i32>(), 2);
+        assert_eq!(arr.index(2).item::<i32>(), 3);
+    }
+
+    #[test]
+    fn test_array_2d() {
+        let a = array![[1, 2, 3], [4, 5, 6]];
+
+        assert!(a.ndim() == 2);
+        assert_eq!(a.shape(), &[2, 3]);
+        assert_eq!(a.index((0, 0)).item::<i32>(), 1);
+        assert_eq!(a.index((0, 1)).item::<i32>(), 2);
+        assert_eq!(a.index((0, 2)).item::<i32>(), 3);
+        assert_eq!(a.index((1, 0)).item::<i32>(), 4);
+        assert_eq!(a.index((1, 1)).item::<i32>(), 5);
+        assert_eq!(a.index((1, 2)).item::<i32>(), 6);
+    }
+
+    #[test]
+    fn test_array_3d() {
+        let a = array![[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]];
+
+        assert!(a.ndim() == 3);
+        assert_eq!(a.shape(), &[2, 2, 3]);
+        assert_eq!(a.index((0, 0, 0)).item::<i32>(), 1);
+        assert_eq!(a.index((0, 0, 1)).item::<i32>(), 2);
+        assert_eq!(a.index((0, 0, 2)).item::<i32>(), 3);
+        assert_eq!(a.index((0, 1, 0)).item::<i32>(), 4);
+        assert_eq!(a.index((0, 1, 1)).item::<i32>(), 5);
+        assert_eq!(a.index((0, 1, 2)).item::<i32>(), 6);
+        assert_eq!(a.index((1, 0, 0)).item::<i32>(), 7);
+        assert_eq!(a.index((1, 0, 1)).item::<i32>(), 8);
+        assert_eq!(a.index((1, 0, 2)).item::<i32>(), 9);
+        assert_eq!(a.index((1, 1, 0)).item::<i32>(), 10);
+        assert_eq!(a.index((1, 1, 1)).item::<i32>(), 11);
+        assert_eq!(a.index((1, 1, 2)).item::<i32>(), 12);
+    }
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -8,7 +8,6 @@ use num_complex::Complex;
 use std::ffi::c_void;
 
 mod element;
-mod macros;
 mod operators;
 
 pub use element::ArrayElement;

--- a/src/macros/array.rs
+++ b/src/macros/array.rs
@@ -1,6 +1,4 @@
 //! Macros for creating arrays.
-//!
-//! TODO: This will be moved to the `crate::macros::array` module in the future.
 
 /// A helper macro to create an array with up to 3 dimensions.
 ///

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,2 +1,4 @@
 #[macro_use]
 mod internal;
+
+mod array;


### PR DESCRIPTION
This allows creating array with up to 3 dims using the macro `array!`

```rust
use mlx_rs::array;

// Create a 1D array
let a1 = array![1, 2, 3];

// Create a 2D array
let a2 = array![
    [1, 2, 3], 
    [4, 5, 6]
];

// Create a 3D array
let a3 = array![
    [
        [1, 2, 3], 
        [4, 5, 6]
    ], 
    [
        [7, 8, 9], 
        [10, 11, 12]
    ]
];
```

### Dependencies

- [x] #76 
- [x] ~~The macro is expected to move to `crate::macros::array` once #69 is merged~~(already moved in 15e7f30)