### PR TITLE
Allow using named `shape` parameter in `array!()` macro

### DIFF
--- a/mlx-rs/examples/tutorial.rs
+++ b/mlx-rs/examples/tutorial.rs
@@ -83,10 +83,10 @@ fn automatic_differentiation() {
 
     let x = Array::from(1.5);
 
-    let mut dfdx = calculate_grad(f, &x);
+    let dfdx = calculate_grad(f, &x);
     assert_eq!(dfdx.item::<f32>(), 2.0 * 1.5);
 
-    let mut dfdx2 = calculate_grad(|args| calculate_grad(f, args), &x);
+    let dfdx2 = calculate_grad(|args| calculate_grad(f, args), &x);
     assert_eq!(dfdx2.item::<f32>(), 2.0);
 }
 

--- a/mlx-rs/src/macros/array.rs
+++ b/mlx-rs/src/macros/array.rs
@@ -41,9 +41,19 @@
 ///         [10, 11, 12]
 ///     ]
 /// ]);
+///
+/// // Create a 2x2 array by specifying the shape
+/// let a = array!([1, 2, 3, 4], shape=[2, 2]);
 /// ```
 #[macro_export]
 macro_rules! array {
+    ([$($x:expr),*], shape=[$($s:expr),*]) => {
+        {
+            let data = [$($x,)*];
+            let shape = [$($s,)*];
+            $crate::Array::from_slice(&data, &shape)
+        }
+    };
     ([$([$([$($x:expr),*]),*]),*]) => {
         {
             let arr = [$([$([$($x,)*],)*],)*];
@@ -132,5 +142,17 @@ mod tests {
         assert_eq!(a.index((1, 1, 0)).item::<i32>(), 10);
         assert_eq!(a.index((1, 1, 1)).item::<i32>(), 11);
         assert_eq!(a.index((1, 1, 2)).item::<i32>(), 12);
+    }
+
+    #[test]
+    fn test_array_with_shape() {
+        let a = array!([1, 2, 3, 4], shape = [2, 2]);
+
+        assert!(a.ndim() == 2);
+        assert_eq!(a.shape(), &[2, 2]);
+        assert_eq!(a.index((0, 0)).item::<i32>(), 1);
+        assert_eq!(a.index((0, 1)).item::<i32>(), 2);
+        assert_eq!(a.index((1, 0)).item::<i32>(), 3);
+        assert_eq!(a.index((1, 1)).item::<i32>(), 4);
     }
 }

--- a/mlx-rs/src/ops/conversion.rs
+++ b/mlx-rs/src/ops/conversion.rs
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn test_view() {
         let array = Array::from_slice(&[1i16, 2, 3], &[3]);
-        let mut new_array = array.view::<i8>();
+        let new_array = array.view::<i8>();
 
         assert_eq!(new_array.dtype(), Dtype::Int8);
         assert_eq!(new_array.shape(), &[6]);


### PR DESCRIPTION
Closes #107 

This PR allows the following usage

```rust
let a = array!([1, 2, 3, 4], shape=[2, 2]);
```