### PR TITLE
Set version numbers for 0.14.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ authors = [
 ]
 edition = "2021"
 
-description = "Rust wrapper for Apple's mlx machine learning library."
-repository = "https://github.com/minghuaw/mlx-rs"
+description = "Unofficial rust wrapper for Apple's mlx machine learning library."
+repository = "https://github.com/oxideai/mlx-rs"
 keywords = ["mlx", "deep-learning", "machine-learning"]
 categories = ["science"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-rs"
-version = "0.10.0-alpha.0"
+version = "0.14.0"
 authors = [
   "Minghua Wu <michael.wu1107@gmail.com>",
   "David Chavez <david@dcvz.io>",
@@ -15,8 +15,8 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-mlx-sys = { version = "0.10.0-alpha.0", path = "mlx-sys" }
-mlx-macros = { version = "0.10.0-alpha.0", path = "mlx-macros" }
+mlx-sys = { version = "0.0.8", path = "mlx-sys" }
+mlx-macros = { version = "0.1.0", path = "mlx-macros" }
 half = "2"
 mach-sys = "0.5.4"
 num-complex = "0.4"

--- a/mlx-macros/Cargo.toml
+++ b/mlx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-macros"
-version = "0.10.0-alpha.0"
+version = "0.1.0"
 authors = ["Minghua Wu <michael.wu1107@gmail.com>", "David Chavez <david@dcvz.io>"]
 edition = "2021"
 

--- a/mlx-macros/Cargo.toml
+++ b/mlx-macros/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Minghua Wu <michael.wu1107@gmail.com>", "David Chavez <david@dcvz.io
 edition = "2021"
 
 description = "Code generation crate for mlx-rs"
-repository = "https://github.com/minghuaw/mlx-rs"
+repository = "https://github.com/oxideai/mlx-rs"
 keywords = ["mlx", "deep-learning", "machine-learning"]
 categories = ["science"]
 license = "MIT OR Apache-2.0"

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Minghua Wu <michael.wu1107@gmail.com>", "David Chavez <david@dcvz.io
 edition = "2021"
 
 description = "Low-level interface and binding generation for the mlx library"
-repository = "https://github.com/minghuaw/mlx-rs"
+repository = "https://github.com/oxideai/mlx-rs"
 keywords = ["mlx", "deep-learning", "machine-learning"]
 categories = ["science"]
 license = "MIT OR Apache-2.0"

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-sys"
-version = "0.10.0-alpha.0"
+version = "0.0.8"
 authors = ["Minghua Wu <michael.wu1107@gmail.com>", "David Chavez <david@dcvz.io>"]
 edition = "2021"
 


### PR DESCRIPTION
Assign version number for initial release after migrating to the c api.

- `mlx-rs` - 0.14.0 (follows the version of `mlx`)
- `mlx-sys` - 0.0.8 (follows the version of `mlx-c`)
- `mlx-macros` - 0.1.0

I think we can then make a PR to merge `dev` into `main` and make our first release