### PR TITLE
Allow using closure that may return an error (partial)

### DIFF
--- a/mlx-rs/examples/tutorial.rs
+++ b/mlx-rs/examples/tutorial.rs
@@ -83,10 +83,10 @@ fn automatic_differentiation() {
 
     let x = Array::from(1.5);
 
-    let mut dfdx = calculate_grad(f, &x);
+    let dfdx = calculate_grad(f, &x);
     assert_eq!(dfdx.item::<f32>(), 2.0 * 1.5);
 
-    let mut dfdx2 = calculate_grad(|args| calculate_grad(f, args), &x);
+    let dfdx2 = calculate_grad(|args| calculate_grad(f, args), &x);
     assert_eq!(dfdx2.item::<f32>(), 2.0);
 }
 

--- a/mlx-rs/src/error.rs
+++ b/mlx-rs/src/error.rs
@@ -44,7 +44,7 @@ impl Exception {
 
 thread_local! {
     static LAST_MLX_ERROR: Cell<*const c_char> = const { Cell::new(std::ptr::null()) };
-    static LAST_MLX_CLOSURE_ERROR: Cell<Option<Exception>> = Cell::new(None);
+    static LAST_MLX_CLOSURE_ERROR: Cell<Option<Exception>> = const { Cell::new(None) };
     static IS_HANDLER_SET: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -95,6 +95,7 @@ pub(crate) fn get_and_clear_last_mlx_error() -> Option<Exception> {
 }
 
 pub(crate) fn set_last_mlx_closure_error(error: Exception) {
+    // Another alternative is to use mlx_sys::_mlx_error, but it gives memory access errors
     LAST_MLX_CLOSURE_ERROR.with(|last_error| last_error.set(Some(error)));
 }
 

--- a/mlx-rs/src/error.rs
+++ b/mlx-rs/src/error.rs
@@ -43,8 +43,9 @@ impl Exception {
 }
 
 thread_local! {
-    pub static LAST_MLX_ERROR: Cell<*const c_char> = const { Cell::new(std::ptr::null()) };
-    pub static IS_HANDLER_SET: Cell<bool> = const { Cell::new(false) };
+    static LAST_MLX_ERROR: Cell<*const c_char> = const { Cell::new(std::ptr::null()) };
+    static LAST_MLX_CLOSURE_ERROR: Cell<Option<Exception>> = Cell::new(None);
+    static IS_HANDLER_SET: Cell<bool> = const { Cell::new(false) };
 }
 
 #[no_mangle]
@@ -91,6 +92,14 @@ pub(crate) fn get_and_clear_last_mlx_error() -> Option<Exception> {
         }
         Some(Exception { what: last_err })
     })
+}
+
+pub(crate) fn set_last_mlx_closure_error(error: Exception) {
+    LAST_MLX_CLOSURE_ERROR.with(|last_error| last_error.set(Some(error)));
+}
+
+pub(crate) fn take_last_mlx_closure_error() -> Option<Exception> {
+    LAST_MLX_CLOSURE_ERROR.with(|last_error| last_error.replace(None))
 }
 
 #[cfg(test)]

--- a/mlx-rs/src/macros/internal.rs
+++ b/mlx-rs/src/macros/internal.rs
@@ -15,6 +15,26 @@ macro_rules! try_catch_c_ptr_expr {
     }};
 }
 
+macro_rules! try_catch_mlx_closure_error {
+    ($expr:expr) => {{
+        if !$crate::error::is_mlx_error_handler_set() {
+            $crate::error::setup_mlx_error_handler();
+        }
+
+        let c_ptr = $expr;
+        // Always check for closure errors
+        if let Some(error) = $crate::error::get_and_clear_last_mlx_error()
+            .or($crate::error::take_last_mlx_closure_error())
+        {
+            return Err(error);
+        }
+        if c_ptr.is_null() {
+            panic!("A null pointer was returned, but no error was set.");
+        }
+        c_ptr
+    }};
+}
+
 /// See `assertEqual` in the swift binding tests
 #[allow(unused_macros)]
 macro_rules! assert_array_all_close {

--- a/mlx-rs/src/macros/internal.rs
+++ b/mlx-rs/src/macros/internal.rs
@@ -8,30 +8,8 @@ macro_rules! try_catch_c_ptr_expr {
         if c_ptr.is_null() {
             // SAFETY: there must be an error if the pointer is null
             return Err($crate::error::get_and_clear_last_mlx_error()
+                .or($crate::error::take_last_mlx_closure_error())
                 .expect("A null pointer was returned, but no error was set."));
-        }
-        c_ptr
-    }};
-}
-
-/// This is intended to be used on expressions that contains a closure that may
-/// return an error.
-macro_rules! try_catch_mlx_closure_error {
-    ($expr:expr) => {{
-        if !$crate::error::is_mlx_error_handler_set() {
-            $crate::error::setup_mlx_error_handler();
-        }
-
-        let c_ptr = $expr;
-
-        // Always check for error, even if the pointer is not null
-        if let Some(e) = $crate::error::get_and_clear_last_mlx_error()
-            .or_else(|| $crate::error::take_last_mlx_closure_error()) 
-        {
-            return Err(e);
-        }
-        if c_ptr.is_null() {
-            panic!("A null pointer was returned, but no error was set.");
         }
         c_ptr
     }};

--- a/mlx-rs/src/macros/internal.rs
+++ b/mlx-rs/src/macros/internal.rs
@@ -8,6 +8,7 @@ macro_rules! try_catch_c_ptr_expr {
         if c_ptr.is_null() {
             // SAFETY: there must be an error if the pointer is null
             return Err($crate::error::get_and_clear_last_mlx_error()
+                .or($crate::error::take_last_mlx_closure_error())
                 .expect("A null pointer was returned, but no error was set."));
         }
         c_ptr

--- a/mlx-rs/src/macros/internal.rs
+++ b/mlx-rs/src/macros/internal.rs
@@ -8,8 +8,30 @@ macro_rules! try_catch_c_ptr_expr {
         if c_ptr.is_null() {
             // SAFETY: there must be an error if the pointer is null
             return Err($crate::error::get_and_clear_last_mlx_error()
-                .or($crate::error::take_last_mlx_closure_error())
                 .expect("A null pointer was returned, but no error was set."));
+        }
+        c_ptr
+    }};
+}
+
+/// This is intended to be used on expressions that contains a closure that may
+/// return an error.
+macro_rules! try_catch_mlx_closure_error {
+    ($expr:expr) => {{
+        if !$crate::error::is_mlx_error_handler_set() {
+            $crate::error::setup_mlx_error_handler();
+        }
+
+        let c_ptr = $expr;
+
+        // Always check for error, even if the pointer is not null
+        if let Some(e) = $crate::error::get_and_clear_last_mlx_error()
+            .or_else(|| $crate::error::take_last_mlx_closure_error()) 
+        {
+            return Err(e);
+        }
+        if c_ptr.is_null() {
+            panic!("A null pointer was returned, but no error was set.");
         }
         c_ptr
     }};

--- a/mlx-rs/src/ops/conversion.rs
+++ b/mlx-rs/src/ops/conversion.rs
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn test_view() {
         let array = Array::from_slice(&[1i16, 2, 3], &[3]);
-        let mut new_array = array.view::<i8>();
+        let new_array = array.view::<i8>();
 
         assert_eq!(new_array.dtype(), Dtype::Int8);
         assert_eq!(new_array.shape(), &[6]);

--- a/mlx-rs/src/transforms/compile.rs
+++ b/mlx-rs/src/transforms/compile.rs
@@ -35,16 +35,16 @@ pub fn disable_compile() {
     }
 }
 
-pub trait Compile<'a, Args, Output>: Sized {
+pub trait Compile<'a, Args, Output, Err>: Sized {
     fn compile(
         self,
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, Args, Output>;
+    ) -> impl CallMut<'a, Args, Output, Err>;
 }
 
-impl<'a, F> Compile<'a, &'a [Array], Vec<Array>> for F
+impl<'a, F> Compile<'a, &'a [Array], Vec<Array>, ()> for F
 where
     F: FnMut(&[Array]) -> Vec<Array> + 'static,
 {
@@ -53,7 +53,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, &'a [Array], Vec<Array>> {
+    ) -> impl CallMut<'a, &'a [Array], Vec<Array>, ()> {
         let id = type_id_to_usize(&self);
         let state = CompiledState {
             f: self,
@@ -69,7 +69,32 @@ where
     }
 }
 
-impl<'a, F> Compile<'a, &'a Array, Array> for F
+impl<'a, F> Compile<'a, &'a [Array], Vec<Array>, Exception> for F 
+where 
+    F: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'static,
+{
+    fn compile(
+        self,
+        inputs: Option<&'a mut [Array]>,
+        outputs: Option<&'a mut [Array]>,
+        shapeless: bool,
+    ) -> impl CallMut<'a, &'a [Array], Vec<Array>, Exception> {
+        let id = type_id_to_usize(&self);
+        let state = CompiledState {
+            f: self,
+            inputs,
+            outputs,
+            shapeless,
+            id,
+        };
+        Compiled {
+            f_marker: PhantomData::<F>,
+            state,
+        }
+    }
+}
+
+impl<'a, F> Compile<'a, &'a Array, Array, ()> for F
 where
     F: FnMut(&Array) -> Array + 'static,
 {
@@ -78,7 +103,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, &'a Array, Array> {
+    ) -> impl CallMut<'a, &'a Array, Array, ()> {
         let f = move |args: &[Array]| -> Vec<Array> {
             let result = (self)(&args[0]);
             vec![result]
@@ -98,7 +123,36 @@ where
     }
 }
 
-impl<'a, F> Compile<'a, (&'a Array, &'a Array), Array> for F
+impl<'a, F> Compile<'a, &'a Array, Array, Exception> for F
+where 
+    F: FnMut(&Array) -> Result<Array, Exception> + 'static,
+{
+    fn compile(
+        mut self,
+        inputs: Option<&'a mut [Array]>,
+        outputs: Option<&'a mut [Array]>,
+        shapeless: bool,
+    ) -> impl CallMut<'a, &'a Array, Array, Exception> {
+        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> {
+            let result = (self)(&args[0])?;
+            Ok(vec![result])
+        };
+        let id = type_id_to_usize(&f);
+        let state = CompiledState {
+            f,
+            inputs,
+            outputs,
+            shapeless,
+            id,
+        };
+        Compiled {
+            f_marker: PhantomData::<F>,
+            state,
+        }
+    }
+}
+
+impl<'a, F> Compile<'a, (&'a Array, &'a Array), Array, ()> for F
 where
     F: FnMut((&Array, &Array)) -> Array + 'static,
 {
@@ -107,7 +161,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, (&'a Array, &'a Array), Array> {
+    ) -> impl CallMut<'a, (&'a Array, &'a Array), Array, ()> {
         let f = move |args: &[Array]| -> Vec<Array> {
             let result = (self)((&args[0], &args[1]));
             vec![result]
@@ -127,7 +181,36 @@ where
     }
 }
 
-impl<'a, F> Compile<'a, (&'a Array, &'a Array, &'a Array), Array> for F
+impl<'a, F> Compile<'a, (&'a Array, &'a Array), Array, Exception> for F
+where
+    F: FnMut((&Array, &Array)) -> Result<Array, Exception> + 'static,
+{
+    fn compile(
+        mut self,
+        inputs: Option<&'a mut [Array]>,
+        outputs: Option<&'a mut [Array]>,
+        shapeless: bool,
+    ) -> impl CallMut<'a, (&'a Array, &'a Array), Array, Exception> {
+        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> {
+            let result = (self)((&args[0], &args[1]))?;
+            Ok(vec![result])
+        };
+        let id = type_id_to_usize(&f);
+        let state = CompiledState {
+            f,
+            inputs,
+            outputs,
+            shapeless,
+            id,
+        };
+        Compiled {
+            f_marker: PhantomData::<F>,
+            state,
+        }
+    }
+}
+
+impl<'a, F> Compile<'a, (&'a Array, &'a Array, &'a Array), Array, ()> for F
 where
     F: FnMut((&Array, &Array, &Array)) -> Array + 'static,
 {
@@ -136,7 +219,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, (&'a Array, &'a Array, &'a Array), Array> {
+    ) -> impl CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, ()> {
         let f = move |args: &[Array]| -> Vec<Array> {
             let result = (self)((&args[0], &args[1], &args[2]));
             vec![result]
@@ -156,7 +239,36 @@ where
     }
 }
 
-pub trait CallMut<'a, Args, Output> {
+impl<'a, F> Compile<'a, (&'a Array, &'a Array, &'a Array), Array, Exception> for F
+where
+    F: FnMut((&Array, &Array, &Array)) -> Result<Array, Exception> + 'static,
+{
+    fn compile(
+        mut self,
+        inputs: Option<&'a mut [Array]>,
+        outputs: Option<&'a mut [Array]>,
+        shapeless: bool,
+    ) -> impl CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, Exception> {
+        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> {
+            let result = (self)((&args[0], &args[1], &args[2]))?;
+            Ok(vec![result])
+        };
+        let id = type_id_to_usize(&f);
+        let state = CompiledState {
+            f,
+            inputs,
+            outputs,
+            shapeless,
+            id,
+        };
+        Compiled {
+            f_marker: PhantomData::<F>,
+            state,
+        }
+    }
+}
+
+pub trait CallMut<'a, Args, Output, Err> {
     fn call_mut(&mut self, args: Args) -> Result<Output, Exception>;
 }
 
@@ -166,7 +278,7 @@ pub struct Compiled<'a, F, G> {
     state: CompiledState<'a, G>,
 }
 
-impl<'a, F, G> CallMut<'a, &'a [Array], Vec<Array>> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, &'a [Array], Vec<Array>, ()> for Compiled<'a, F, G>
 where
     F: FnMut(&[Array]) -> Vec<Array> + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -176,7 +288,17 @@ where
     }
 }
 
-impl<'a, F, G> CallMut<'a, &'a Array, Array> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, &'a [Array], Vec<Array>, Exception> for Compiled<'a, F, G>
+where
+    F: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
+    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
+{
+    fn call_mut(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception> {
+        self.state.call_mut_with_error(args)
+    }
+}
+
+impl<'a, F, G> CallMut<'a, &'a Array, Array, ()> for Compiled<'a, F, G>
 where
     F: FnMut(&Array) -> Array + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -189,7 +311,21 @@ where
     }
 }
 
-impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array), Array> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, &'a Array, Array, Exception> for Compiled<'a, F, G>
+where
+    F: FnMut(&Array) -> Result<Array, Exception> + 'a,
+    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
+{
+    fn call_mut(&mut self, args: &Array) -> Result<Array, Exception> {
+        // Is there any way to avoid this shallow clone?
+        let args = &[args.clone()];
+        let result = self.state.call_mut_with_error(args)?;
+        Ok(result.into_iter().next().unwrap())
+    }
+}
+
+
+impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array), Array, ()> for Compiled<'a, F, G>
 where
     F: FnMut((&Array, &Array)) -> Array + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -202,7 +338,20 @@ where
     }
 }
 
-impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array, &'a Array), Array> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array), Array, Exception> for Compiled<'a, F, G>
+where
+    F: FnMut((&Array, &Array)) -> Result<Array, Exception> + 'a,
+    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
+{
+    fn call_mut(&mut self, args: (&Array, &Array)) -> Result<Array, Exception> {
+        // Is there any way to avoid this shallow clone?
+        let args = &[args.0.clone(), args.1.clone()];
+        let result = self.state.call_mut_with_error(args)?;
+        Ok(result.into_iter().next().unwrap())
+    }
+}
+
+impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, ()> for Compiled<'a, F, G>
 where
     F: FnMut((&Array, &Array, &Array)) -> Array + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -211,6 +360,19 @@ where
         // Is there any way to avoid this shallow clone?
         let args = &[args.0.clone(), args.1.clone(), args.2.clone()];
         let result = self.state.call_mut(args)?;
+        Ok(result.into_iter().next().unwrap())
+    }
+}
+
+impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, Exception> for Compiled<'a, F, G>
+where
+    F: FnMut((&Array, &Array, &Array)) -> Result<Array, Exception> + 'a,
+    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
+{
+    fn call_mut(&mut self, args: (&Array, &Array, &Array)) -> Result<Array, Exception> {
+        // Is there any way to avoid this shallow clone?
+        let args = &[args.0.clone(), args.1.clone(), args.2.clone()];
+        let result = self.state.call_mut_with_error(args)?;
         Ok(result.into_iter().next().unwrap())
     }
 }
@@ -227,9 +389,74 @@ where
     id: usize,
 }
 
+#[inline]
+fn call_mut_inner(
+    inner_closure: Closure,
+    fun_id: usize,
+    shapeless: bool,
+    state_inputs: Rc<RefCell<&mut Option<&mut [Array]>>>,
+    state_outputs: Rc<RefCell<&mut Option<&mut [Array]>>>,
+    args: &[Array],
+) -> Result<Vec<Array>, Exception> {
+        // note: this will use the cached compile (via the id)
+        // but will be able to re-evaluate with fresh state if needed
+        let compiled = unsafe {
+            let constants = &[];
+            let c_closure = try_catch_mlx_closure_error! {
+                mlx_detail_compile(
+                    inner_closure.as_ptr(),
+                    fun_id,
+                    shapeless,
+                    constants.as_ptr(),
+                    0,
+                )
+            };
+            Closure::from_ptr(c_closure)
+        };
+
+        let inner_inputs_vector = match state_inputs.borrow().as_ref() {
+            Some(s) => VectorArray::from_iter(args.iter().chain(s.iter())),
+            None => VectorArray::from_iter(args.iter()),
+        };
+
+        // will compile the function (if needed) and evaluate the
+        // compiled graph
+        let result_vector = unsafe {
+            let c_vector = try_catch_mlx_closure_error! {
+                mlx_closure_apply(compiled.as_ptr(), inner_inputs_vector.as_ptr())
+            };
+            VectorArray::from_ptr(c_vector)
+        };
+        let result_plus_state_output: Vec<Array> = result_vector.into_values();
+
+        // push the stateOutput into the state
+        if let Some(outputs) = state_outputs.borrow_mut().as_mut() {
+            let result_plus_state_output_len = result_plus_state_output.len();
+            let state_output_len = outputs.len();
+            let suffix_len = result_plus_state_output_len - state_output_len;
+            for (s, new_values) in outputs
+                .iter_mut()
+                .zip(result_plus_state_output[suffix_len..].iter())
+            {
+                update_by_replace_with_ref_to_new_array(s, new_values);
+            }
+        }
+
+        let result_len = result_plus_state_output.len()
+            - state_outputs
+                .borrow()
+                .as_ref()
+                .map(|x| x.len())
+                .unwrap_or(0);
+        Ok(result_plus_state_output
+            .into_iter()
+            .take(result_len)
+            .collect())
+}
+
 impl<'a, F> CompiledState<'a, F> {
-    fn call_mut(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception>
-    where
+    fn call_mut(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception> 
+    where 
         F: FnMut(&[Array]) -> Vec<Array> + 'a,
     {
         let args_len = args.len();
@@ -285,60 +512,84 @@ impl<'a, F> CompiledState<'a, F> {
 
         let inner_closure = Closure::new(inner);
 
-        // note: this will use the cached compile (via the id)
-        // but will be able to re-evaluate with fresh state if needed
-        let compiled = unsafe {
-            let constants = &[];
-            let c_closure = try_catch_c_ptr_expr! {
-                mlx_detail_compile(
-                    inner_closure.as_ptr(),
-                    self.id,
-                    self.shapeless,
-                    constants.as_ptr(),
-                    0,
-                )
-            };
-            Closure::from_ptr(c_closure)
-        };
+        call_mut_inner(
+            inner_closure,
+            self.id,
+            self.shapeless,
+            state_inputs,
+            state_outputs,
+            args,
+        )
+    }
 
-        let inner_inputs_vector = match state_inputs.borrow().as_ref() {
-            Some(s) => VectorArray::from_iter(args.iter().chain(s.iter())),
-            None => VectorArray::from_iter(args.iter()),
-        };
+    fn call_mut_with_error(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception>
+    where
+        F: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
+    {
+        let args_len = args.len();
+        let state_inputs = Rc::new(RefCell::new(&mut self.inputs));
+        let state_outputs = Rc::new(RefCell::new(&mut self.outputs));
+        let f = &mut self.f;
 
-        // will compile the function (if needed) and evaluate the
-        // compiled graph
-        let result_vector = unsafe {
-            let c_vector = try_catch_c_ptr_expr! {
-                mlx_closure_apply(compiled.as_ptr(), inner_inputs_vector.as_ptr())
-            };
-            VectorArray::from_ptr(c_vector)
-        };
-        let result_plus_state_output: Vec<Array> = result_vector.into_values();
+        let state_inputs_clone = Rc::clone(&state_inputs);
+        let state_outputs_clone = Rc::clone(&state_outputs);
+        let inner = move |tracers: &[Array]| -> Result<Vec<Array>, Exception> {
+            // put the tracers in their appropriate places:
+            // - arguments to the function
+            // - inner state
 
-        // push the stateOutput into the state
-        if let Some(outputs) = state_outputs.borrow_mut().as_mut() {
-            let result_plus_state_output_len = result_plus_state_output.len();
-            let state_output_len = outputs.len();
-            let suffix_len = result_plus_state_output_len - state_output_len;
-            for (s, new_values) in outputs
-                .iter_mut()
-                .zip(result_plus_state_output[suffix_len..].iter())
-            {
-                update_by_replace_with_ref_to_new_array(s, new_values);
-            }
-        }
+            let tracer_args = &tracers[..args_len];
 
-        let result_len = result_plus_state_output.len()
-            - state_outputs
+            // save a snapshot of the inner state
+            let saved_state_inputs: Option<Vec<Array>> = state_inputs_clone
                 .borrow()
                 .as_ref()
-                .map(|x| x.len())
-                .unwrap_or(0);
-        Ok(result_plus_state_output
-            .into_iter()
-            .take(result_len)
-            .collect())
+                .map(|inputs| inputs.iter().map(Clone::clone).collect());
+
+            // replace the inner state with the tracers
+            if let Some(inputs) = state_inputs_clone.borrow_mut().as_mut() {
+                for (s, tracer) in inputs.iter_mut().zip(tracers.iter().skip(args_len)) {
+                    update_by_replace_with_ref_to_new_array(s, tracer);
+                }
+            }
+
+            // call the function with the tracer arguments and the state holding tracers
+            let mut result = (f)(tracer_args);
+
+            // recapture the state as it may have changed
+            let state_output_tracers: Option<Vec<Array>> = state_outputs_clone
+                .borrow()
+                .as_ref()
+                .map(|outputs| outputs.iter().map(Clone::clone).collect());
+
+            // put the original values back in the state
+            if let Some(inputs) = state_inputs_clone.borrow_mut().as_mut() {
+                for (s, saved) in inputs.iter_mut().zip(saved_state_inputs.unwrap()) {
+                    update_by_replace_with_ref_to_new_array(s, &saved);
+                }
+            }
+
+            // return the result of the function and the state
+            if let Some(mut state_output_tracers) = state_output_tracers {
+                result = result.map(|mut r| {
+                    r.append(&mut state_output_tracers);
+                    r
+                });
+            }
+
+            result
+        };
+
+        let inner_closure = Closure::new_with_error(inner);
+
+        call_mut_inner(
+            inner_closure,
+            self.id,
+            self.shapeless,
+            state_inputs,
+            state_outputs,
+            args,
+        )
     }
 }
 
@@ -377,16 +628,17 @@ fn update_by_replace_with_ref_to_new_array(src: &mut Array, new_array: &Array) {
 /// Please refer to the [swift binding
 /// documentation](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/compilation)
 /// for more information.
-pub fn compile<'a, F, Args, Output>(
+pub fn compile<'a, F, Args, Output, Err>(
     f: F,
     shapeless: Option<bool>,
     inputs: Option<&'a mut [Array]>,
     outputs: Option<&'a mut [Array]>,
 ) -> impl FnMut(Args) -> Result<Output, Exception> + 'a
 where
-    F: Compile<'a, Args, Output> + 'static,
+    F: Compile<'a, Args, Output, Err> + 'static,
     Args: 'a,
     Output: 'a,
+    Err: 'a,
 {
     let shapeless = shapeless.unwrap_or(false);
     let mut compiled = f.compile(inputs, outputs, shapeless);
@@ -403,7 +655,7 @@ pub fn clear_cache() {
 mod tests {
     use core::panic;
 
-    use crate::{ops::ones, Array};
+    use crate::{array, error::Exception, ops::{multiply, ones}, Array};
 
     use super::compile;
 
@@ -469,6 +721,55 @@ mod tests {
 
         let r3 = compiled(&args).unwrap().drain(0..1).next().unwrap();
         assert_eq!(&r1, &r3);
+    }
+
+    #[test]
+    fn test_compile_with_error() {
+        let f = |inputs: &[Array]| -> Result<Vec<Array>, Exception> {
+            multiply(&inputs[0], &inputs[1]).map(|x| vec![x])
+        };
+
+        // Success case
+        let i1 = ones::<f32>(&[20, 20]).unwrap();
+        let i2 = ones::<f32>(&[20, 20]).unwrap();
+        let args = [i1, i2];
+
+        // evaluate directly
+        let r1 = f(&args).unwrap().drain(0..1).next().unwrap();
+
+        // evaluate compiled
+        let mut compiled = compile(f, None, None, None);
+        let r2 = compiled(&args).unwrap().drain(0..1).next().unwrap();
+
+        assert_eq!(&r1, &r2);
+
+        let r3 = compiled(&args).unwrap().drain(0..1).next().unwrap();
+        assert_eq!(&r1, &r3);
+
+        // Error case
+        let a = array!([1.0, 2.0, 3.0]);
+        let b = array!([4.0, 5.0]);
+        let args = [a, b];
+
+        let c = array!([1.0, 2.0, 3.0]);
+        let d = array!([4.0, 5.0]);
+        let another_args = [c, d];
+
+        // evaluate directly
+        let result = f(&args);
+        assert!(result.is_err());
+
+        // evaluate compiled
+        let mut compiled = compile(f, None, None, None);
+        let result = compiled(&args);
+        assert!(result.is_err());
+
+        let result = compiled(&args);
+        println!("{:?}", result);
+
+        let result = compiled(&another_args);
+        println!("{:?}", result);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/mlx-rs/src/transforms/compile.rs
+++ b/mlx-rs/src/transforms/compile.rs
@@ -35,16 +35,16 @@ pub fn disable_compile() {
     }
 }
 
-pub trait Compile<'a, Args, Output, Err>: Sized {
+pub trait Compile<'a, Args, Output>: Sized {
     fn compile(
         self,
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, Args, Output, Err>;
+    ) -> impl CallMut<'a, Args, Output>;
 }
 
-impl<'a, F> Compile<'a, &'a [Array], Vec<Array>, ()> for F
+impl<'a, F> Compile<'a, &'a [Array], Vec<Array>> for F
 where
     F: FnMut(&[Array]) -> Vec<Array> + 'static,
 {
@@ -53,7 +53,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, &'a [Array], Vec<Array>, ()> {
+    ) -> impl CallMut<'a, &'a [Array], Vec<Array>> {
         let id = type_id_to_usize(&self);
         let state = CompiledState {
             f: self,
@@ -69,32 +69,7 @@ where
     }
 }
 
-impl<'a, F> Compile<'a, &'a [Array], Vec<Array>, Exception> for F 
-where 
-    F: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'static,
-{
-    fn compile(
-        self,
-        inputs: Option<&'a mut [Array]>,
-        outputs: Option<&'a mut [Array]>,
-        shapeless: bool,
-    ) -> impl CallMut<'a, &'a [Array], Vec<Array>, Exception> {
-        let id = type_id_to_usize(&self);
-        let state = CompiledState {
-            f: self,
-            inputs,
-            outputs,
-            shapeless,
-            id,
-        };
-        Compiled {
-            f_marker: PhantomData::<F>,
-            state,
-        }
-    }
-}
-
-impl<'a, F> Compile<'a, &'a Array, Array, ()> for F
+impl<'a, F> Compile<'a, &'a Array, Array> for F
 where
     F: FnMut(&Array) -> Array + 'static,
 {
@@ -103,7 +78,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, &'a Array, Array, ()> {
+    ) -> impl CallMut<'a, &'a Array, Array> {
         let f = move |args: &[Array]| -> Vec<Array> {
             let result = (self)(&args[0]);
             vec![result]
@@ -123,36 +98,7 @@ where
     }
 }
 
-impl<'a, F> Compile<'a, &'a Array, Array, Exception> for F
-where 
-    F: FnMut(&Array) -> Result<Array, Exception> + 'static,
-{
-    fn compile(
-        mut self,
-        inputs: Option<&'a mut [Array]>,
-        outputs: Option<&'a mut [Array]>,
-        shapeless: bool,
-    ) -> impl CallMut<'a, &'a Array, Array, Exception> {
-        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> {
-            let result = (self)(&args[0])?;
-            Ok(vec![result])
-        };
-        let id = type_id_to_usize(&f);
-        let state = CompiledState {
-            f,
-            inputs,
-            outputs,
-            shapeless,
-            id,
-        };
-        Compiled {
-            f_marker: PhantomData::<F>,
-            state,
-        }
-    }
-}
-
-impl<'a, F> Compile<'a, (&'a Array, &'a Array), Array, ()> for F
+impl<'a, F> Compile<'a, (&'a Array, &'a Array), Array> for F
 where
     F: FnMut((&Array, &Array)) -> Array + 'static,
 {
@@ -161,7 +107,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, (&'a Array, &'a Array), Array, ()> {
+    ) -> impl CallMut<'a, (&'a Array, &'a Array), Array> {
         let f = move |args: &[Array]| -> Vec<Array> {
             let result = (self)((&args[0], &args[1]));
             vec![result]
@@ -181,36 +127,7 @@ where
     }
 }
 
-impl<'a, F> Compile<'a, (&'a Array, &'a Array), Array, Exception> for F
-where
-    F: FnMut((&Array, &Array)) -> Result<Array, Exception> + 'static,
-{
-    fn compile(
-        mut self,
-        inputs: Option<&'a mut [Array]>,
-        outputs: Option<&'a mut [Array]>,
-        shapeless: bool,
-    ) -> impl CallMut<'a, (&'a Array, &'a Array), Array, Exception> {
-        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> {
-            let result = (self)((&args[0], &args[1]))?;
-            Ok(vec![result])
-        };
-        let id = type_id_to_usize(&f);
-        let state = CompiledState {
-            f,
-            inputs,
-            outputs,
-            shapeless,
-            id,
-        };
-        Compiled {
-            f_marker: PhantomData::<F>,
-            state,
-        }
-    }
-}
-
-impl<'a, F> Compile<'a, (&'a Array, &'a Array, &'a Array), Array, ()> for F
+impl<'a, F> Compile<'a, (&'a Array, &'a Array, &'a Array), Array> for F
 where
     F: FnMut((&Array, &Array, &Array)) -> Array + 'static,
 {
@@ -219,7 +136,7 @@ where
         inputs: Option<&'a mut [Array]>,
         outputs: Option<&'a mut [Array]>,
         shapeless: bool,
-    ) -> impl CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, ()> {
+    ) -> impl CallMut<'a, (&'a Array, &'a Array, &'a Array), Array> {
         let f = move |args: &[Array]| -> Vec<Array> {
             let result = (self)((&args[0], &args[1], &args[2]));
             vec![result]
@@ -239,36 +156,7 @@ where
     }
 }
 
-impl<'a, F> Compile<'a, (&'a Array, &'a Array, &'a Array), Array, Exception> for F
-where
-    F: FnMut((&Array, &Array, &Array)) -> Result<Array, Exception> + 'static,
-{
-    fn compile(
-        mut self,
-        inputs: Option<&'a mut [Array]>,
-        outputs: Option<&'a mut [Array]>,
-        shapeless: bool,
-    ) -> impl CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, Exception> {
-        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> {
-            let result = (self)((&args[0], &args[1], &args[2]))?;
-            Ok(vec![result])
-        };
-        let id = type_id_to_usize(&f);
-        let state = CompiledState {
-            f,
-            inputs,
-            outputs,
-            shapeless,
-            id,
-        };
-        Compiled {
-            f_marker: PhantomData::<F>,
-            state,
-        }
-    }
-}
-
-pub trait CallMut<'a, Args, Output, Err> {
+pub trait CallMut<'a, Args, Output> {
     fn call_mut(&mut self, args: Args) -> Result<Output, Exception>;
 }
 
@@ -278,7 +166,7 @@ pub struct Compiled<'a, F, G> {
     state: CompiledState<'a, G>,
 }
 
-impl<'a, F, G> CallMut<'a, &'a [Array], Vec<Array>, ()> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, &'a [Array], Vec<Array>> for Compiled<'a, F, G>
 where
     F: FnMut(&[Array]) -> Vec<Array> + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -288,17 +176,7 @@ where
     }
 }
 
-impl<'a, F, G> CallMut<'a, &'a [Array], Vec<Array>, Exception> for Compiled<'a, F, G>
-where
-    F: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
-    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
-{
-    fn call_mut(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception> {
-        self.state.call_mut_with_error(args)
-    }
-}
-
-impl<'a, F, G> CallMut<'a, &'a Array, Array, ()> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, &'a Array, Array> for Compiled<'a, F, G>
 where
     F: FnMut(&Array) -> Array + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -311,21 +189,7 @@ where
     }
 }
 
-impl<'a, F, G> CallMut<'a, &'a Array, Array, Exception> for Compiled<'a, F, G>
-where
-    F: FnMut(&Array) -> Result<Array, Exception> + 'a,
-    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
-{
-    fn call_mut(&mut self, args: &Array) -> Result<Array, Exception> {
-        // Is there any way to avoid this shallow clone?
-        let args = &[args.clone()];
-        let result = self.state.call_mut_with_error(args)?;
-        Ok(result.into_iter().next().unwrap())
-    }
-}
-
-
-impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array), Array, ()> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array), Array> for Compiled<'a, F, G>
 where
     F: FnMut((&Array, &Array)) -> Array + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -338,20 +202,7 @@ where
     }
 }
 
-impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array), Array, Exception> for Compiled<'a, F, G>
-where
-    F: FnMut((&Array, &Array)) -> Result<Array, Exception> + 'a,
-    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
-{
-    fn call_mut(&mut self, args: (&Array, &Array)) -> Result<Array, Exception> {
-        // Is there any way to avoid this shallow clone?
-        let args = &[args.0.clone(), args.1.clone()];
-        let result = self.state.call_mut_with_error(args)?;
-        Ok(result.into_iter().next().unwrap())
-    }
-}
-
-impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, ()> for Compiled<'a, F, G>
+impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array, &'a Array), Array> for Compiled<'a, F, G>
 where
     F: FnMut((&Array, &Array, &Array)) -> Array + 'a,
     G: FnMut(&[Array]) -> Vec<Array> + 'a,
@@ -360,19 +211,6 @@ where
         // Is there any way to avoid this shallow clone?
         let args = &[args.0.clone(), args.1.clone(), args.2.clone()];
         let result = self.state.call_mut(args)?;
-        Ok(result.into_iter().next().unwrap())
-    }
-}
-
-impl<'a, F, G> CallMut<'a, (&'a Array, &'a Array, &'a Array), Array, Exception> for Compiled<'a, F, G>
-where
-    F: FnMut((&Array, &Array, &Array)) -> Result<Array, Exception> + 'a,
-    G: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
-{
-    fn call_mut(&mut self, args: (&Array, &Array, &Array)) -> Result<Array, Exception> {
-        // Is there any way to avoid this shallow clone?
-        let args = &[args.0.clone(), args.1.clone(), args.2.clone()];
-        let result = self.state.call_mut_with_error(args)?;
         Ok(result.into_iter().next().unwrap())
     }
 }
@@ -389,74 +227,9 @@ where
     id: usize,
 }
 
-#[inline]
-fn call_mut_inner(
-    inner_closure: Closure,
-    fun_id: usize,
-    shapeless: bool,
-    state_inputs: Rc<RefCell<&mut Option<&mut [Array]>>>,
-    state_outputs: Rc<RefCell<&mut Option<&mut [Array]>>>,
-    args: &[Array],
-) -> Result<Vec<Array>, Exception> {
-        // note: this will use the cached compile (via the id)
-        // but will be able to re-evaluate with fresh state if needed
-        let compiled = unsafe {
-            let constants = &[];
-            let c_closure = try_catch_mlx_closure_error! {
-                mlx_detail_compile(
-                    inner_closure.as_ptr(),
-                    fun_id,
-                    shapeless,
-                    constants.as_ptr(),
-                    0,
-                )
-            };
-            Closure::from_ptr(c_closure)
-        };
-
-        let inner_inputs_vector = match state_inputs.borrow().as_ref() {
-            Some(s) => VectorArray::from_iter(args.iter().chain(s.iter())),
-            None => VectorArray::from_iter(args.iter()),
-        };
-
-        // will compile the function (if needed) and evaluate the
-        // compiled graph
-        let result_vector = unsafe {
-            let c_vector = try_catch_mlx_closure_error! {
-                mlx_closure_apply(compiled.as_ptr(), inner_inputs_vector.as_ptr())
-            };
-            VectorArray::from_ptr(c_vector)
-        };
-        let result_plus_state_output: Vec<Array> = result_vector.into_values();
-
-        // push the stateOutput into the state
-        if let Some(outputs) = state_outputs.borrow_mut().as_mut() {
-            let result_plus_state_output_len = result_plus_state_output.len();
-            let state_output_len = outputs.len();
-            let suffix_len = result_plus_state_output_len - state_output_len;
-            for (s, new_values) in outputs
-                .iter_mut()
-                .zip(result_plus_state_output[suffix_len..].iter())
-            {
-                update_by_replace_with_ref_to_new_array(s, new_values);
-            }
-        }
-
-        let result_len = result_plus_state_output.len()
-            - state_outputs
-                .borrow()
-                .as_ref()
-                .map(|x| x.len())
-                .unwrap_or(0);
-        Ok(result_plus_state_output
-            .into_iter()
-            .take(result_len)
-            .collect())
-}
-
 impl<'a, F> CompiledState<'a, F> {
-    fn call_mut(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception> 
-    where 
+    fn call_mut(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception>
+    where
         F: FnMut(&[Array]) -> Vec<Array> + 'a,
     {
         let args_len = args.len();
@@ -512,84 +285,60 @@ impl<'a, F> CompiledState<'a, F> {
 
         let inner_closure = Closure::new(inner);
 
-        call_mut_inner(
-            inner_closure,
-            self.id,
-            self.shapeless,
-            state_inputs,
-            state_outputs,
-            args,
-        )
-    }
-
-    fn call_mut_with_error(&mut self, args: &[Array]) -> Result<Vec<Array>, Exception>
-    where
-        F: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
-    {
-        let args_len = args.len();
-        let state_inputs = Rc::new(RefCell::new(&mut self.inputs));
-        let state_outputs = Rc::new(RefCell::new(&mut self.outputs));
-        let f = &mut self.f;
-
-        let state_inputs_clone = Rc::clone(&state_inputs);
-        let state_outputs_clone = Rc::clone(&state_outputs);
-        let inner = move |tracers: &[Array]| -> Result<Vec<Array>, Exception> {
-            // put the tracers in their appropriate places:
-            // - arguments to the function
-            // - inner state
-
-            let tracer_args = &tracers[..args_len];
-
-            // save a snapshot of the inner state
-            let saved_state_inputs: Option<Vec<Array>> = state_inputs_clone
-                .borrow()
-                .as_ref()
-                .map(|inputs| inputs.iter().map(Clone::clone).collect());
-
-            // replace the inner state with the tracers
-            if let Some(inputs) = state_inputs_clone.borrow_mut().as_mut() {
-                for (s, tracer) in inputs.iter_mut().zip(tracers.iter().skip(args_len)) {
-                    update_by_replace_with_ref_to_new_array(s, tracer);
-                }
-            }
-
-            // call the function with the tracer arguments and the state holding tracers
-            let mut result = (f)(tracer_args);
-
-            // recapture the state as it may have changed
-            let state_output_tracers: Option<Vec<Array>> = state_outputs_clone
-                .borrow()
-                .as_ref()
-                .map(|outputs| outputs.iter().map(Clone::clone).collect());
-
-            // put the original values back in the state
-            if let Some(inputs) = state_inputs_clone.borrow_mut().as_mut() {
-                for (s, saved) in inputs.iter_mut().zip(saved_state_inputs.unwrap()) {
-                    update_by_replace_with_ref_to_new_array(s, &saved);
-                }
-            }
-
-            // return the result of the function and the state
-            if let Some(mut state_output_tracers) = state_output_tracers {
-                result = result.map(|mut r| {
-                    r.append(&mut state_output_tracers);
-                    r
-                });
-            }
-
-            result
+        // note: this will use the cached compile (via the id)
+        // but will be able to re-evaluate with fresh state if needed
+        let compiled = unsafe {
+            let constants = &[];
+            let c_closure = try_catch_c_ptr_expr! {
+                mlx_detail_compile(
+                    inner_closure.as_ptr(),
+                    self.id,
+                    self.shapeless,
+                    constants.as_ptr(),
+                    0,
+                )
+            };
+            Closure::from_ptr(c_closure)
         };
 
-        let inner_closure = Closure::new_with_error(inner);
+        let inner_inputs_vector = match state_inputs.borrow().as_ref() {
+            Some(s) => VectorArray::from_iter(args.iter().chain(s.iter())),
+            None => VectorArray::from_iter(args.iter()),
+        };
 
-        call_mut_inner(
-            inner_closure,
-            self.id,
-            self.shapeless,
-            state_inputs,
-            state_outputs,
-            args,
-        )
+        // will compile the function (if needed) and evaluate the
+        // compiled graph
+        let result_vector = unsafe {
+            let c_vector = try_catch_c_ptr_expr! {
+                mlx_closure_apply(compiled.as_ptr(), inner_inputs_vector.as_ptr())
+            };
+            VectorArray::from_ptr(c_vector)
+        };
+        let result_plus_state_output: Vec<Array> = result_vector.into_values();
+
+        // push the stateOutput into the state
+        if let Some(outputs) = state_outputs.borrow_mut().as_mut() {
+            let result_plus_state_output_len = result_plus_state_output.len();
+            let state_output_len = outputs.len();
+            let suffix_len = result_plus_state_output_len - state_output_len;
+            for (s, new_values) in outputs
+                .iter_mut()
+                .zip(result_plus_state_output[suffix_len..].iter())
+            {
+                update_by_replace_with_ref_to_new_array(s, new_values);
+            }
+        }
+
+        let result_len = result_plus_state_output.len()
+            - state_outputs
+                .borrow()
+                .as_ref()
+                .map(|x| x.len())
+                .unwrap_or(0);
+        Ok(result_plus_state_output
+            .into_iter()
+            .take(result_len)
+            .collect())
     }
 }
 
@@ -628,17 +377,16 @@ fn update_by_replace_with_ref_to_new_array(src: &mut Array, new_array: &Array) {
 /// Please refer to the [swift binding
 /// documentation](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/compilation)
 /// for more information.
-pub fn compile<'a, F, Args, Output, Err>(
+pub fn compile<'a, F, Args, Output>(
     f: F,
     shapeless: Option<bool>,
     inputs: Option<&'a mut [Array]>,
     outputs: Option<&'a mut [Array]>,
 ) -> impl FnMut(Args) -> Result<Output, Exception> + 'a
 where
-    F: Compile<'a, Args, Output, Err> + 'static,
+    F: Compile<'a, Args, Output> + 'static,
     Args: 'a,
     Output: 'a,
-    Err: 'a,
 {
     let shapeless = shapeless.unwrap_or(false);
     let mut compiled = f.compile(inputs, outputs, shapeless);
@@ -655,7 +403,7 @@ pub fn clear_cache() {
 mod tests {
     use core::panic;
 
-    use crate::{array, error::Exception, ops::{multiply, ones}, Array};
+    use crate::{ops::ones, Array};
 
     use super::compile;
 
@@ -721,55 +469,6 @@ mod tests {
 
         let r3 = compiled(&args).unwrap().drain(0..1).next().unwrap();
         assert_eq!(&r1, &r3);
-    }
-
-    #[test]
-    fn test_compile_with_error() {
-        let f = |inputs: &[Array]| -> Result<Vec<Array>, Exception> {
-            multiply(&inputs[0], &inputs[1]).map(|x| vec![x])
-        };
-
-        // Success case
-        let i1 = ones::<f32>(&[20, 20]).unwrap();
-        let i2 = ones::<f32>(&[20, 20]).unwrap();
-        let args = [i1, i2];
-
-        // evaluate directly
-        let r1 = f(&args).unwrap().drain(0..1).next().unwrap();
-
-        // evaluate compiled
-        let mut compiled = compile(f, None, None, None);
-        let r2 = compiled(&args).unwrap().drain(0..1).next().unwrap();
-
-        assert_eq!(&r1, &r2);
-
-        let r3 = compiled(&args).unwrap().drain(0..1).next().unwrap();
-        assert_eq!(&r1, &r3);
-
-        // Error case
-        let a = array!([1.0, 2.0, 3.0]);
-        let b = array!([4.0, 5.0]);
-        let args = [a, b];
-
-        let c = array!([1.0, 2.0, 3.0]);
-        let d = array!([4.0, 5.0]);
-        let another_args = [c, d];
-
-        // evaluate directly
-        let result = f(&args);
-        assert!(result.is_err());
-
-        // evaluate compiled
-        let mut compiled = compile(f, None, None, None);
-        let result = compiled(&args);
-        assert!(result.is_err());
-
-        let result = compiled(&args);
-        println!("{:?}", result);
-
-        let result = compiled(&another_args);
-        println!("{:?}", result);
-        assert!(result.is_err());
     }
 
     #[test]

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -53,7 +53,7 @@ fn jvp_inner<'a>(
     let c_tangents = VectorArray::from_iter(tangents.iter());
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_mlx_closure_error! {
+        let c_vector_pair = try_catch_c_ptr_expr! {
             mlx_sys::mlx_jvp(
                 closure.as_ptr(),
                 c_primals.as_ptr(),
@@ -123,7 +123,7 @@ fn vjp_inner<'a>(
     let c_cotangents = VectorArray::from_iter(cotangents.iter());
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_mlx_closure_error! {
+        let c_vector_pair = try_catch_c_ptr_expr! {
             mlx_sys::mlx_vjp(
                 closure.as_ptr(),
                 c_primals.as_ptr(),
@@ -189,7 +189,7 @@ fn value_and_gradient(
     let input_vector = VectorArray::from_iter(arrays);
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_mlx_closure_error! {
+        let c_vector_pair = try_catch_c_ptr_expr! {
             mlx_closure_value_and_grad_apply(value_and_grad, input_vector.as_ptr())
         };
         VectorVectorArray::from_ptr(c_vector_pair)
@@ -210,7 +210,7 @@ fn build_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a {
     move |arrays: &[Array]| -> Result<Vec<Array>, Exception> {
         unsafe {
-            let c_value_and_grad = try_catch_mlx_closure_error! {
+            let c_value_and_grad = try_catch_c_ptr_expr! {
                 mlx_sys::mlx_value_and_grad(
                     closure.as_ptr(),
                     argument_numbers.as_ptr(),
@@ -252,7 +252,7 @@ fn build_value_and_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>), Exception> + 'a {
     move |arrays: &[Array]| {
         let c_value_and_grad = unsafe {
-            try_catch_mlx_closure_error! {
+            try_catch_c_ptr_expr! {
                 mlx_sys::mlx_value_and_grad(
                     closure.as_ptr(),
                     argument_numbers.as_ptr(),

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -44,8 +44,8 @@ pub fn async_eval<'a>(outputs: impl IntoIterator<Item = &'a mut Array>) -> Resul
 }
 
 #[inline]
-fn jvp_inner<'a>(
-    closure: Closure<'a>,
+fn jvp_inner(
+    closure: Closure<'_>,
     primals: &[Array],
     tangents: &[Array],
 ) -> Result<(Vec<Array>, Vec<Array>), Exception> {
@@ -114,8 +114,8 @@ where
 }
 
 #[inline]
-fn vjp_inner<'a>(
-    closure: Closure<'a>,
+fn vjp_inner(
+    closure: Closure<'_>,
     primals: &[Array],
     cotangents: &[Array],
 ) -> Result<(Vec<Array>, Vec<Array>), Exception> {
@@ -449,9 +449,7 @@ where
         mut self,
         argument_numbers: &'a [i32],
     ) -> impl FnMut(&Array) -> Result<Vec<Array>, Exception> + 'a {
-        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> {
-            self(&args[0])
-        };
+        let f = move |args: &[Array]| -> Result<Vec<Array>, Exception> { self(&args[0]) };
         let mut g = build_gradient_with_error(f, argument_numbers);
         move |args: &Array| -> Result<Vec<Array>, Exception> {
             let args_clone = &[args.clone()];
@@ -474,9 +472,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        array, error::Exception, Array
-    };
+    use crate::{array, error::Exception, Array};
 
     use super::*;
 
@@ -578,7 +574,7 @@ mod tests {
         let y = array!(1.0f32);
         let result = value_and_grad_with_error(fun, argnums)(&[x, y]);
         assert!(result.is_ok());
-        
+
         // Error case
         // Use non-broadcastable shapes
         let a = array!([1.0, 2.0, 3.0]);

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -53,7 +53,7 @@ fn jvp_inner<'a>(
     let c_tangents = VectorArray::from_iter(tangents.iter());
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_c_ptr_expr! {
+        let c_vector_pair = try_catch_mlx_closure_error! {
             mlx_sys::mlx_jvp(
                 closure.as_ptr(),
                 c_primals.as_ptr(),
@@ -123,7 +123,7 @@ fn vjp_inner<'a>(
     let c_cotangents = VectorArray::from_iter(cotangents.iter());
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_c_ptr_expr! {
+        let c_vector_pair = try_catch_mlx_closure_error! {
             mlx_sys::mlx_vjp(
                 closure.as_ptr(),
                 c_primals.as_ptr(),
@@ -189,7 +189,7 @@ fn value_and_gradient(
     let input_vector = VectorArray::from_iter(arrays);
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_c_ptr_expr! {
+        let c_vector_pair = try_catch_mlx_closure_error! {
             mlx_closure_value_and_grad_apply(value_and_grad, input_vector.as_ptr())
         };
         VectorVectorArray::from_ptr(c_vector_pair)
@@ -210,7 +210,7 @@ fn build_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a {
     move |arrays: &[Array]| -> Result<Vec<Array>, Exception> {
         unsafe {
-            let c_value_and_grad = try_catch_c_ptr_expr! {
+            let c_value_and_grad = try_catch_mlx_closure_error! {
                 mlx_sys::mlx_value_and_grad(
                     closure.as_ptr(),
                     argument_numbers.as_ptr(),
@@ -252,7 +252,7 @@ fn build_value_and_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>), Exception> + 'a {
     move |arrays: &[Array]| {
         let c_value_and_grad = unsafe {
-            try_catch_c_ptr_expr! {
+            try_catch_mlx_closure_error! {
                 mlx_sys::mlx_value_and_grad(
                     closure.as_ptr(),
                     argument_numbers.as_ptr(),

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -53,7 +53,7 @@ fn jvp_inner(
     let c_tangents = VectorArray::from_iter(tangents.iter());
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_c_ptr_expr! {
+        let c_vector_pair = try_catch_mlx_closure_error! {
             mlx_sys::mlx_jvp(
                 closure.as_ptr(),
                 c_primals.as_ptr(),
@@ -123,7 +123,7 @@ fn vjp_inner(
     let c_cotangents = VectorArray::from_iter(cotangents.iter());
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_c_ptr_expr! {
+        let c_vector_pair = try_catch_mlx_closure_error! {
             mlx_sys::mlx_vjp(
                 closure.as_ptr(),
                 c_primals.as_ptr(),
@@ -189,7 +189,7 @@ fn value_and_gradient(
     let input_vector = VectorArray::from_iter(arrays);
 
     let vector_pair = unsafe {
-        let c_vector_pair = try_catch_c_ptr_expr! {
+        let c_vector_pair = try_catch_mlx_closure_error! {
             mlx_closure_value_and_grad_apply(value_and_grad, input_vector.as_ptr())
         };
         VectorVectorArray::from_ptr(c_vector_pair)
@@ -210,7 +210,7 @@ fn build_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a {
     move |arrays: &[Array]| -> Result<Vec<Array>, Exception> {
         unsafe {
-            let c_value_and_grad = try_catch_c_ptr_expr! {
+            let c_value_and_grad = try_catch_mlx_closure_error! {
                 mlx_sys::mlx_value_and_grad(
                     closure.as_ptr(),
                     argument_numbers.as_ptr(),
@@ -252,7 +252,7 @@ fn build_value_and_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>), Exception> + 'a {
     move |arrays: &[Array]| {
         let c_value_and_grad = unsafe {
-            try_catch_c_ptr_expr! {
+            try_catch_mlx_closure_error! {
                 mlx_sys::mlx_value_and_grad(
                     closure.as_ptr(),
                     argument_numbers.as_ptr(),

--- a/mlx-rs/src/utils.rs
+++ b/mlx-rs/src/utils.rs
@@ -349,8 +349,11 @@ where
         match result {
             Ok(result) => new_mlx_vector_array(result),
             Err(exception) => {
+                println!("Setting last mlx closure error");
                 crate::error::set_last_mlx_closure_error(exception);
-                std::ptr::null_mut()
+                // We cannot return a null pointer here otherwise 
+                // it will panic if the c binding is trying to create a std::vector from it
+                mlx_sys::mlx_vector_array_new()
             }
         }
     }

--- a/mlx-rs/src/utils.rs
+++ b/mlx-rs/src/utils.rs
@@ -349,11 +349,8 @@ where
         match result {
             Ok(result) => new_mlx_vector_array(result),
             Err(exception) => {
-                println!("Setting last mlx closure error");
                 crate::error::set_last_mlx_closure_error(exception);
-                // We cannot return a null pointer here otherwise 
-                // it will panic if the c binding is trying to create a std::vector from it
-                mlx_sys::mlx_vector_array_new()
+                std::ptr::null_mut()
             }
         }
     }

--- a/mlx-rs/src/utils.rs
+++ b/mlx-rs/src/utils.rs
@@ -253,7 +253,6 @@ impl<'a> Closure<'a> {
             lt_marker: PhantomData,
         }
     }
-
 }
 
 impl<'a> Drop for Closure<'a> {
@@ -288,7 +287,11 @@ where
     let payload = raw as *mut std::ffi::c_void;
 
     unsafe {
-        mlx_sys::mlx_closure_new_with_payload(Some(trampoline_with_exception::<F>), payload, Some(noop_dtor))
+        mlx_sys::mlx_closure_new_with_payload(
+            Some(trampoline_with_exception::<F>),
+            payload,
+            Some(noop_dtor),
+        )
     }
 }
 
@@ -337,8 +340,8 @@ where
 extern "C" fn trampoline_with_exception<'a, F>(
     vector_array: mlx_sys::mlx_vector_array,
     payload: *mut std::ffi::c_void,
-) -> mlx_sys::mlx_vector_array 
-where 
+) -> mlx_sys::mlx_vector_array
+where
     F: FnMut(&[Array]) -> Result<Vec<Array>, Exception> + 'a,
 {
     unsafe {

--- a/mlx-rs/src/utils.rs
+++ b/mlx-rs/src/utils.rs
@@ -353,7 +353,9 @@ where
             Ok(result) => new_mlx_vector_array(result),
             Err(exception) => {
                 crate::error::set_last_mlx_closure_error(exception);
-                std::ptr::null_mut()
+                // We cannot return a null ptr here, otherwise vjp will get an invalid memory
+                // reference error
+                mlx_sys::mlx_vector_array_new()
             }
         }
     }


### PR DESCRIPTION
Closes #113 

This PR allow variants of `vjp`, `jvp`, `value_and_grad`, and `grad` to take a closure that returns a `Result`. Support for `compile` to take such closure is NOT included because 

1. https://github.com/ml-explore/mlx-c/issues/34 
2. the compiler cache would cache the result if an empty `mlx_vector_array` were returned to get around https://github.com/ml-explore/mlx-c/issues/34 