### PR TITLE
Trust synchronization on the cpp side

### DIFF
--- a/mlx-rs/examples/tutorial.rs
+++ b/mlx-rs/examples/tutorial.rs
@@ -2,7 +2,7 @@ use mlx_rs::{Array, Dtype};
 
 fn scalar_basics() {
     // create a scalar array
-    let mut x: Array = 1.0.into();
+    let x: Array = 1.0.into();
 
     // the datatype is .float32
     let dtype = x.dtype();

--- a/mlx-rs/src/array/mod.rs
+++ b/mlx-rs/src/array/mod.rs
@@ -47,38 +47,11 @@ impl std::fmt::Display for Array {
 // TODO: Clone should probably NOT be implemented because the underlying pointer is atomically
 // reference counted but not guarded by a mutex.
 
-impl Array {
-    /// Clone the array by copying the data.
-    pub(crate) fn clone(&self) -> Self {
-        unsafe {
-            let dtype = self.dtype();
-            let shape = self.shape();
-            let data = match dtype {
-                Dtype::Bool => mlx_sys::mlx_array_data_bool(self.c_array) as *const c_void,
-                Dtype::Uint8 => mlx_sys::mlx_array_data_uint8(self.c_array) as *const c_void,
-                Dtype::Uint16 => mlx_sys::mlx_array_data_uint16(self.c_array) as *const c_void,
-                Dtype::Uint32 => mlx_sys::mlx_array_data_uint32(self.c_array) as *const c_void,
-                Dtype::Uint64 => mlx_sys::mlx_array_data_uint64(self.c_array) as *const c_void,
-                Dtype::Int8 => mlx_sys::mlx_array_data_int8(self.c_array) as *const c_void,
-                Dtype::Int16 => mlx_sys::mlx_array_data_int16(self.c_array) as *const c_void,
-                Dtype::Int32 => mlx_sys::mlx_array_data_int32(self.c_array) as *const c_void,
-                Dtype::Int64 => mlx_sys::mlx_array_data_int64(self.c_array) as *const c_void,
-                Dtype::Float16 => mlx_sys::mlx_array_data_float16(self.c_array) as *const c_void,
-                Dtype::Float32 => mlx_sys::mlx_array_data_float32(self.c_array) as *const c_void,
-                Dtype::Bfloat16 => mlx_sys::mlx_array_data_bfloat16(self.c_array) as *const c_void,
-                Dtype::Complex64 => {
-                    mlx_sys::mlx_array_data_complex64(self.c_array) as *const c_void
-                }
-            };
-
-            let new_c_array = mlx_sys::mlx_array_from_data(
-                data,
-                shape.as_ptr(),
-                shape.len() as i32,
-                dtype.into(),
-            );
-
-            Array::from_ptr(new_c_array)
+impl Clone for Array {
+    fn clone(&self) -> Self {
+        unsafe { mlx_sys::mlx_retain(self.c_array as *mut c_void) };
+        Self {
+            c_array: self.c_array,
         }
     }
 }
@@ -279,7 +252,7 @@ impl Array {
 
     // TODO: document that mlx is lazy
     /// Evaluate the array.
-    pub fn eval(&mut self) -> Result<(), Exception> {
+    pub fn eval(&self) -> Result<(), Exception> {
         if !is_mlx_error_handler_set() {
             setup_mlx_error_handler();
         }
@@ -293,7 +266,7 @@ impl Array {
     /// If `T` does not match the array's `dtype` this will convert the type first.
     ///
     /// _Note: This will evaluate the array._
-    pub fn item<T: ArrayElement>(&mut self) -> T {
+    pub fn item<T: ArrayElement>(&self) -> T {
         self.try_item().unwrap()
     }
 
@@ -305,7 +278,7 @@ impl Array {
     /// # Safety
     ///
     /// This is unsafe because the array is not checked for being a scalar.
-    pub fn item_unchecked<T: ArrayElement>(&mut self) -> T {
+    pub fn item_unchecked<T: ArrayElement>(&self) -> T {
         // Evaluate the array, so we have content to work with in the conversion
         self.eval().unwrap();
 
@@ -317,7 +290,7 @@ impl Array {
                     StreamOrDevice::default().as_ptr(),
                 )
             };
-            let mut new_array = unsafe { Array::from_ptr(new_array_ctx) };
+            let new_array = unsafe { Array::from_ptr(new_array_ctx) };
             new_array.eval().unwrap();
 
             return T::array_item(&new_array);
@@ -330,7 +303,7 @@ impl Array {
     /// If `T` does not match the array's `dtype` this will convert the type first.
     ///
     /// _Note: This will evaluate the array._
-    pub fn try_item<T: ArrayElement>(&mut self) -> Result<T, ItemError> {
+    pub fn try_item<T: ArrayElement>(&self) -> Result<T, ItemError> {
         if self.size() != 1 {
             return Err(ItemError::NotScalar);
         }
@@ -346,7 +319,7 @@ impl Array {
                     StreamOrDevice::default().as_ptr(),
                 )
             };
-            let mut new_array = unsafe { Array::from_ptr(new_array_ctx) };
+            let new_array = unsafe { Array::from_ptr(new_array_ctx) };
             new_array.eval()?;
 
             return Ok(T::array_item(&new_array));
@@ -356,7 +329,6 @@ impl Array {
     }
 
     /// Returns a slice of the array data without validating the dtype.
-    /// This method requires a mutable reference (`&mut self`) because it evaluates the array.
     ///
     /// # Safety
     ///
@@ -376,7 +348,7 @@ impl Array {
     ///    assert_eq!(slice, &[1, 2, 3, 4, 5]);
     /// }
     /// ```
-    pub unsafe fn as_slice_unchecked<T: ArrayElement>(&mut self) -> &[T] {
+    pub unsafe fn as_slice_unchecked<T: ArrayElement>(&self) -> &[T] {
         self.eval().unwrap();
 
         unsafe {
@@ -387,7 +359,6 @@ impl Array {
     }
 
     /// Returns a slice of the array data returning an error if the dtype does not match the actual dtype.
-    /// This method requires a mutable reference (`&mut self`) because it evaluates the array.
     ///
     /// # Example
     ///
@@ -400,7 +371,7 @@ impl Array {
     /// let slice = array.try_as_slice::<i32>();
     /// assert_eq!(slice, Ok(&data[..]));
     /// ```
-    pub fn try_as_slice<T: ArrayElement>(&mut self) -> Result<&[T], AsSliceError> {
+    pub fn try_as_slice<T: ArrayElement>(&self) -> Result<&[T], AsSliceError> {
         if self.dtype() != T::DTYPE {
             return Err(AsSliceError::DtypeMismatch {
                 expecting: T::DTYPE,
@@ -422,7 +393,7 @@ impl Array {
     }
 
     /// Returns a slice of the array data.
-    /// This method requires a mutable reference (`&mut self`) because it evaluates the array.
+    /// This method requires a mutable reference (`&self`) because it evaluates the array.
     ///
     /// # Panics
     ///
@@ -439,8 +410,44 @@ impl Array {
     /// let slice = array.as_slice::<i32>();
     /// assert_eq!(slice, &data[..]);
     /// ```
-    pub fn as_slice<T: ArrayElement>(&mut self) -> &[T] {
+    pub fn as_slice<T: ArrayElement>(&self) -> &[T] {
         self.try_as_slice().unwrap()
+    }
+
+    /// Clone the array by copying the data.
+    ///
+    /// This is named `deep_clone` to avoid confusion with the `Clone` trait.
+    pub fn deep_clone(&self) -> Self {
+        unsafe {
+            let dtype = self.dtype();
+            let shape = self.shape();
+            let data = match dtype {
+                Dtype::Bool => mlx_sys::mlx_array_data_bool(self.c_array) as *const c_void,
+                Dtype::Uint8 => mlx_sys::mlx_array_data_uint8(self.c_array) as *const c_void,
+                Dtype::Uint16 => mlx_sys::mlx_array_data_uint16(self.c_array) as *const c_void,
+                Dtype::Uint32 => mlx_sys::mlx_array_data_uint32(self.c_array) as *const c_void,
+                Dtype::Uint64 => mlx_sys::mlx_array_data_uint64(self.c_array) as *const c_void,
+                Dtype::Int8 => mlx_sys::mlx_array_data_int8(self.c_array) as *const c_void,
+                Dtype::Int16 => mlx_sys::mlx_array_data_int16(self.c_array) as *const c_void,
+                Dtype::Int32 => mlx_sys::mlx_array_data_int32(self.c_array) as *const c_void,
+                Dtype::Int64 => mlx_sys::mlx_array_data_int64(self.c_array) as *const c_void,
+                Dtype::Float16 => mlx_sys::mlx_array_data_float16(self.c_array) as *const c_void,
+                Dtype::Float32 => mlx_sys::mlx_array_data_float32(self.c_array) as *const c_void,
+                Dtype::Bfloat16 => mlx_sys::mlx_array_data_bfloat16(self.c_array) as *const c_void,
+                Dtype::Complex64 => {
+                    mlx_sys::mlx_array_data_complex64(self.c_array) as *const c_void
+                }
+            };
+
+            let new_c_array = mlx_sys::mlx_array_from_data(
+                data,
+                shape.as_ptr(),
+                shape.len() as i32,
+                dtype.into(),
+            );
+
+            Array::from_ptr(new_c_array)
+        }
     }
 }
 
@@ -865,7 +872,7 @@ mod tests {
 
     #[test]
     fn new_scalar_array_from_bool() {
-        let mut array = Array::from_bool(true);
+        let array = Array::from_bool(true);
         assert!(array.item::<bool>());
         assert_eq!(array.item_size(), 1);
         assert_eq!(array.size(), 1);
@@ -878,7 +885,7 @@ mod tests {
 
     #[test]
     fn new_scalar_array_from_int() {
-        let mut array = Array::from_int(42);
+        let array = Array::from_int(42);
         assert_eq!(array.item::<i32>(), 42);
         assert_eq!(array.item_size(), 4);
         assert_eq!(array.size(), 1);
@@ -891,7 +898,7 @@ mod tests {
 
     #[test]
     fn new_scalar_array_from_float() {
-        let mut array = Array::from_float(3.14);
+        let array = Array::from_float(3.14);
         assert_eq!(array.item::<f32>(), 3.14);
         assert_eq!(array.item_size(), 4);
         assert_eq!(array.size(), 1);
@@ -905,7 +912,7 @@ mod tests {
     #[test]
     fn new_scalar_array_from_complex() {
         let val = complex64::new(1.0, 2.0);
-        let mut array = Array::from_complex(val);
+        let array = Array::from_complex(val);
         assert_eq!(array.item::<complex64>(), val);
         assert_eq!(array.item_size(), 8);
         assert_eq!(array.size(), 1);
@@ -919,7 +926,7 @@ mod tests {
     #[test]
     fn new_array_from_single_element_slice() {
         let data = [1i32];
-        let mut array = Array::from_slice(&data, &[1]);
+        let array = Array::from_slice(&data, &[1]);
         assert_eq!(array.as_slice::<i32>(), &data[..]);
         assert_eq!(array.item::<i32>(), 1);
         assert_eq!(array.item_size(), 4);
@@ -935,7 +942,7 @@ mod tests {
     #[test]
     fn new_array_from_multi_element_slice() {
         let data = [1i32, 2, 3, 4, 5];
-        let mut array = Array::from_slice(&data, &[5]);
+        let array = Array::from_slice(&data, &[5]);
         assert_eq!(array.as_slice::<i32>(), &data[..]);
         assert_eq!(array.item_size(), 4);
         assert_eq!(array.size(), 5);
@@ -950,7 +957,7 @@ mod tests {
     #[test]
     fn new_2d_array_from_slice() {
         let data = [1i32, 2, 3, 4, 5, 6];
-        let mut array = Array::from_slice(&data, &[2, 3]);
+        let array = Array::from_slice(&data, &[2, 3]);
         assert_eq!(array.as_slice::<i32>(), &data[..]);
         assert_eq!(array.item_size(), 4);
         assert_eq!(array.size(), 6);
@@ -966,10 +973,10 @@ mod tests {
     }
 
     #[test]
-    fn cloned_array_has_different_ptr() {
+    fn deep_cloned_array_has_different_ptr() {
         let data = [1i32, 2, 3, 4, 5];
-        let mut orig = Array::from_slice(&data, &[5]);
-        let mut clone = orig.clone();
+        let orig = Array::from_slice(&data, &[5]);
+        let clone = orig.deep_clone();
 
         // Data should be the same
         assert_eq!(orig.as_slice::<i32>(), clone.as_slice::<i32>());
@@ -998,13 +1005,13 @@ mod tests {
     #[test]
     fn test_array_item_non_scalar() {
         let data = [1i32, 2, 3, 4, 5];
-        let mut array = Array::from_slice(&data, &[5]);
+        let array = Array::from_slice(&data, &[5]);
         assert!(array.try_item::<i32>().is_err());
     }
 
     #[test]
     fn test_item_type_conversion() {
-        let mut array = Array::from_float(1.0);
+        let array = Array::from_float(1.0);
         assert_eq!(array.item::<i32>(), 1);
         assert_eq!(array.item::<complex64>(), complex64::new(1.0, 0.0));
         assert_eq!(array.item::<u8>(), 1);

--- a/mlx-rs/src/fft/fftn.rs
+++ b/mlx-rs/src/fft/fftn.rs
@@ -230,13 +230,13 @@ mod tests {
             complex64::new(-2.0, -2.0),
         ];
 
-        let mut array = Array::from_slice(FFT_DATA, FFT_SHAPE);
-        let mut fft = fft(&array, None, None).unwrap();
+        let array = Array::from_slice(FFT_DATA, FFT_SHAPE);
+        let fft = fft(&array, None, None).unwrap();
 
         assert_eq!(fft.dtype(), Dtype::Complex64);
         assert_eq!(fft.as_slice::<complex64>(), FFT_EXPECTED);
 
-        let mut ifft = ifft(&fft, None, None).unwrap();
+        let ifft = ifft(&fft, None, None).unwrap();
 
         assert_eq!(ifft.dtype(), Dtype::Complex64);
         assert_eq!(
@@ -263,13 +263,13 @@ mod tests {
             complex64::new(0.0, 0.0),
         ];
 
-        let mut array = Array::from_slice(FFT2_DATA, FFT2_SHAPE);
-        let mut fft2 = fft2(&array, None, None).unwrap();
+        let array = Array::from_slice(FFT2_DATA, FFT2_SHAPE);
+        let fft2 = fft2(&array, None, None).unwrap();
 
         assert_eq!(fft2.dtype(), Dtype::Complex64);
         assert_eq!(fft2.as_slice::<complex64>(), FFT2_EXPECTED);
 
-        let mut ifft2 = ifft2(&fft2, None, None).unwrap();
+        let ifft2 = ifft2(&fft2, None, None).unwrap();
 
         assert_eq!(ifft2.dtype(), Dtype::Complex64);
         assert_eq!(
@@ -300,13 +300,13 @@ mod tests {
             complex64::new(0.0, 0.0),
         ];
 
-        let mut array = Array::from_slice(FFTN_DATA, FFTN_SHAPE);
-        let mut fftn = fftn(&array, None, None).unwrap();
+        let array = Array::from_slice(FFTN_DATA, FFTN_SHAPE);
+        let fftn = fftn(&array, None, None).unwrap();
 
         assert_eq!(fftn.dtype(), Dtype::Complex64);
         assert_eq!(fftn.as_slice::<complex64>(), FFTN_EXPECTED);
 
-        let mut ifftn = ifftn(&fftn, None, None).unwrap();
+        let ifftn = ifftn(&fftn, None, None).unwrap();
 
         assert_eq!(ifftn.dtype(), Dtype::Complex64);
         assert_eq!(

--- a/mlx-rs/src/fft/rfftn.rs
+++ b/mlx-rs/src/fft/rfftn.rs
@@ -269,11 +269,11 @@ mod tests {
         ];
 
         let a = Array::from_slice(RFFT_DATA, RFFT_SHAPE);
-        let mut rfft = super::rfft(&a, RFFT_N, RFFT_AXIS).unwrap();
+        let rfft = super::rfft(&a, RFFT_N, RFFT_AXIS).unwrap();
         assert_eq!(rfft.dtype(), Dtype::Complex64);
         assert_eq!(rfft.as_slice::<complex64>(), RFFT_EXPECTED);
 
-        let mut irfft = super::irfft(&rfft, RFFT_N, RFFT_AXIS).unwrap();
+        let irfft = super::irfft(&rfft, RFFT_N, RFFT_AXIS).unwrap();
         assert_eq!(irfft.dtype(), Dtype::Float32);
         assert_eq!(irfft.as_slice::<f32>(), RFFT_DATA);
     }
@@ -310,11 +310,11 @@ mod tests {
         ];
 
         let a = Array::from_slice(RFFT2_DATA, RFFT2_SHAPE);
-        let mut rfft2 = super::rfft2(&a, None, None).unwrap();
+        let rfft2 = super::rfft2(&a, None, None).unwrap();
         assert_eq!(rfft2.dtype(), Dtype::Complex64);
         assert_eq!(rfft2.as_slice::<complex64>(), RFFT2_EXPECTED);
 
-        let mut irfft2 = super::irfft2(&rfft2, None, None).unwrap();
+        let irfft2 = super::irfft2(&rfft2, None, None).unwrap();
         assert_eq!(irfft2.dtype(), Dtype::Float32);
         assert_eq!(irfft2.as_slice::<f32>(), RFFT2_DATA);
     }
@@ -355,11 +355,11 @@ mod tests {
         ];
 
         let a = Array::from_slice(RFFTN_DATA, RFFTN_SHAPE);
-        let mut rfftn = super::rfftn(&a, None, None).unwrap();
+        let rfftn = super::rfftn(&a, None, None).unwrap();
         assert_eq!(rfftn.dtype(), Dtype::Complex64);
         assert_eq!(rfftn.as_slice::<complex64>(), RFFTN_EXPECTED);
 
-        let mut irfftn = super::irfftn(&rfftn, None, None).unwrap();
+        let irfftn = super::irfftn(&rfftn, None, None).unwrap();
         assert_eq!(irfftn.dtype(), Dtype::Float32);
         assert_eq!(irfftn.as_slice::<f32>(), RFFTN_DATA);
     }

--- a/mlx-rs/src/lib.rs
+++ b/mlx-rs/src/lib.rs
@@ -28,7 +28,7 @@ pub mod prelude {
         dtype::Dtype,
         ops::indexing::{Ellipsis, IndexMutOp, IndexOp, IntoStrideBy, NewAxis},
         stream::StreamOrDevice,
-        utils::{OwnedOrRef, ScalarOrArray},
+        utils::ScalarOrArray,
     };
 
     pub use num_traits::Pow;

--- a/mlx-rs/src/macros/array.rs
+++ b/mlx-rs/src/macros/array.rs
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_scalar_array() {
-        let mut arr = array!(1);
+        let arr = array!(1);
 
         // Scalar array has 0 dimension
         assert!(arr.ndim() == 0);

--- a/mlx-rs/src/macros/internal.rs
+++ b/mlx-rs/src/macros/internal.rs
@@ -19,7 +19,7 @@ macro_rules! try_catch_c_ptr_expr {
 macro_rules! assert_array_all_close {
     ($a:tt, $b:tt) => {
         let _b: Array = $b.into();
-        let mut assert = $a.all_close(&_b, None, None, None).unwrap();
+        let assert = $a.all_close(&_b, None, None, None).unwrap();
         assert!(assert.item::<bool>());
     };
 }

--- a/mlx-rs/src/ops/arithmetic.rs
+++ b/mlx-rs/src/ops/arithmetic.rs
@@ -1841,7 +1841,7 @@ mod tests {
         let data = Array::from_slice(&[0.0, 1.0, 2.0, 3.0], &[2, 2]);
         let x = split_equal(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0f32.exp(), 2.0f32.exp()], &[2, 1]);
-        assert!(all_close(&exp(&x[0]), &expected, None, None, None)
+        assert!(all_close(exp(&x[0]), &expected, None, None, None)
             .unwrap()
             .item::<bool>());
     }
@@ -1906,7 +1906,7 @@ mod tests {
         let data = Array::from_slice(&[0.0, 1.0, 2.0, 3.0], &[2, 2]);
         let x = split_equal(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0f32.sin(), 2.0f32.sin()], &[2, 1]);
-        assert!(all_close(&sin(&x[0]), &expected, None, None, None)
+        assert!(all_close(sin(&x[0]), &expected, None, None, None)
             .unwrap()
             .item::<bool>());
     }
@@ -1949,7 +1949,7 @@ mod tests {
         let data = Array::from_slice(&[0.0, 1.0, 2.0, 3.0], &[2, 2]);
         let x = split_equal(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0f32.cos(), 2.0f32.cos()], &[2, 1]);
-        assert!(all_close(&cos(&x[0]), &expected, None, None, None)
+        assert!(all_close(cos(&x[0]), &expected, None, None, None)
             .unwrap()
             .item::<bool>());
     }
@@ -1980,7 +1980,7 @@ mod tests {
         let angles = Array::from_slice(&[0.0, PI / 2.0, PI, 1.5 * PI], &[2, 2]);
         let x = split_equal(&angles, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0, 180.0], &[2, 1]);
-        assert!(all_close(&degrees(&x[0]), &expected, None, None, None)
+        assert!(all_close(degrees(&x[0]), &expected, None, None, None)
             .unwrap()
             .item::<bool>());
     }
@@ -2011,7 +2011,7 @@ mod tests {
         let angles = Array::from_slice(&[0.0, 90.0, 180.0, 270.0], &[2, 2]);
         let x = split_equal(&angles, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0, PI], &[2, 1]);
-        assert!(all_close(&radians(&x[0]), &expected, None, None, None)
+        assert!(all_close(radians(&x[0]), &expected, None, None, None)
             .unwrap()
             .item::<bool>());
     }
@@ -2040,7 +2040,7 @@ mod tests {
         let data = Array::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
         let x = split_equal(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[1.0f32.ln(), 3.0f32.ln()], &[2, 1]);
-        assert!(all_close(&log(&x[0]), &expected, None, None, None)
+        assert!(all_close(log(&x[0]), &expected, None, None, None)
             .unwrap()
             .item::<bool>());
     }
@@ -2105,7 +2105,7 @@ mod tests {
         let data = Array::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
         let x = split_equal(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[1.0f32.ln_1p(), 3.0f32.ln_1p()], &[2, 1]);
-        assert!(all_close(&log1p(&x[0]), &expected, None, None, None)
+        assert!(all_close(log1p(&x[0]), &expected, None, None, None)
             .unwrap()
             .item::<bool>());
     }
@@ -2146,8 +2146,8 @@ mod tests {
 
         let x = Array::full::<f32>(&[3, 3], 2.0).unwrap();
         assert!(all_close(
-            &square(&x),
-            &Array::full::<f32>(&[3, 3], 4.0).unwrap(),
+            square(&x),
+            Array::full::<f32>(&[3, 3], 4.0).unwrap(),
             None,
             None,
             None
@@ -2164,8 +2164,8 @@ mod tests {
 
         let x = Array::full::<f32>(&[3, 3], 9.0).unwrap();
         assert!(all_close(
-            &sqrt(&x),
-            &Array::full::<f32>(&[3, 3], 3.0).unwrap(),
+            sqrt(&x),
+            Array::full::<f32>(&[3, 3], 3.0).unwrap(),
             None,
             None,
             None
@@ -2190,8 +2190,8 @@ mod tests {
 
         let x = Array::full::<f32>(&[3, 3], 2.0).unwrap();
         assert!(all_close(
-            &reciprocal(&x),
-            &Array::full::<f32>(&[3, 3], 0.5).unwrap(),
+            reciprocal(&x),
+            Array::full::<f32>(&[3, 3], 0.5).unwrap(),
             None,
             None,
             None

--- a/mlx-rs/src/ops/arithmetic.rs
+++ b/mlx-rs/src/ops/arithmetic.rs
@@ -1251,8 +1251,8 @@ mod tests {
     #[test]
     fn test_abs() {
         let data = [1i32, 2, -3, -4, -5];
-        let mut array = Array::from_slice(&data, &[5]);
-        let mut result = array.abs();
+        let array = Array::from_slice(&data, &[5]);
+        let result = array.abs();
 
         let data: &[i32] = result.as_slice();
         assert_eq!(data, [1, 2, 3, 4, 5]);
@@ -1264,10 +1264,10 @@ mod tests {
 
     #[test]
     fn test_add() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
-        let mut c = &a + &b;
+        let c = &a + &b;
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[5.0, 7.0, 9.0]);
@@ -1291,10 +1291,10 @@ mod tests {
 
     #[test]
     fn test_sub() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
-        let mut c = &a - &b;
+        let c = &a - &b;
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[-3.0, -3.0, -3.0]);
@@ -1317,8 +1317,8 @@ mod tests {
 
     #[test]
     fn test_neg() {
-        let mut a = Array::from_slice::<f32>(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = a.negative().unwrap();
+        let a = Array::from_slice::<f32>(&[1.0, 2.0, 3.0], &[3]);
+        let b = a.negative().unwrap();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[-1.0, -2.0, -3.0]);
@@ -1338,7 +1338,7 @@ mod tests {
     #[test]
     fn test_logical_not() {
         let a: Array = false.into();
-        let mut b = a.logical_not();
+        let b = a.logical_not();
 
         let b_data: &[bool] = b.as_slice();
         assert_eq!(b_data, [true]);
@@ -1346,10 +1346,10 @@ mod tests {
 
     #[test]
     fn test_mul() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
-        let mut c = &a * &b;
+        let c = &a * &b;
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[4.0, 10.0, 18.0]);
@@ -1372,10 +1372,10 @@ mod tests {
 
     #[test]
     fn test_div() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
-        let mut c = &a / &b;
+        let c = &a / &b;
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[0.25, 0.4, 0.5]);
@@ -1398,10 +1398,10 @@ mod tests {
 
     #[test]
     fn test_pow() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = Array::from_slice(&[2.0, 3.0, 4.0], &[3]);
 
-        let mut c = a.power(&b).unwrap();
+        let c = a.power(&b).unwrap();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[1.0, 8.0, 81.0]);
@@ -1424,10 +1424,10 @@ mod tests {
 
     #[test]
     fn test_rem() {
-        let mut a = Array::from_slice(&[10.0, 11.0, 12.0], &[3]);
-        let mut b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
+        let a = Array::from_slice(&[10.0, 11.0, 12.0], &[3]);
+        let b = Array::from_slice(&[3.0, 4.0, 5.0], &[3]);
 
-        let mut c = &a % &b;
+        let c = &a % &b;
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[1.0, 3.0, 2.0]);
@@ -1450,8 +1450,8 @@ mod tests {
 
     #[test]
     fn test_sqrt() {
-        let mut a = Array::from_slice(&[1.0, 4.0, 9.0], &[3]);
-        let mut b = a.sqrt();
+        let a = Array::from_slice(&[1.0, 4.0, 9.0], &[3]);
+        let b = a.sqrt();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 2.0, 3.0]);
@@ -1463,8 +1463,8 @@ mod tests {
 
     #[test]
     fn test_cos() {
-        let mut a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
-        let mut b = a.cos();
+        let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
+        let b = a.cos();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 0.54030234, -0.41614687]);
@@ -1476,8 +1476,8 @@ mod tests {
 
     #[test]
     fn test_exp() {
-        let mut a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
-        let mut b = a.exp();
+        let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
+        let b = a.exp();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 2.7182817, 7.389056]);
@@ -1489,8 +1489,8 @@ mod tests {
 
     #[test]
     fn test_floor() {
-        let mut a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
-        let mut b = a.floor().unwrap();
+        let a = Array::from_slice(&[0.1, 1.9, 2.5], &[3]);
+        let b = a.floor().unwrap();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 1.0, 2.0]);
@@ -1510,10 +1510,10 @@ mod tests {
 
     #[test]
     fn test_floor_divide() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = Array::from_slice(&[4.0, 5.0, 6.0], &[3]);
 
-        let mut c = a.floor_divide(&b).unwrap();
+        let c = a.floor_divide(&b).unwrap();
 
         let c_data: &[f32] = c.as_slice();
         assert_eq!(c_data, &[0.0, 0.0, 0.0]);
@@ -1545,8 +1545,8 @@ mod tests {
 
     #[test]
     fn test_log() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = a.log();
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = a.log();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 0.6931472, 1.0986123]);
@@ -1558,8 +1558,8 @@ mod tests {
 
     #[test]
     fn test_log2() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 4.0, 8.0], &[4]);
-        let mut b = a.log2();
+        let a = Array::from_slice(&[1.0, 2.0, 4.0, 8.0], &[4]);
+        let b = a.log2();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 1.0, 2.0, 3.0]);
@@ -1571,8 +1571,8 @@ mod tests {
 
     #[test]
     fn test_log10() {
-        let mut a = Array::from_slice(&[1.0, 10.0, 100.0], &[3]);
-        let mut b = a.log10();
+        let a = Array::from_slice(&[1.0, 10.0, 100.0], &[3]);
+        let b = a.log10();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 1.0, 2.0]);
@@ -1584,8 +1584,8 @@ mod tests {
 
     #[test]
     fn test_log1p() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = a.log1p();
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = a.log1p();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.6931472, 1.0986123, 1.3862944]);
@@ -1597,10 +1597,10 @@ mod tests {
 
     #[test]
     fn test_matmul() {
-        let mut a = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
-        let mut b = Array::from_slice(&[-5.0, 37.5, 4., 7., 1., 0.], &[2, 3]);
+        let a = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
+        let b = Array::from_slice(&[-5.0, 37.5, 4., 7., 1., 0.], &[2, 3]);
 
-        let mut c = a.matmul(&b).unwrap();
+        let c = a.matmul(&b).unwrap();
 
         assert_eq!(c.shape(), &[2, 3]);
         let c_data: &[f32] = c.as_slice();
@@ -1649,8 +1649,8 @@ mod tests {
 
     #[test]
     fn test_reciprocal() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
-        let mut b = a.reciprocal();
+        let a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
+        let b = a.reciprocal();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 0.5, 0.25]);
@@ -1662,8 +1662,8 @@ mod tests {
 
     #[test]
     fn test_round() {
-        let mut a = Array::from_slice(&[1.1, 2.9, 3.5], &[3]);
-        let mut b = a.round(None);
+        let a = Array::from_slice(&[1.1, 2.9, 3.5], &[3]);
+        let b = a.round(None);
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 3.0, 4.0]);
@@ -1675,8 +1675,8 @@ mod tests {
 
     #[test]
     fn test_rsqrt() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
-        let mut b = a.rsqrt();
+        let a = Array::from_slice(&[1.0, 2.0, 4.0], &[3]);
+        let b = a.rsqrt();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 0.70710677, 0.5]);
@@ -1688,8 +1688,8 @@ mod tests {
 
     #[test]
     fn test_sin() {
-        let mut a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
-        let mut b = a.sin();
+        let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
+        let b = a.sin();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[0.0, 0.841471, 0.9092974]);
@@ -1701,8 +1701,8 @@ mod tests {
 
     #[test]
     fn test_square() {
-        let mut a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
-        let mut b = a.square();
+        let a = Array::from_slice(&[1.0, 2.0, 3.0], &[3]);
+        let b = a.square();
 
         let b_data: &[f32] = b.as_slice();
         assert_eq!(b_data, &[1.0, 4.0, 9.0]);
@@ -2184,7 +2184,7 @@ mod tests {
         assert_eq!(reciprocal(&x).item::<f32>(), 0.125);
 
         let x = array![2];
-        let mut out = reciprocal(&x);
+        let out = reciprocal(&x);
         assert_eq!(out.dtype(), Dtype::Float32);
         assert_eq!(out.item::<f32>(), 0.5);
 
@@ -2204,13 +2204,13 @@ mod tests {
     fn test_binary_add() {
         let x = array![1.0];
         let y = array![1.0];
-        let mut z = add(&x, &y).unwrap();
+        let z = add(&x, &y).unwrap();
         assert_eq!(z.item::<f32>(), 2.0);
 
-        let mut z = &x + y;
+        let z = &x + y;
         assert_eq!(z.item::<f32>(), 2.0);
 
-        let mut z = add(z, &x).unwrap();
+        let z = add(z, &x).unwrap();
         assert_eq!(z.item::<f32>(), 3.0);
 
         // Chain a few adds:
@@ -2266,7 +2266,7 @@ mod tests {
         // Works for empty arrays
         let x = array!();
         let y = array!();
-        let mut z = x + y;
+        let z = x + y;
         z.eval().unwrap();
         assert_eq!(z.size(), 0);
         assert_eq!(z.shape(), &[0]);
@@ -2451,7 +2451,7 @@ mod tests {
 
         let x = array!([1.0, 2.0, 3.0]);
         let y = array!([0.0, 1.0, 0.0]);
-        let mut z = inner(&x, &y).unwrap();
+        let z = inner(&x, &y).unwrap();
         assert_eq!(z.item::<f32>(), 2.0);
 
         let x = reshape(&arange::<f32, _>(None, 24.0, None).unwrap(), &[2, 3, 4]).unwrap();
@@ -2509,7 +2509,7 @@ mod tests {
         let x = array![1.0];
         let y = array![2.0];
         let (quo, rem) = divmod(&x, &y).unwrap();
-        let mut z = quo + rem;
+        let z = quo + rem;
         assert_eq!(z.item::<f32>(), 1.0);
 
         // Check that we can still eval when one output goes out of scope

--- a/mlx-rs/src/ops/conversion.rs
+++ b/mlx-rs/src/ops/conversion.rs
@@ -47,7 +47,7 @@ mod tests {
                 #[test]
                 fn [<test_as_type_ $src_type _ $dst_type>]() {
                     let array = Array::from_slice(&[$src_val; $len], &[$len as i32]);
-                    let mut new_array = array.as_type::<$dst_type>();
+                    let new_array = array.as_type::<$dst_type>();
 
                     assert_eq!(new_array.dtype(), $dst_type::DTYPE);
                     assert_eq!(new_array.shape(), &[3]);

--- a/mlx-rs/src/ops/convolution.rs
+++ b/mlx-rs/src/ops/convolution.rs
@@ -169,7 +169,7 @@ mod tests {
         let weight_data = [0.5, 0.0, -0.5, 1.0, 0.0, 1.5, 2.0, 0.0, -2.0, 1.5, 0.0, 1.0];
         let weight_array = Array::from_slice(&weight_data, &[2, 3, 2]);
 
-        let mut result = conv1d(
+        let result = conv1d(
             &input_array,
             &weight_array,
             Some(1), // stride
@@ -197,7 +197,7 @@ mod tests {
         let weight_array = Array::from_slice(&weight_data, &weight_shape);
 
         // Perform the convolution with no padding and stride of 1
-        let mut result = conv2d(
+        let result = conv2d(
             &input_array,
             &weight_array,
             Some((1, 1)), // stride

--- a/mlx-rs/src/ops/cumulative.rs
+++ b/mlx-rs/src/ops/cumulative.rs
@@ -281,23 +281,23 @@ mod tests {
     fn test_cummax() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
-        let mut result = array.cummax(0, None, None).unwrap();
+        let result = array.cummax(0, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 5, 9]);
 
-        let mut result = array.cummax(1, None, None).unwrap();
+        let result = array.cummax(1, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 4, 9]);
 
-        let mut result = array.cummax(None, None, None).unwrap();
+        let result = array.cummax(None, None, None).unwrap();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 8, 9]);
 
-        let mut result = array.cummax(0, Some(true), None).unwrap();
+        let result = array.cummax(0, Some(true), None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 9, 4, 9]);
 
-        let mut result = array.cummax(0, None, Some(true)).unwrap();
+        let result = array.cummax(0, None, Some(true)).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 5, 9]);
     }
@@ -313,23 +313,23 @@ mod tests {
     fn test_cummin() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
-        let mut result = array.cummin(0, None, None).unwrap();
+        let result = array.cummin(0, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 4, 8]);
 
-        let mut result = array.cummin(1, None, None).unwrap();
+        let result = array.cummin(1, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 5, 4, 4]);
 
-        let mut result = array.cummin(None, None, None).unwrap();
+        let result = array.cummin(None, None, None).unwrap();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 5, 4, 4]);
 
-        let mut result = array.cummin(0, Some(true), None).unwrap();
+        let result = array.cummin(0, Some(true), None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[4, 8, 4, 9]);
 
-        let mut result = array.cummin(0, None, Some(true)).unwrap();
+        let result = array.cummin(0, None, Some(true)).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 4, 8]);
     }
@@ -345,23 +345,23 @@ mod tests {
     fn test_cumprod() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
-        let mut result = array.cumprod(0, None, None).unwrap();
+        let result = array.cumprod(0, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 20, 72]);
 
-        let mut result = array.cumprod(1, None, None).unwrap();
+        let result = array.cumprod(1, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 40, 4, 36]);
 
-        let mut result = array.cumprod(None, None, None).unwrap();
+        let result = array.cumprod(None, None, None).unwrap();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 40, 160, 1440]);
 
-        let mut result = array.cumprod(0, Some(true), None).unwrap();
+        let result = array.cumprod(0, Some(true), None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[20, 72, 4, 9]);
 
-        let mut result = array.cumprod(0, None, Some(true)).unwrap();
+        let result = array.cumprod(0, None, Some(true)).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 20, 72]);
     }
@@ -377,23 +377,23 @@ mod tests {
     fn test_cumsum() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
 
-        let mut result = array.cumsum(0, None, None).unwrap();
+        let result = array.cumsum(0, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 9, 17]);
 
-        let mut result = array.cumsum(1, None, None).unwrap();
+        let result = array.cumsum(1, None, None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 13, 4, 13]);
 
-        let mut result = array.cumsum(None, None, None).unwrap();
+        let result = array.cumsum(None, None, None).unwrap();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.as_slice::<i32>(), &[5, 13, 17, 26]);
 
-        let mut result = array.cumsum(0, Some(true), None).unwrap();
+        let result = array.cumsum(0, Some(true), None).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[9, 17, 4, 9]);
 
-        let mut result = array.cumsum(0, None, Some(true)).unwrap();
+        let result = array.cumsum(0, None, Some(true)).unwrap();
         assert_eq!(result.shape(), &[2, 2]);
         assert_eq!(result.as_slice::<i32>(), &[5, 8, 9, 17]);
     }

--- a/mlx-rs/src/ops/factory.rs
+++ b/mlx-rs/src/ops/factory.rs
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_zeros() {
-        let mut array = Array::zeros::<f32>(&[2, 3]).unwrap();
+        let array = Array::zeros::<f32>(&[2, 3]).unwrap();
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_ones() {
-        let mut array = Array::ones::<f16>(&[2, 3]).unwrap();
+        let array = Array::ones::<f16>(&[2, 3]).unwrap();
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float16);
 
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn test_eye() {
-        let mut array = Array::eye::<f32>(3, None, None).unwrap();
+        let array = Array::eye::<f32>(3, None, None).unwrap();
         assert_eq!(array.shape(), &[3, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -518,7 +518,7 @@ mod tests {
 
     #[test]
     fn test_full_scalar() {
-        let mut array = Array::full::<f32>(&[2, 3], 7f32).unwrap();
+        let array = Array::full::<f32>(&[2, 3], 7f32).unwrap();
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn test_full_array() {
         let source = Array::zeros_device::<f32>(&[1, 3], StreamOrDevice::cpu()).unwrap();
-        let mut array = Array::full::<f32>(&[2, 3], source).unwrap();
+        let array = Array::full::<f32>(&[2, 3], source).unwrap();
         assert_eq!(array.shape(), &[2, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn test_identity() {
-        let mut array = Array::identity::<f32>(3).unwrap();
+        let array = Array::identity::<f32>(3).unwrap();
         assert_eq!(array.shape(), &[3, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -560,7 +560,7 @@ mod tests {
 
     #[test]
     fn test_arange() {
-        let mut array = Array::arange::<f32, _>(None, 50, None).unwrap();
+        let array = Array::arange::<f32, _>(None, 50, None).unwrap();
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -568,7 +568,7 @@ mod tests {
         let expected: Vec<f32> = (0..50).map(|x| x as f32).collect();
         assert_eq!(data, expected.as_slice());
 
-        let mut array = Array::arange::<i32, _>(0, 50, None).unwrap();
+        let array = Array::arange::<i32, _>(0, 50, None).unwrap();
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Int32);
 
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_linspace_int() {
-        let mut array = Array::linspace::<f32, _>(0, 50, None).unwrap();
+        let array = Array::linspace::<f32, _>(0, 50, None).unwrap();
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_linspace_float() {
-        let mut array = Array::linspace::<f32, _>(0., 50., None).unwrap();
+        let array = Array::linspace::<f32, _>(0., 50., None).unwrap();
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
@@ -632,7 +632,7 @@ mod tests {
     #[test]
     fn test_repeat() {
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let mut array = Array::repeat::<i32>(source, 4, 1).unwrap();
+        let array = Array::repeat::<i32>(source, 4, 1).unwrap();
         assert_eq!(array.shape(), &[2, 8]);
         assert_eq!(array.dtype(), Dtype::Int32);
 
@@ -654,7 +654,7 @@ mod tests {
     #[test]
     fn test_repeat_all() {
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let mut array = Array::repeat_all::<i32>(source, 4).unwrap();
+        let array = Array::repeat_all::<i32>(source, 4).unwrap();
         assert_eq!(array.shape(), &[16]);
         assert_eq!(array.dtype(), Dtype::Int32);
 
@@ -675,7 +675,7 @@ mod tests {
 
     #[test]
     fn test_tri() {
-        let mut array = Array::tri::<f32>(3, None, None);
+        let array = Array::tri::<f32>(3, None, None);
         assert_eq!(array.shape(), &[3, 3]);
         assert_eq!(array.dtype(), Dtype::Float32);
 

--- a/mlx-rs/src/ops/indexing/index_impl.rs
+++ b/mlx-rs/src/ops/indexing/index_impl.rs
@@ -1,4 +1,4 @@
-use std::{ops::Bound, rc::Rc};
+use std::ops::Bound;
 
 use smallvec::{smallvec, SmallVec};
 
@@ -10,16 +10,13 @@ use crate::{
     Array, Stream,
 };
 
-use super::{ArrayIndexOp, Ellipsis, IndexBounds, IndexOp, NewAxis, RangeIndex, StrideBy};
+use super::{
+    ArrayIndex, ArrayIndexOp, Ellipsis, IndexBounds, IndexOp, NewAxis, RangeIndex, StrideBy,
+};
 
 /* -------------------------------------------------------------------------- */
 /*                               Implementation                               */
 /* -------------------------------------------------------------------------- */
-
-pub trait ArrayIndex {
-    /// `mlx` allows out of bounds indexing.
-    fn index_op(self) -> ArrayIndexOp;
-}
 
 impl ArrayIndex for i32 {
     fn index_op(self) -> ArrayIndexOp {
@@ -40,14 +37,6 @@ impl ArrayIndex for Ellipsis {
 }
 
 impl ArrayIndex for Array {
-    fn index_op(self) -> ArrayIndexOp {
-        ArrayIndexOp::TakeArray {
-            indices: Rc::new(self),
-        }
-    }
-}
-
-impl ArrayIndex for Rc<Array> {
     fn index_op(self) -> ArrayIndexOp {
         ArrayIndexOp::TakeArray { indices: self }
     }
@@ -622,7 +611,7 @@ fn gather_nd<'a>(
     let mut max_dims = 0;
     let mut slice_count = 0;
     let mut is_slice: Vec<bool> = Vec::with_capacity(last_array_or_index);
-    let mut gather_indices: Vec<Rc<Array>> = Vec::with_capacity(last_array_or_index);
+    let mut gather_indices: Vec<Array> = Vec::with_capacity(last_array_or_index);
 
     let shape = src.shape();
 
@@ -640,7 +629,7 @@ fn gather_nd<'a>(
                     *index,
                     src.dim(i as i32) as usize,
                 ) as i32);
-                gather_indices.push(Rc::new(item));
+                gather_indices.push(item);
                 is_slice.push(false);
             }
             Slice(range) => {
@@ -654,12 +643,12 @@ fn gather_nd<'a>(
 
                 let item = Array::from_slice(&indices, &[indices.len() as i32]);
 
-                gather_indices.push(Rc::new(item));
+                gather_indices.push(item);
             }
             TakeArray { indices } => {
                 is_slice.push(false);
                 max_dims = max_dims.max(indices.ndim());
-                gather_indices.push(Rc::clone(indices));
+                gather_indices.push(indices.clone());
             }
             Ellipsis | ExpandDims => {
                 unreachable!("Unexpected operation in gather_nd")
@@ -675,12 +664,12 @@ fn gather_nd<'a>(
                 if is_slice[i] {
                     let mut new_shape = vec![1; max_dims + slice_count];
                     new_shape[max_dims + slice_index] = item.dim(0);
-                    *item = Rc::new(item.reshape(&new_shape)?);
+                    *item = item.reshape(&new_shape)?;
                     slice_index += 1;
                 } else {
                     let mut new_shape = item.shape().to_vec();
                     new_shape.extend((0..slice_count).map(|_| 1));
-                    *item = Rc::new(item.reshape(&new_shape)?);
+                    *item = item.reshape(&new_shape)?;
                 }
             }
         }
@@ -689,7 +678,7 @@ fn gather_nd<'a>(
         for (i, item) in gather_indices[..slice_count].iter_mut().enumerate() {
             let mut new_shape = vec![1; max_dims + slice_count];
             new_shape[i] = item.dim(0);
-            *item = Rc::new(item.reshape(&new_shape)?);
+            *item = item.reshape(&new_shape)?;
         }
     }
 
@@ -960,8 +949,6 @@ fn get_item_nd(
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
     use crate::{
         assert_array_eq,
         ops::indexing::{index_impl::IndexOp, Ellipsis, IntoStrideBy, NewAxis},
@@ -972,12 +959,12 @@ mod tests {
     fn test_array_index_negative_int() {
         let a = Array::from_iter(0i32..8, &[8]);
 
-        let mut s = a.index(-1);
+        let s = a.index(-1);
 
         assert_eq!(s.ndim(), 0);
         assert_eq!(s.item::<i32>(), 7);
 
-        let mut s = a.index(-8);
+        let s = a.index(-8);
 
         assert_eq!(s.ndim(), 0);
         assert_eq!(s.item::<i32>(), 0);
@@ -1052,7 +1039,7 @@ mod tests {
         let expected = Array::from_iter(80..88, &[8]);
         assert_array_eq!(s1, expected, 0.01);
 
-        let mut s2 = a.index((1, 2, 3));
+        let s2 = a.index((1, 2, 3));
 
         assert_eq!(s2.ndim(), 0);
         assert!(s2.shape().is_empty());
@@ -1084,7 +1071,7 @@ mod tests {
     fn test_array_subscript_from_end() {
         let a = Array::from_iter(0i32..12, &[3, 4]);
 
-        let mut s = a.index((-1, -2));
+        let s = a.index((-1, -2));
 
         assert_eq!(s.ndim(), 0);
         assert_eq!(s.item::<i32>(), 10);
@@ -1204,7 +1191,7 @@ mod tests {
     fn check(result: Array, shape: &[i32], expected_sum: i32) {
         assert_eq!(result.shape(), shape);
 
-        let mut sum = result.sum(None, None).unwrap();
+        let sum = result.sum(None, None).unwrap();
 
         assert_eq!(sum.item::<i32>(), expected_sum);
     }
@@ -1276,7 +1263,7 @@ mod tests {
         let a = Array::from_iter(0..540, &[3, 3, 4, 5, 3]);
 
         // i = mx.array([2, 1])
-        let i = Rc::new(Array::from_slice(&[2, 1], &[2]));
+        let i = Array::from_slice(&[2, 1], &[2]);
 
         // a[0, i]
         check(a.index((0, i.clone())), &[2, 4, 5, 3], 14340);

--- a/mlx-rs/src/ops/indexing/indexmut_impl.rs
+++ b/mlx-rs/src/ops/indexing/indexmut_impl.rs
@@ -1079,8 +1079,6 @@ where
 /// The unit tests below are adapted from the Swift binding tests
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
     use crate::{
         ops::indexing::{ArrayIndex, IndexOp},
         prelude::*,
@@ -1240,7 +1238,7 @@ mod tests {
         }
 
         // i = mx.array([2, 1])
-        let i = Rc::new(Array::from_slice(&[2, 1], &[2]));
+        let i = Array::from_slice(&[2, 1], &[2]);
 
         // a[0, i] = 1
         check!((0, i.clone()), 131310);

--- a/mlx-rs/src/ops/indexing/indexmut_impl.rs
+++ b/mlx-rs/src/ops/indexing/indexmut_impl.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use smallvec::{smallvec, SmallVec};
 
 use crate::{
@@ -7,7 +9,7 @@ use crate::{
         broadcast_arrays_device, broadcast_to_device,
         indexing::{count_non_new_axis_operations, expand_ellipsis_operations},
     },
-    utils::{resolve_index_signed_unchecked, OwnedOrRef, VectorArray},
+    utils::{resolve_index_signed_unchecked, VectorArray},
     Array, Stream,
 };
 
@@ -48,8 +50,6 @@ fn update_slice(
     update: &Array,
     stream: impl AsRef<Stream>,
 ) -> Result<Option<Array>, Exception> {
-    use OwnedOrRef::*;
-
     let ndim = src.ndim();
     if ndim == 0 || operations.is_empty() {
         return Ok(None);
@@ -127,7 +127,7 @@ fn update_slice(
     }
 
     if !update_expand_dims.is_empty() {
-        update = Owned(update.expand_dims_device(&update_expand_dims, &stream)?);
+        update = Cow::Owned(update.expand_dims_device(&update_expand_dims, &stream)?);
     }
 
     Ok(Some(src.slice_update_device(
@@ -139,39 +139,38 @@ fn update_slice(
 fn remove_leading_singleton_dimensions(
     a: &Array,
     stream: impl AsRef<Stream>,
-) -> Result<OwnedOrRef<'_, Array>, Exception> {
+) -> Result<Cow<'_, Array>, Exception> {
     let shape = a.shape();
     let mut new_shape: Vec<_> = shape.iter().skip_while(|&&dim| dim == 1).cloned().collect();
     if shape != new_shape {
         if new_shape.is_empty() {
             new_shape = vec![1];
         }
-        Ok(OwnedOrRef::Owned(a.reshape_device(&new_shape, stream)?))
+        Ok(Cow::Owned(a.reshape_device(&new_shape, stream)?))
     } else {
-        Ok(OwnedOrRef::Ref(a))
+        Ok(Cow::Borrowed(a))
     }
 }
 
-struct ScatterArgs<'a> {
-    indices: SmallVec<[OwnedOrRef<'a, Array>; DEFAULT_STACK_VEC_LEN]>,
+struct ScatterArgs {
+    indices: SmallVec<[Array; DEFAULT_STACK_VEC_LEN]>,
     update: Array,
     axes: SmallVec<[i32; DEFAULT_STACK_VEC_LEN]>,
 }
 
 /// See `scatterArguments` in the swift binding
-fn scatter_args<'a>(
+fn scatter_args(
     src: &Array,
-    operations: &'a [ArrayIndexOp],
+    operations: &[ArrayIndexOp],
     update: &Array,
     stream: impl AsRef<Stream>,
-) -> Result<ScatterArgs<'a>, Exception> {
+) -> Result<ScatterArgs, Exception> {
     use ArrayIndexOp::*;
-    use OwnedOrRef::*;
 
     if operations.len() == 1 {
         return match &operations[0] {
             TakeIndex { index } => scatter_args_index(src, *index, update, stream),
-            TakeArray { indices } => scatter_args_array(src, Ref(indices), update, stream),
+            TakeArray { indices } => scatter_args_array(src, indices, update, stream),
             Slice(range_index) => scatter_args_slice(src, range_index, update, stream),
             ExpandDims => Ok(ScatterArgs {
                 indices: smallvec![],
@@ -185,12 +184,12 @@ fn scatter_args<'a>(
     scatter_args_nd(src, operations, update, stream)
 }
 
-fn scatter_args_index<'a>(
+fn scatter_args_index(
     src: &Array,
     index: i32,
     update: &Array,
     stream: impl AsRef<Stream>,
-) -> Result<ScatterArgs<'a>, Exception> {
+) -> Result<ScatterArgs, Exception> {
     // mlx_scatter_args_index
 
     // Remove any leading singleton dimensions from the update
@@ -201,20 +200,21 @@ fn scatter_args_index<'a>(
     shape[0] = 1;
 
     Ok(ScatterArgs {
-        indices: smallvec![OwnedOrRef::Owned(Array::from_int(
-            resolve_index_signed_unchecked(index, src.dim(0))
+        indices: smallvec![Array::from_int(resolve_index_signed_unchecked(
+            index,
+            src.dim(0)
         ))],
         update: broadcast_to_device(&update, &shape, &stream)?,
         axes: smallvec![0],
     })
 }
 
-fn scatter_args_array<'a>(
+fn scatter_args_array(
     src: &Array,
-    a: OwnedOrRef<'a, Array>,
+    a: &Array,
     update: &Array,
     stream: impl AsRef<Stream>,
-) -> Result<ScatterArgs<'a>, Exception> {
+) -> Result<ScatterArgs, Exception> {
     // mlx_scatter_args_array
 
     // trim leading singleton dimensions
@@ -233,20 +233,18 @@ fn scatter_args_array<'a>(
     let update = update.reshape_device(&update_shape, &stream)?;
 
     Ok(ScatterArgs {
-        indices: smallvec![a],
+        indices: smallvec![a.clone()],
         update,
         axes: smallvec![0],
     })
 }
 
-fn scatter_args_slice<'a>(
+fn scatter_args_slice(
     src: &Array,
-    range_index: &'a RangeIndex,
+    range_index: &RangeIndex,
     update: &Array,
     stream: impl AsRef<Stream>,
-) -> Result<ScatterArgs<'a>, Exception> {
-    use OwnedOrRef::*;
-
+) -> Result<ScatterArgs, Exception> {
     // mlx_scatter_args_slice
 
     // if none slice is requested braodcast the update to the src size and return it
@@ -277,7 +275,7 @@ fn scatter_args_slice<'a>(
 
         let indices = Array::from_slice(&[start], &[1]);
         Ok(ScatterArgs {
-            indices: smallvec![Owned(indices)],
+            indices: smallvec![indices],
             update,
             axes: smallvec![0],
         })
@@ -286,16 +284,16 @@ fn scatter_args_slice<'a>(
         let a_vals = strided_range_to_vec(start, end, stride);
         let a = Array::from_slice(&a_vals, &[a_vals.len() as i32]);
 
-        scatter_args_array(src, Owned(a), update, stream)
+        scatter_args_array(src, &a, update, stream)
     }
 }
 
-fn scatter_args_nd<'a>(
+fn scatter_args_nd(
     src: &Array,
-    operations: &'a [ArrayIndexOp],
+    operations: &[ArrayIndexOp],
     update: &Array,
     stream: impl AsRef<Stream>,
-) -> Result<ScatterArgs<'a>, Exception> {
+) -> Result<ScatterArgs, Exception> {
     use ArrayIndexOp::*;
 
     // mlx_scatter_args_nd
@@ -481,7 +479,7 @@ fn scatter_args_nd<'a>(
     let array_indices_len = array_indices.len();
 
     Ok(ScatterArgs {
-        indices: array_indices.into_iter().map(OwnedOrRef::Owned).collect(),
+        indices: array_indices.into(),
         update,
         axes: (0..array_indices_len as i32).collect(),
     })

--- a/mlx-rs/src/ops/logical.rs
+++ b/mlx-rs/src/ops/logical.rs
@@ -735,9 +735,9 @@ mod tests {
 
     #[test]
     fn test_eq() {
-        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut c = a.eq(&b).unwrap();
+        let a = Array::from_slice(&[1, 2, 3], &[3]);
+        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let c = a.eq(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
@@ -760,9 +760,9 @@ mod tests {
 
     #[test]
     fn test_le() {
-        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut c = a.le(&b).unwrap();
+        let a = Array::from_slice(&[1, 2, 3], &[3]);
+        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let c = a.le(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
@@ -785,9 +785,9 @@ mod tests {
 
     #[test]
     fn test_ge() {
-        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut c = a.ge(&b).unwrap();
+        let a = Array::from_slice(&[1, 2, 3], &[3]);
+        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let c = a.ge(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
@@ -810,9 +810,9 @@ mod tests {
 
     #[test]
     fn test_ne() {
-        let mut a = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut c = a.ne(&b).unwrap();
+        let a = Array::from_slice(&[1, 2, 3], &[3]);
+        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let c = a.ne(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, false, false]);
@@ -835,9 +835,9 @@ mod tests {
 
     #[test]
     fn test_lt() {
-        let mut a = Array::from_slice(&[1, 0, 3], &[3]);
-        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut c = a.lt(&b).unwrap();
+        let a = Array::from_slice(&[1, 0, 3], &[3]);
+        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let c = a.lt(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, true, false]);
@@ -860,9 +860,9 @@ mod tests {
 
     #[test]
     fn test_gt() {
-        let mut a = Array::from_slice(&[1, 4, 3], &[3]);
-        let mut b = Array::from_slice(&[1, 2, 3], &[3]);
-        let mut c = a.gt(&b).unwrap();
+        let a = Array::from_slice(&[1, 4, 3], &[3]);
+        let b = Array::from_slice(&[1, 2, 3], &[3]);
+        let c = a.gt(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, true, false]);
@@ -885,9 +885,9 @@ mod tests {
 
     #[test]
     fn test_logical_and() {
-        let mut a = Array::from_slice(&[true, false, true], &[3]);
-        let mut b = Array::from_slice(&[true, true, false], &[3]);
-        let mut c = a.logical_and(&b).unwrap();
+        let a = Array::from_slice(&[true, false, true], &[3]);
+        let b = Array::from_slice(&[true, true, false], &[3]);
+        let c = a.logical_and(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, false, false]);
@@ -910,9 +910,9 @@ mod tests {
 
     #[test]
     fn test_logical_or() {
-        let mut a = Array::from_slice(&[true, false, true], &[3]);
-        let mut b = Array::from_slice(&[true, true, false], &[3]);
-        let mut c = a.logical_or(&b).unwrap();
+        let a = Array::from_slice(&[true, false, true], &[3]);
+        let b = Array::from_slice(&[true, true, false], &[3]);
+        let c = a.logical_or(&b).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
@@ -939,7 +939,7 @@ mod tests {
         let b = Array::from_slice(&[0., 1., 2., 3.], &[4])
             .power(0.5)
             .unwrap();
-        let mut c = a.all_close(&b, 1e-5, None, None).unwrap();
+        let c = a.all_close(&b, 1e-5, None, None).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true]);
@@ -957,7 +957,7 @@ mod tests {
     fn test_is_close_false() {
         let a = Array::from_slice(&[1., 2., 3.], &[3]);
         let b = Array::from_slice(&[1.1, 2.2, 3.3], &[3]);
-        let mut c = a.is_close(&b, None, None, false).unwrap();
+        let c = a.is_close(&b, None, None, false).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [false, false, false]);
@@ -967,7 +967,7 @@ mod tests {
     fn test_is_close_true() {
         let a = Array::from_slice(&[1., 2., 3.], &[3]);
         let b = Array::from_slice(&[1.1, 2.2, 3.3], &[3]);
-        let mut c = a.is_close(&b, 0.1, 0.2, true).unwrap();
+        let c = a.is_close(&b, 0.1, 0.2, true).unwrap();
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true, true, true]);
@@ -985,7 +985,7 @@ mod tests {
     fn test_array_eq() {
         let a = Array::from_slice(&[0, 1, 2, 3], &[4]);
         let b = Array::from_slice(&[0., 1., 2., 3.], &[4]);
-        let mut c = a.array_eq(&b, None);
+        let c = a.array_eq(&b, None);
 
         let c_data: &[bool] = c.as_slice();
         assert_eq!(c_data, [true]);
@@ -994,7 +994,7 @@ mod tests {
     #[test]
     fn test_any() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-        let mut all = array.any(&[0][..], None).unwrap();
+        let all = array.any(&[0][..], None).unwrap();
 
         let results: &[bool] = all.as_slice();
         assert_eq!(results, &[true, true, true, true]);
@@ -1003,7 +1003,7 @@ mod tests {
     #[test]
     fn test_any_empty_axes() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-        let mut all = array.any(&[][..], None).unwrap();
+        let all = array.any(&[][..], None).unwrap();
 
         let results: &[bool] = all.as_slice();
         assert_eq!(
@@ -1031,7 +1031,7 @@ mod tests {
         let condition = Array::from_slice(&[true, false, true], &[3]);
         let a = Array::from_slice(&[1, 2, 3], &[3]);
         let b = Array::from_slice(&[4, 5, 6], &[3]);
-        let mut c = which(&condition, &a, &b).unwrap();
+        let c = which(&condition, &a, &b).unwrap();
 
         let c_data: &[i32] = c.as_slice();
         assert_eq!(c_data, [1, 5, 3]);
@@ -1054,12 +1054,12 @@ mod tests {
         assert!(logical_not(&x).item::<bool>());
 
         let x = array!(1.0);
-        let mut y = logical_not(&x);
+        let y = logical_not(&x);
         assert_eq!(y.dtype(), Dtype::Bool);
         assert!(!y.item::<bool>());
 
         let x = array!(0);
-        let mut y = logical_not(&x);
+        let y = logical_not(&x);
         assert_eq!(y.dtype(), Dtype::Bool);
         assert!(y.item::<bool>());
     }
@@ -1072,13 +1072,13 @@ mod tests {
 
         let x = array!(1.0);
         let y = array!(1.0);
-        let mut z = logical_and(&x, &y).unwrap();
+        let z = logical_and(&x, &y).unwrap();
         assert_eq!(z.dtype(), Dtype::Bool);
         assert!(z.item::<bool>());
 
         let x = array!(0);
         let y = array!(1.0);
-        let mut z = logical_and(&x, &y).unwrap();
+        let z = logical_and(&x, &y).unwrap();
         assert_eq!(z.dtype(), Dtype::Bool);
         assert!(!z.item::<bool>());
     }
@@ -1091,13 +1091,13 @@ mod tests {
 
         let a = array!(1.0);
         let b = array!(1.0);
-        let mut c = logical_or(&a, &b).unwrap();
+        let c = logical_or(&a, &b).unwrap();
         assert_eq!(c.dtype(), Dtype::Bool);
         assert!(c.item::<bool>());
 
         let a = array!(0);
         let b = array!(1.0);
-        let mut c = logical_or(&a, &b).unwrap();
+        let c = logical_or(&a, &b).unwrap();
         assert_eq!(c.dtype(), Dtype::Bool);
         assert!(c.item::<bool>());
     }

--- a/mlx-rs/src/ops/other.rs
+++ b/mlx-rs/src/ops/other.rs
@@ -117,7 +117,7 @@ mod tests {
         let out = diagonal(&x, -1, 0, 1).unwrap();
         assert_eq!(out, array!([4, 9]));
 
-        let mut out = diagonal(&x, -5, 0, 1).unwrap();
+        let out = diagonal(&x, -5, 0, 1).unwrap();
         out.eval().unwrap();
         assert_eq!(out.shape(), &[0]);
 

--- a/mlx-rs/src/ops/reduction.rs
+++ b/mlx-rs/src/ops/reduction.rs
@@ -443,17 +443,17 @@ mod tests {
         assert_eq!(array.all(None, true).unwrap().shape(), &[1, 1]);
         assert_eq!(array.all(&[0, 1][..], None).unwrap().item::<bool>(), false);
 
-        let mut result = array.all(&[0][..], None).unwrap();
+        let result = array.all(&[0][..], None).unwrap();
         assert_eq!(result.as_slice::<bool>(), &[true, false]);
 
-        let mut result = array.all(&[1][..], None).unwrap();
+        let result = array.all(&[1][..], None).unwrap();
         assert_eq!(result.as_slice::<bool>(), &[false, false]);
     }
 
     #[test]
     fn test_all_empty_axes() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-        let mut all = array.all(&[][..], None).unwrap();
+        let all = array.all(&[][..], None).unwrap();
 
         let results: &[bool] = all.as_slice();
         assert_eq!(
@@ -467,21 +467,21 @@ mod tests {
         let x = Array::from_slice(&[1, 2, 3, 3], &[2, 2]);
         assert_eq!(x.prod(None, None).unwrap().item::<i32>(), 18);
 
-        let mut y = x.prod(None, true).unwrap();
+        let y = x.prod(None, true).unwrap();
         assert_eq!(y.item::<i32>(), 18);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let mut result = x.prod(&[0][..], None).unwrap();
+        let result = x.prod(&[0][..], None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[3, 6]);
 
-        let mut result = x.prod(&[1][..], None).unwrap();
+        let result = x.prod(&[1][..], None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[2, 9])
     }
 
     #[test]
     fn test_prod_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.prod(&[][..], None).unwrap();
+        let result = array.prod(&[][..], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -491,21 +491,21 @@ mod tests {
     fn test_max() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.max(None, None).unwrap().item::<i32>(), 4);
-        let mut y = x.max(None, true).unwrap();
+        let y = x.max(None, true).unwrap();
         assert_eq!(y.item::<i32>(), 4);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let mut result = x.max(&[0][..], None).unwrap();
+        let result = x.max(&[0][..], None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[3, 4]);
 
-        let mut result = x.max(&[1][..], None).unwrap();
+        let result = x.max(&[1][..], None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[2, 4]);
     }
 
     #[test]
     fn test_max_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.max(&[][..], None).unwrap();
+        let result = array.max(&[][..], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -514,7 +514,7 @@ mod tests {
     #[test]
     fn test_sum() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.sum(&[0][..], None).unwrap();
+        let result = array.sum(&[0][..], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[9, 17]);
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn test_sum_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.sum(&[][..], None).unwrap();
+        let result = array.sum(&[][..], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -533,21 +533,21 @@ mod tests {
     fn test_mean() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.mean(None, None).unwrap().item::<f32>(), 2.5);
-        let mut y = x.mean(None, true).unwrap();
+        let y = x.mean(None, true).unwrap();
         assert_eq!(y.item::<f32>(), 2.5);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let mut result = x.mean(&[0][..], None).unwrap();
+        let result = x.mean(&[0][..], None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[2.0, 3.0]);
 
-        let mut result = x.mean(&[1][..], None).unwrap();
+        let result = x.mean(&[1][..], None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[1.5, 3.5]);
     }
 
     #[test]
     fn test_mean_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.mean(&[][..], None).unwrap();
+        let result = array.mean(&[][..], None).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.0, 8.0, 4.0, 9.0]);
@@ -564,21 +564,21 @@ mod tests {
     fn test_min() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.min(None, None).unwrap().item::<i32>(), 1);
-        let mut y = x.min(None, true).unwrap();
+        let y = x.min(None, true).unwrap();
         assert_eq!(y.item::<i32>(), 1);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let mut result = x.min(&[0][..], None).unwrap();
+        let result = x.min(&[0][..], None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[1, 2]);
 
-        let mut result = x.min(&[1][..], None).unwrap();
+        let result = x.min(&[1][..], None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[1, 3]);
     }
 
     #[test]
     fn test_min_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.min(&[][..], None).unwrap();
+        let result = array.min(&[][..], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -588,25 +588,25 @@ mod tests {
     fn test_var() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
         assert_eq!(x.variance(None, None, None).unwrap().item::<f32>(), 1.25);
-        let mut y = x.variance(None, true, None).unwrap();
+        let y = x.variance(None, true, None).unwrap();
         assert_eq!(y.item::<f32>(), 1.25);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let mut result = x.variance(&[0][..], None, None).unwrap();
+        let result = x.variance(&[0][..], None, None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[1.0, 1.0]);
 
-        let mut result = x.variance(&[1][..], None, None).unwrap();
+        let result = x.variance(&[1][..], None, None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[0.25, 0.25]);
 
         let x = Array::from_slice(&[1.0, 2.0], &[2]);
-        let mut out = x.variance(None, None, Some(3)).unwrap();
+        let out = x.variance(None, None, Some(3)).unwrap();
         assert_eq!(out.item::<f32>(), f32::INFINITY);
     }
 
     #[test]
     fn test_var_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.variance(&[][..], None, 0).unwrap();
+        let result = array.variance(&[][..], None, 0).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[0.0, 0.0, 0.0, 0.0]);
@@ -615,7 +615,7 @@ mod tests {
     #[test]
     fn test_log_sum_exp() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.log_sum_exp(&[0][..], None).unwrap();
+        let result = array.log_sum_exp(&[0][..], None).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.3132615, 9.313262]);
@@ -624,7 +624,7 @@ mod tests {
     #[test]
     fn test_log_sum_exp_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let mut result = array.log_sum_exp(&[][..], None).unwrap();
+        let result = array.log_sum_exp(&[][..], None).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.0, 8.0, 4.0, 9.0]);

--- a/mlx-rs/src/ops/shapes.rs
+++ b/mlx-rs/src/ops/shapes.rs
@@ -976,7 +976,7 @@ mod tests {
         assert!(reshape(&x, &[-1, 7]).is_err());
 
         let x = Array::from_slice::<i32>(&[], &[0]);
-        let mut y = reshape(&x, &[0, 0, 0]).unwrap();
+        let y = reshape(&x, &[0, 0, 0]).unwrap();
         assert_eq!(y.shape(), &[0, 0, 0]);
         y.eval().unwrap();
         assert_eq!(y.size(), 0);
@@ -1260,18 +1260,18 @@ mod tests {
     #[test]
     fn test_transpose() {
         let x = Array::from_int(1);
-        let mut y = transpose(&x, None).unwrap();
+        let y = transpose(&x, None).unwrap();
         assert!(y.shape().is_empty());
         assert_eq!(y.item::<i32>(), 1);
         assert!(transpose(&x, &[0][..]).is_err());
         assert!(transpose(&x, &[1][..]).is_err());
 
         let x = Array::from_slice(&[1], &[1]);
-        let mut y = transpose(&x, None).unwrap();
+        let y = transpose(&x, None).unwrap();
         assert_eq!(y.shape(), &[1]);
         assert_eq!(y.item::<i32>(), 1);
 
-        let mut y = transpose(&x, &[-1][..]).unwrap();
+        let y = transpose(&x, &[-1][..]).unwrap();
         assert_eq!(y.shape(), &[1]);
         assert_eq!(y.item::<i32>(), 1);
 
@@ -1279,7 +1279,7 @@ mod tests {
         assert!(transpose(&x, &[0, 0][..]).is_err());
 
         let x = Array::from_slice::<i32>(&[], &[0]);
-        let mut y = transpose(&x, None).unwrap();
+        let y = transpose(&x, None).unwrap();
         assert_eq!(y.shape(), &[0]);
         y.eval().unwrap();
         assert_eq!(y.size(), 0);

--- a/mlx-rs/src/random.rs
+++ b/mlx-rs/src/random.rs
@@ -596,7 +596,7 @@ mod tests {
     fn test_bernoulli_single() {
         let key = key(0);
         let value = bernoulli(None, None, &key).unwrap();
-        assert_eq!(value.item::<bool>(), true);
+        assert!(value.item::<bool>());
     }
 
     #[test]

--- a/mlx-rs/src/random.rs
+++ b/mlx-rs/src/random.rs
@@ -515,7 +515,7 @@ mod tests {
     #[test]
     fn test_uniform_single() {
         let key = key(0);
-        let mut value = uniform::<_, f32>(0, 10, None, Some(&key)).unwrap();
+        let value = uniform::<_, f32>(0, 10, None, Some(&key)).unwrap();
         float_eq!(value.item::<f32>(), 4.18, abs <= 0.01);
     }
 
@@ -547,7 +547,7 @@ mod tests {
     #[test]
     fn test_normal() {
         let key = key(0);
-        let mut value = normal::<f32>(None, None, None, &key).unwrap();
+        let value = normal::<f32>(None, None, None, &key).unwrap();
         float_eq!(value.item::<f32>(), -0.20, abs <= 0.01);
     }
 
@@ -571,7 +571,7 @@ mod tests {
     #[test]
     fn test_randint_single() {
         let key = key(0);
-        let mut value = randint::<_, i32>(0, 100, None, Some(&key)).unwrap();
+        let value = randint::<_, i32>(0, 100, None, Some(&key)).unwrap();
         assert_eq!(value.item::<i32>(), 41);
     }
 
@@ -595,7 +595,7 @@ mod tests {
     #[test]
     fn test_bernoulli_single() {
         let key = key(0);
-        let mut value = bernoulli(None, None, &key).unwrap();
+        let value = bernoulli(None, None, &key).unwrap();
         assert_eq!(value.item::<bool>(), true);
     }
 

--- a/mlx-rs/src/random.rs
+++ b/mlx-rs/src/random.rs
@@ -1,8 +1,9 @@
 use crate::prelude::IndexOp;
-use crate::utils::{IntoOption, OwnedOrRef};
+use crate::utils::IntoOption;
 use crate::{error::Exception, Array, ArrayElement, Stream, StreamOrDevice};
 use mach_sys::mach_time;
 use mlx_macros::default_device;
+use std::borrow::Cow;
 use std::sync::{Mutex, OnceLock};
 
 struct RandomState {
@@ -32,13 +33,13 @@ fn state() -> &'static Mutex<RandomState> {
 }
 
 /// Use given key or generate a new one if `None`.
-fn key_or_next<'a>(key: impl Into<Option<&'a Array>>) -> OwnedOrRef<'a, Array> {
+fn key_or_next<'a>(key: impl Into<Option<&'a Array>>) -> Cow<'a, Array> {
     key.into().map_or_else(
         || {
             let mut state = state().lock().unwrap();
-            OwnedOrRef::Owned(state.next())
+            Cow::Owned(state.next())
         },
-        OwnedOrRef::Ref,
+        Cow::Borrowed,
     )
 }
 

--- a/mlx-rs/src/transforms/compile.rs
+++ b/mlx-rs/src/transforms/compile.rs
@@ -17,8 +17,6 @@ use crate::{
     Array,
 };
 
-use super::clone_by_increment_ref_count;
-
 /// Globally enable the compilation of functions.
 ///
 /// Default is enabled.
@@ -185,7 +183,7 @@ where
 {
     fn call_mut(&mut self, args: &Array) -> Result<Array, Exception> {
         // Is there any way to avoid this shallow clone?
-        let args = &[clone_by_increment_ref_count(args)];
+        let args = &[args.clone()];
         let result = self.state.call_mut(args)?;
         Ok(result.into_iter().next().unwrap())
     }
@@ -198,10 +196,7 @@ where
 {
     fn call_mut(&mut self, args: (&Array, &Array)) -> Result<Array, Exception> {
         // Is there any way to avoid this shallow clone?
-        let args = &[
-            clone_by_increment_ref_count(args.0),
-            clone_by_increment_ref_count(args.1),
-        ];
+        let args = &[args.0.clone(), args.1.clone()];
         let result = self.state.call_mut(args)?;
         Ok(result.into_iter().next().unwrap())
     }
@@ -214,11 +209,7 @@ where
 {
     fn call_mut(&mut self, args: (&Array, &Array, &Array)) -> Result<Array, Exception> {
         // Is there any way to avoid this shallow clone?
-        let args = &[
-            clone_by_increment_ref_count(args.0),
-            clone_by_increment_ref_count(args.1),
-            clone_by_increment_ref_count(args.2),
-        ];
+        let args = &[args.0.clone(), args.1.clone(), args.2.clone()];
         let result = self.state.call_mut(args)?;
         Ok(result.into_iter().next().unwrap())
     }
@@ -259,7 +250,7 @@ impl<'a, F> CompiledState<'a, F> {
             let saved_state_inputs: Option<Vec<Array>> = state_inputs_clone
                 .borrow()
                 .as_ref()
-                .map(|inputs| inputs.iter().map(clone_by_increment_ref_count).collect());
+                .map(|inputs| inputs.iter().map(Clone::clone).collect());
 
             // replace the inner state with the tracers
             if let Some(inputs) = state_inputs_clone.borrow_mut().as_mut() {
@@ -275,7 +266,7 @@ impl<'a, F> CompiledState<'a, F> {
             let state_output_tracers: Option<Vec<Array>> = state_outputs_clone
                 .borrow()
                 .as_ref()
-                .map(|outputs| outputs.iter().map(clone_by_increment_ref_count).collect());
+                .map(|outputs| outputs.iter().map(Clone::clone).collect());
 
             // put the original values back in the state
             if let Some(inputs) = state_inputs_clone.borrow_mut().as_mut() {

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -1,4 +1,4 @@
-use mlx_sys::{mlx_closure_value_and_grad, mlx_closure_value_and_grad_apply, mlx_retain};
+use mlx_sys::{mlx_closure_value_and_grad, mlx_closure_value_and_grad_apply};
 use smallvec::SmallVec;
 
 use crate::{
@@ -208,13 +208,6 @@ where
     }
 }
 
-fn clone_by_increment_ref_count(src: &Array) -> Array {
-    unsafe {
-        mlx_retain(src.as_ptr() as *mut _);
-        Array::from_ptr(src.as_ptr())
-    }
-}
-
 /// Returns a function which computes the value and gradient of `f`.
 pub fn value_and_grad<'a, F>(
     f: F,
@@ -260,7 +253,7 @@ where
         let f = move |args: &[Array]| -> Vec<Array> { vec![self(&args[0])] };
         let mut g = build_gradient(f, argument_numbers);
         move |args: &Array| -> Result<Array, Exception> {
-            let args_clone = &[clone_by_increment_ref_count(args)];
+            let args_clone = &[args.clone()];
             let result = g(args_clone)?;
             Ok(result.into_iter().next().unwrap())
         }
@@ -297,7 +290,7 @@ where
         let f = move |args: &[Array]| -> Vec<Array> { self(&args[0]) };
         let mut g = build_gradient(f, argument_numbers);
         move |args: &Array| -> Result<Vec<Array>, Exception> {
-            let args_clone = &[clone_by_increment_ref_count(args)];
+            let args_clone = &[args.clone()];
             let result = g(args_clone)?;
             Ok(result)
         }

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -330,7 +330,7 @@ mod tests {
         let f = |inputs: &[Array]| -> Vec<Array> { vec![&inputs[0] + &inputs[1]] };
         let x = array!(1.0f32);
         let y = array!(1.0f32);
-        let (mut out, mut dout) = jvp(f, &[x, y], &[array!(1.0f32), array!(3.0f32)]).unwrap();
+        let (out, dout) = jvp(f, &[x, y], &[array!(1.0f32), array!(3.0f32)]).unwrap();
         assert_eq!(out[0].item::<f32>(), 2.0f32);
         assert_eq!(dout[0].item::<f32>(), 4.0f32);
     }
@@ -342,7 +342,7 @@ mod tests {
         let y = array!(1.0f32);
         let primals = vec![x, y];
         let cotangents = vec![array!(1.0f32)];
-        let (mut out, mut dout) = vjp(f, &primals, &cotangents).unwrap();
+        let (out, dout) = vjp(f, &primals, &cotangents).unwrap();
         assert_eq!(out[0].item::<f32>(), 2.0f32);
         assert_eq!(dout[0].item::<f32>(), 1.0f32);
     }
@@ -352,14 +352,14 @@ mod tests {
         let x = &[Array::from_float(1.0)];
         let fun = |argin: &[Array]| -> Vec<Array> { vec![&argin[0] + 1.0] };
         let argnums = &[0];
-        let (mut y, mut dfdx) = value_and_grad(fun, argnums)(x).unwrap();
+        let (y, dfdx) = value_and_grad(fun, argnums)(x).unwrap();
 
         assert_eq!(y[0].item::<f32>(), 2.0);
         assert_eq!(dfdx[0].item::<f32>(), 1.0);
 
         // TODO: how to make this more "functional"?
         let grad_fn = move |args: &[Array]| -> Vec<Array> { grad(fun, argnums)(args).unwrap() };
-        let (mut z, mut d2fdx2) = value_and_grad(grad_fn, argnums)(x).unwrap();
+        let (z, d2fdx2) = value_and_grad(grad_fn, argnums)(x).unwrap();
 
         assert_eq!(z[0].item::<f32>(), 1.0);
         assert_eq!(d2fdx2[0].item::<f32>(), 0.0);

--- a/mlx-rs/src/utils.rs
+++ b/mlx-rs/src/utils.rs
@@ -96,31 +96,6 @@ impl Drop for VectorArray {
     }
 }
 
-/// A custom type for internal use with `Array` only that is essentially `Cow` but doens't require
-/// the `Clone`
-#[derive(Debug)]
-pub enum OwnedOrRef<'a, T> {
-    Owned(T),
-    Ref(&'a T),
-}
-
-impl<'a, T> AsRef<T> for OwnedOrRef<'a, T> {
-    fn as_ref(&self) -> &T {
-        match self {
-            OwnedOrRef::Owned(array) => array,
-            OwnedOrRef::Ref(array) => array,
-        }
-    }
-}
-
-impl<'a, T> std::ops::Deref for OwnedOrRef<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.as_ref()
-    }
-}
-
 pub(crate) struct MlxString(mlx_sys::mlx_string);
 
 impl MlxString {


### PR DESCRIPTION
This PR removes all methods that require mutable borrows on `Array`. We might have been too cautious, but it seems like all the computation takes place when `eval` is called, and the `eval` event on the cpp side is protected by mutex and cond var (https://github.com/ml-explore/mlx/blob/969337345ffd34159884c8bf124dbb6eeaa902bb/mlx/backend/no_metal/event.cpp#L21)