### PR TITLE
Change `GenarateBuilder` and `GenerateTestCases` to function-like proc_macro

### DIFF
--- a/mlx-internal-macros/src/lib.rs
+++ b/mlx-internal-macros/src/lib.rs
@@ -3,7 +3,7 @@ use darling::FromMeta;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::punctuated::Punctuated;
-use syn::{parse_macro_input, parse_quote, DeriveInput, FnArg, ItemFn, ItemStruct, Pat};
+use syn::{parse_macro_input, parse_quote, FnArg, ItemEnum, ItemFn, ItemStruct, Pat};
 
 mod generate_builder;
 
@@ -100,9 +100,9 @@ pub fn default_device(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[doc(hidden)]
-#[proc_macro_derive(GenerateDtypeTestCases)]
+#[proc_macro]
 pub fn generate_test_cases(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+    let input = parse_macro_input!(input as ItemEnum);
     let name = &input.ident;
 
     let tests = quote! {
@@ -144,7 +144,10 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
         }
     };
 
-    TokenStream::from(tests)
+    TokenStream::from(quote! {
+        #input
+        #tests
+    })
 }
 
 /// This is for internal use only

--- a/mlx-internal-macros/src/lib.rs
+++ b/mlx-internal-macros/src/lib.rs
@@ -185,9 +185,9 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 ///     If either `generate_build_fn` is `false` or any field is marked as `skip = true`, this
 ///     argument is not required.
 #[doc(hidden)]
-#[proc_macro_derive(GenerateBuilder, attributes(generate_builder, optional))]
-pub fn derive_generate_builder(input: TokenStream) -> TokenStream {
+#[proc_macro]
+pub fn generate_builder(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
-    let builder = generate_builder::expand_generate_builder(&input).unwrap();
+    let builder = generate_builder::expand_generate_builder(input).unwrap();
     TokenStream::from(builder)
 }

--- a/mlx-internal-macros/tests/test_generate_builder.rs
+++ b/mlx-internal-macros/tests/test_generate_builder.rs
@@ -1,13 +1,17 @@
-use mlx_internal_macros::GenerateBuilder;
+use mlx_internal_macros::generate_builder;
 
-#[derive(Debug, Default, GenerateBuilder)]
-struct TestStruct {
-    #[optional(default_value = TestStruct::DEFAULT_OPT_FIELD_1)]
-    opt_field_1: i32,
-    #[optional(default_value = TestStruct::DEFAULT_OPT_FIELD_2)]
-    opt_field_2: i32,
-    mandatory_field_1: i32,
-    mandatory_field_2: i32,
+generate_builder! {
+    /// Test struct for the builder generation.
+    #[derive(Debug)]
+    #[generate_builder(generate_build_fn = true)]
+    struct TestStruct {
+        #[optional(default_value = TestStruct::DEFAULT_OPT_FIELD_1)]
+        opt_field_1: i32,
+        #[optional(default_value = TestStruct::DEFAULT_OPT_FIELD_2)]
+        opt_field_2: i32,
+        mandatory_field_1: i32,
+        mandatory_field_2: i32,
+    }
 }
 
 impl TestStruct {

--- a/mlx-nn/src/activation.rs
+++ b/mlx-nn/src/activation.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 
-use mlx_internal_macros::GenerateBuilder;
+use mlx_internal_macros::generate_builder;
 use mlx_macros::ModuleParameters;
 use mlx_rs::module::{Module, Param};
 use mlx_rs::{
@@ -262,15 +262,17 @@ pub fn hard_swish(x: impl AsRef<Array>) -> Result<Array, Exception> {
     compiled_hard_swish(x.as_ref())
 }
 
-/// Applies the gated linear unit function.
-///
-/// This splits the `axis` dimension of the input into two halves
-/// (`a` and `b`) and applies `a * sigmoid(b)`.
-#[derive(Debug, Clone, ModuleParameters, GenerateBuilder)]
-pub struct Glu {
-    /// The axis to split the input tensor. Default to [`Glu::DEFAULT_AXIS`] if not provided.
-    #[optional(default_value = Glu::DEFAULT_AXIS)]
-    pub axis: i32,
+generate_builder! {
+    /// Applies the gated linear unit function.
+    ///
+    /// This splits the `axis` dimension of the input into two halves
+    /// (`a` and `b`) and applies `a * sigmoid(b)`.
+    #[derive(Debug, Clone, ModuleParameters)]
+    pub struct Glu {
+        /// The axis to split the input tensor. Default to [`Glu::DEFAULT_AXIS`] if not provided.
+        #[optional(default_value = Glu::DEFAULT_AXIS)]
+        pub axis: i32,
+    }
 }
 
 impl Glu {
@@ -355,18 +357,20 @@ impl Module for Relu {
     fn training_mode(&mut self, _: bool) {}
 }
 
-/// Applies the Leaky Rectified Linear Unit.
-///
-/// This is:
-///
-/// ```rust, ignore
-/// maximum(neg_slope * x, x)
-/// ```
-#[derive(Debug, Clone, ModuleParameters, GenerateBuilder)]
-pub struct LeakyRelu {
-    /// The negative slope. Default to [`LeakyReLU::`] if not provided.
-    #[optional(default_value = LeakyRelu::DEFAULT_NEG_SLOPE)]
-    pub neg_slope: f32,
+generate_builder! {
+    /// Applies the Leaky Rectified Linear Unit.
+    ///
+    /// This is:
+    ///
+    /// ```rust, ignore
+    /// maximum(neg_slope * x, x)
+    /// ```
+    #[derive(Debug, Clone, ModuleParameters)]
+    pub struct LeakyRelu {
+        /// The negative slope. Default to [`LeakyReLU::`] if not provided.
+        #[optional(default_value = LeakyRelu::DEFAULT_NEG_SLOPE)]
+        pub neg_slope: f32,
+    }
 }
 
 impl LeakyRelu {
@@ -404,18 +408,20 @@ impl Module for Relu6 {
     fn training_mode(&mut self, _: bool) {}
 }
 
-/// Applies the Softmax function.
-///
-/// This is:
-///
-/// ```rust, ignore
-/// softmax(&x, None, None)
-/// ```
-#[derive(Debug, Clone, ModuleParameters, GenerateBuilder)]
-pub struct Softmax {
-    /// The axis to apply the softmax.
-    #[optional(default_value = Softmax::DEFAULT_AXIS)]
-    pub axis: i32,
+generate_builder! {
+    /// Applies the Softmax function.
+    ///
+    /// This is:
+    ///
+    /// ```rust, ignore
+    /// softmax(&x, None, None)
+    /// ```
+    #[derive(Debug, Clone, ModuleParameters)]
+    pub struct Softmax {
+        /// The axis to apply the softmax.
+        #[optional(default_value = Softmax::DEFAULT_AXIS)]
+        pub axis: i32,
+    }
 }
 
 impl Softmax {
@@ -473,19 +479,21 @@ impl Module for Softsign {
     fn training_mode(&mut self, _: bool) {}
 }
 
-/// Applies the Continuously Differentiable Exponential Linear Unit.
-///
-/// This is:
-///
-/// ```rust, ignore
-/// maximum(x, 0.0).unwrap()
-///     + alpha * (exp(&(minimum(x, 0.0).unwrap() / alpha)) - 1)
-/// ```
-#[derive(Debug, Clone, ModuleParameters, GenerateBuilder)]
-pub struct Celu {
-    /// The alpha value. Default to [`Celu::DEFAULT_ALPHA`] if not provided.
-    #[optional(default_value = Celu::DEFAULT_ALPHA)]
-    pub alpha: f32,
+generate_builder! {
+    /// Applies the Continuously Differentiable Exponential Linear Unit.
+    ///
+    /// This is:
+    ///
+    /// ```rust, ignore
+    /// maximum(x, 0.0).unwrap()
+    ///     + alpha * (exp(&(minimum(x, 0.0).unwrap() / alpha)) - 1)
+    /// ```
+    #[derive(Debug, Clone, ModuleParameters)]
+    pub struct Celu {
+        /// The alpha value. Default to [`Celu::DEFAULT_ALPHA`] if not provided.
+        #[optional(default_value = Celu::DEFAULT_ALPHA)]
+        pub alpha: f32,
+    }
 }
 
 impl Celu {
@@ -523,18 +531,20 @@ impl Module for Silu {
     fn training_mode(&mut self, _: bool) {}
 }
 
-/// Applies the Log Softmax function.
-///
-/// This is:
-///
-/// ```rust, ignore
-/// x - log_sum_exp(x, axis, true)
-/// ```
-#[derive(Debug, Clone, ModuleParameters, GenerateBuilder)]
-pub struct LogSoftmax {
-    /// The axis value. Default to [`LogSoftmax::DEFAULT_AXIS`] if not provided.
-    #[optional(default_value = LogSoftmax::DEFAULT_AXIS)]
-    pub axis: i32,
+generate_builder! {
+    /// Applies the Log Softmax function.
+    ///
+    /// This is:
+    ///
+    /// ```rust, ignore
+    /// x - log_sum_exp(x, axis, true)
+    /// ```
+    #[derive(Debug, Clone, ModuleParameters)]
+    pub struct LogSoftmax {
+        /// The axis value. Default to [`LogSoftmax::DEFAULT_AXIS`] if not provided.
+        #[optional(default_value = LogSoftmax::DEFAULT_AXIS)]
+        pub axis: i32,
+    }
 }
 
 impl LogSoftmax {
@@ -668,18 +678,20 @@ pub enum GeluApprox {
     Fast,
 }
 
-/// Applies the Gaussian Error Linear Units function.
-///
-/// There are three variants:
-///
-/// - `GeluApprox::None`: Uses [`gelu`]. This is the default.
-/// - `GeluApprox::Precise`: Uses [`gelu_approximate`]
-/// - `GeluApprox::Fast`: Uses [`gelu_fast_approximate`]
-#[derive(Debug, Clone, ModuleParameters, GenerateBuilder)]
-pub struct Gelu {
-    /// The approximation to use. Default to `GeluApprox::None` if not provided.
-    #[optional(default_value = GeluApprox::None)]
-    pub approximate: GeluApprox,
+generate_builder! {
+    /// Applies the Gaussian Error Linear Units function.
+    ///
+    /// There are three variants:
+    ///
+    /// - `GeluApprox::None`: Uses [`gelu`]. This is the default.
+    /// - `GeluApprox::Precise`: Uses [`gelu_approximate`]
+    /// - `GeluApprox::Fast`: Uses [`gelu_fast_approximate`]
+    #[derive(Debug, Clone, ModuleParameters)]
+    pub struct Gelu {
+        /// The approximation to use. Default to `GeluApprox::None` if not provided.
+        #[optional(default_value = GeluApprox::None)]
+        pub approximate: GeluApprox,
+    }
 }
 
 impl Module for Gelu {
@@ -730,21 +742,23 @@ impl Module for HardSwish {
     fn training_mode(&mut self, _: bool) {}
 }
 
-/// Applies the Step Activation Function.
-///
-/// This function implements a binary step activation, where the output is set
-/// to 1 if the input is greater than a specified threshold, and 0 otherwise.
-///
-/// This is:
-///
-/// ```rust, ignore
-/// r#where(x.gt(threshold), 1, 0)
-/// ```
-#[derive(Debug, Clone, ModuleParameters, GenerateBuilder)]
-pub struct Step {
-    /// The threshold value. Default to [`Step::DEFAULT_THRESHOLD`] if not provided.
-    #[optional(default_value = Step::DEFAULT_THRESHOLD)]
-    pub threshold: f32,
+generate_builder! {
+    /// Applies the Step Activation Function.
+    ///
+    /// This function implements a binary step activation, where the output is set
+    /// to 1 if the input is greater than a specified threshold, and 0 otherwise.
+    ///
+    /// This is:
+    ///
+    /// ```rust, ignore
+    /// r#where(x.gt(threshold), 1, 0)
+    /// ```
+    #[derive(Debug, Clone, ModuleParameters)]
+    pub struct Step {
+        /// The threshold value. Default to [`Step::DEFAULT_THRESHOLD`] if not provided.
+        #[optional(default_value = Step::DEFAULT_THRESHOLD)]
+        pub threshold: f32,
+    }
 }
 
 impl Step {

--- a/mlx-nn/src/losses.rs
+++ b/mlx-nn/src/losses.rs
@@ -1,6 +1,6 @@
 //! Loss functions
 
-use mlx_internal_macros::GenerateBuilder;
+use mlx_internal_macros::generate_builder;
 use mlx_rs::{
     array,
     error::Exception,
@@ -54,26 +54,28 @@ impl LossReduction {
     }
 }
 
-/// Cross entropy loss function.
-#[derive(Debug, Clone, GenerateBuilder)]
-#[generate_builder(generate_build_fn = false)]
-pub struct CrossEntropy<'a> {
-    /// Weights for each target
-    #[optional(skip = true)]
-    pub weights: Option<&'a Array>,
+generate_builder! {
+    /// Cross entropy loss function.
+    #[derive(Debug, Clone)]
+    #[generate_builder(generate_build_fn = false)]
+    pub struct CrossEntropy<'a> {
+        /// Weights for each target
+        #[optional(skip = true)]
+        pub weights: Option<&'a Array>,
 
-    /// The axis over which to compute softmax. Default to [`CrossEntropy::DEFAULT_AXIS`]
-    #[optional(default_value = CrossEntropy::DEFAULT_AXIS)]
-    pub axis: i32,
+        /// The axis over which to compute softmax. Default to [`CrossEntropy::DEFAULT_AXIS`]
+        #[optional(default_value = CrossEntropy::DEFAULT_AXIS)]
+        pub axis: i32,
 
-    /// The label smoothing factor, range [0, 1). Default to
-    /// [`CrossEntropy::DEFAULT_LABEL_SMOOTHING`]
-    #[optional(default_value = CrossEntropy::DEFAULT_LABEL_SMOOTHING)]
-    pub label_smoothing: f32,
+        /// The label smoothing factor, range [0, 1). Default to
+        /// [`CrossEntropy::DEFAULT_LABEL_SMOOTHING`]
+        #[optional(default_value = CrossEntropy::DEFAULT_LABEL_SMOOTHING)]
+        pub label_smoothing: f32,
 
-    /// Reduction type. Default to [`CrossEntropy::DEFAULT_REDUCTION`]
-    #[optional(default_value = CrossEntropy::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`CrossEntropy::DEFAULT_REDUCTION`]
+        #[optional(default_value = CrossEntropy::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl<'a> CrossEntropyBuilder<'a> {
@@ -173,27 +175,29 @@ impl<'a> CrossEntropy<'a> {
     }
 }
 
-/// Binary cross entropy loss.
-///
-/// By default, this function takes the pre-sigmoid logits, which results in a faster
-/// and more precise loss. For improved numerical stability when `inputs_are_logits` is true,
-/// the loss calculation clips the input probabilities (in log-space) to a minimum value
-/// of `-100`.
-#[derive(Debug, Clone, GenerateBuilder)]
-#[generate_builder(generate_build_fn = false)]
-pub struct BinaryCrossEntropy<'a> {
-    /// Optional weights for each target
-    #[optional(skip = true)]
-    pub weights: Option<&'a Array>,
+generate_builder! {
+    /// Binary cross entropy loss.
+    ///
+    /// By default, this function takes the pre-sigmoid logits, which results in a faster
+    /// and more precise loss. For improved numerical stability when `inputs_are_logits` is true,
+    /// the loss calculation clips the input probabilities (in log-space) to a minimum value
+    /// of `-100`.
+    #[derive(Debug, Clone)]
+    #[generate_builder(generate_build_fn = false)]
+    pub struct BinaryCrossEntropy<'a> {
+        /// Optional weights for each target
+        #[optional(skip = true)]
+        pub weights: Option<&'a Array>,
 
-    /// Whether the inputs are logits. Default to
-    /// [`BinaryCrossEntropy::DEFAULT_INPUTS_ARE_LOGITS`]
-    #[optional]
-    pub inputs_are_logits: bool,
+        /// Whether the inputs are logits. Default to
+        /// [`BinaryCrossEntropy::DEFAULT_INPUTS_ARE_LOGITS`]
+        #[optional]
+        pub inputs_are_logits: bool,
 
-    /// Reduction type. Default to [`BinaryCrossEntropy::DEFAULT_REDUCTION`]
-    #[optional]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`BinaryCrossEntropy::DEFAULT_REDUCTION`]
+        #[optional]
+        pub reduction: LossReduction,
+    }
 }
 
 impl<'a> BinaryCrossEntropyBuilder<'a> {
@@ -273,12 +277,14 @@ impl<'a> BinaryCrossEntropy<'a> {
     }
 }
 
-/// Computes the L1 loss
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct L1Loss {
-    /// Reduction type. Default to [`L1loss::DEFAULT_REDUCTION`]
-    #[optional(default_value = L1Loss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+generate_builder! {
+    /// Computes the L1 loss
+    #[derive(Debug, Clone)]
+    pub struct L1Loss {
+        /// Reduction type. Default to [`L1loss::DEFAULT_REDUCTION`]
+        #[optional(default_value = L1Loss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl L1Loss {
@@ -306,12 +312,14 @@ impl L1Loss {
     }
 }
 
-/// Computes the mean squared error loss.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct MseLoss {
-    /// Reduction type. Default to [`MseLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = MseLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+generate_builder! {
+    /// Computes the mean squared error loss.
+    #[derive(Debug, Clone)]
+    pub struct MseLoss {
+        /// Reduction type. Default to [`MseLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = MseLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl MseLoss {
@@ -339,16 +347,18 @@ impl MseLoss {
     }
 }
 
-/// Computes the negative log likelihood loss.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct NllLoss {
-    /// distribution axis. Default to [`NllLoss::DEFAULT_AXIS`]
-    #[optional(default_value = NllLoss::DEFAULT_AXIS)]
-    pub axis: i32,
+generate_builder! {
+    /// Computes the negative log likelihood loss.
+    #[derive(Debug, Clone)]
+    pub struct NllLoss {
+        /// distribution axis. Default to [`NllLoss::DEFAULT_AXIS`]
+        #[optional(default_value = NllLoss::DEFAULT_AXIS)]
+        pub axis: i32,
 
-    /// Reduction type. Default to [`NllLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = NllLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`NllLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = NllLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl NllLoss {
@@ -379,22 +389,24 @@ impl NllLoss {
     }
 }
 
-/// Compute the negative log likelihood loss for a Gaussian distribution.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct GaussianNllLoss {
-    /// Whether to include the constant term in the loss calculation. Default to
-    /// [`GaussianNllLoss::DEFAULT_FULL`]
-    #[optional(default_value = GaussianNllLoss::DEFAULT_FULL)]
-    pub full: bool,
+generate_builder! {
+    /// Compute the negative log likelihood loss for a Gaussian distribution.
+    #[derive(Debug, Clone)]
+    pub struct GaussianNllLoss {
+        /// Whether to include the constant term in the loss calculation. Default to
+        /// [`GaussianNllLoss::DEFAULT_FULL`]
+        #[optional(default_value = GaussianNllLoss::DEFAULT_FULL)]
+        pub full: bool,
 
-    /// Small positive constant for numerical stability. Default to
-    /// [`GaussianNllLoss::DEFAULT_EPS`]
-    #[optional(default_value = GaussianNllLoss::DEFAULT_EPS)]
-    pub eps: f32,
+        /// Small positive constant for numerical stability. Default to
+        /// [`GaussianNllLoss::DEFAULT_EPS`]
+        #[optional(default_value = GaussianNllLoss::DEFAULT_EPS)]
+        pub eps: f32,
 
-    /// Reduction type. Default to [`GaussianNllLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = GaussianNllLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`GaussianNllLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = GaussianNllLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl GaussianNllLoss {
@@ -443,22 +455,24 @@ impl GaussianNllLoss {
     }
 }
 
-/// Compute the Kullback-Leibler divergence loss.
-///
-/// Computes the following when the `reduction` is `LossReduction::None`:
-///
-/// ```rust, ignore
-/// sum(exp(targets) * (targets - inputs), axis, None)
-/// ```
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct KlDivLoss {
-    /// The distribution axis. Default to [`KlDivLoss::DEFAULT_AXIS`]
-    #[optional(default_value = KlDivLoss::DEFAULT_AXIS)]
-    pub axis: i32,
+generate_builder! {
+    /// Compute the Kullback-Leibler divergence loss.
+    ///
+    /// Computes the following when the `reduction` is `LossReduction::None`:
+    ///
+    /// ```rust, ignore
+    /// sum(exp(targets) * (targets - inputs), axis, None)
+    /// ```
+    #[derive(Debug, Clone)]
+    pub struct KlDivLoss {
+        /// The distribution axis. Default to [`KlDivLoss::DEFAULT_AXIS`]
+        #[optional(default_value = KlDivLoss::DEFAULT_AXIS)]
+        pub axis: i32,
 
-    /// Reduction type. Default to [`KlDivLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = KlDivLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`KlDivLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = KlDivLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl KlDivLoss {
@@ -493,21 +507,23 @@ impl KlDivLoss {
     }
 }
 
-/// Computes the smooth L1 loss.
-///
-/// The smooth L1 loss is a variant of the L1 loss which replaces the absolute
-/// difference with a squared difference when the absolute difference is less
-/// than `beta`.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct SmoothL1Loss {
-    /// The threshold after which the loss changes from the squared to the absolute difference.
-    /// Default to [`SmoothL1Loss::DEFAULT_BETA`]
-    #[optional(default_value = SmoothL1Loss::DEFAULT_BETA)]
-    pub beta: f32,
+generate_builder! {
+    /// Computes the smooth L1 loss.
+    ///
+    /// The smooth L1 loss is a variant of the L1 loss which replaces the absolute
+    /// difference with a squared difference when the absolute difference is less
+    /// than `beta`.
+    #[derive(Debug, Clone)]
+    pub struct SmoothL1Loss {
+        /// The threshold after which the loss changes from the squared to the absolute difference.
+        /// Default to [`SmoothL1Loss::DEFAULT_BETA`]
+        #[optional(default_value = SmoothL1Loss::DEFAULT_BETA)]
+        pub beta: f32,
 
-    /// Reduction type. Default to [`SmoothL1Loss::DEFAULT_REDUCTION`]
-    #[optional(default_value = SmoothL1Loss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`SmoothL1Loss::DEFAULT_REDUCTION`]
+        #[optional(default_value = SmoothL1Loss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl SmoothL1Loss {
@@ -544,29 +560,31 @@ impl SmoothL1Loss {
     }
 }
 
-/// Computes the triplet loss for a set of anchor, positive, and negative samples. Margin is
-/// represented with alpha in the math section.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct TripletLoss {
-    /// Distribution axis. Default to [`TripletLoss::DEFAULT_AXIS`]
-    #[optional(default_value = TripletLoss::DEFAULT_AXIS)]
-    pub axis: i32,
+generate_builder! {
+    /// Computes the triplet loss for a set of anchor, positive, and negative samples. Margin is
+    /// represented with alpha in the math section.
+    #[derive(Debug, Clone)]
+    pub struct TripletLoss {
+        /// Distribution axis. Default to [`TripletLoss::DEFAULT_AXIS`]
+        #[optional(default_value = TripletLoss::DEFAULT_AXIS)]
+        pub axis: i32,
 
-    /// The norm degree for pairwise distance. Default to [`TripletLoss::DEFAULT_P`]
-    #[optional(default_value = TripletLoss::DEFAULT_P)]
-    pub p: f32,
+        /// The norm degree for pairwise distance. Default to [`TripletLoss::DEFAULT_P`]
+        #[optional(default_value = TripletLoss::DEFAULT_P)]
+        pub p: f32,
 
-    /// Margin for the triplet loss. Default to [`TripletLoss::DEFAULT_MARGIN`]
-    #[optional(default_value = TripletLoss::DEFAULT_MARGIN)]
-    pub margin: f32,
+        /// Margin for the triplet loss. Default to [`TripletLoss::DEFAULT_MARGIN`]
+        #[optional(default_value = TripletLoss::DEFAULT_MARGIN)]
+        pub margin: f32,
 
-    /// Small positive constant for numerical stability. Default to [`TripletLoss::DEFAULT_EPS`]
-    #[optional(default_value = TripletLoss::DEFAULT_EPS)]
-    pub eps: f32,
+        /// Small positive constant for numerical stability. Default to [`TripletLoss::DEFAULT_EPS`]
+        #[optional(default_value = TripletLoss::DEFAULT_EPS)]
+        pub eps: f32,
 
-    /// Reduction type. Default to [`TripletLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = TripletLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`TripletLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = TripletLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl TripletLoss {
@@ -627,12 +645,14 @@ impl TripletLoss {
     }
 }
 
-/// Compute the hinge loss.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct HingeLoss {
-    /// Reduction type. Default to [`HingeLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = HingeLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+generate_builder! {
+    /// Compute the hinge loss.
+    #[derive(Debug, Clone)]
+    pub struct HingeLoss {
+        /// Reduction type. Default to [`HingeLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = HingeLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl HingeLoss {
@@ -661,17 +681,19 @@ impl HingeLoss {
     }
 }
 
-/// Compute the Huber loss.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct HuberLoss {
-    /// The threshold at which to change between L1 and L2 loss. Default to
-    /// [`HuberLoss::DEFAULT_DELTA`]
-    #[optional(default_value = HuberLoss::DEFAULT_DELTA)]
-    pub delta: f32,
+generate_builder! {
+    /// Compute the Huber loss.
+    #[derive(Debug, Clone)]
+    pub struct HuberLoss {
+        /// The threshold at which to change between L1 and L2 loss. Default to
+        /// [`HuberLoss::DEFAULT_DELTA`]
+        #[optional(default_value = HuberLoss::DEFAULT_DELTA)]
+        pub delta: f32,
 
-    /// Reduction type. Default to [`HuberLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = HuberLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`HuberLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = HuberLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl HuberLoss {
@@ -708,16 +730,18 @@ impl HuberLoss {
     }
 }
 
-/// Computes the log cosh loss between inputs and targets.
-///
-/// Logcosh acts like L2 loss for small errors, ensuring stable gradients,
-/// and like the L1 loss for large errors, reducing sensitivity to outliers. This
-/// dual behavior offers a balanced, robust approach for regression tasks.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct LogCoshLoss {
-    /// Reduction type. Default to [`LogCoshLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = LogCoshLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+generate_builder! {
+    /// Computes the log cosh loss between inputs and targets.
+    ///
+    /// Logcosh acts like L2 loss for small errors, ensuring stable gradients,
+    /// and like the L1 loss for large errors, reducing sensitivity to outliers. This
+    /// dual behavior offers a balanced, robust approach for regression tasks.
+    #[derive(Debug, Clone)]
+    pub struct LogCoshLoss {
+        /// Reduction type. Default to [`LogCoshLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = LogCoshLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl LogCoshLoss {
@@ -746,21 +770,23 @@ impl LogCoshLoss {
     }
 }
 
-/// Computes the cosine similarity loss.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct CosineSimilarityLoss {
-    /// Embedding axis. Default to [`CosineSimilarityLoss::DEFAULT_AXIS`]
-    #[optional(default_value = CosineSimilarityLoss::DEFAULT_AXIS)]
-    pub axis: i32,
+generate_builder! {
+    /// Computes the cosine similarity loss.
+    #[derive(Debug, Clone)]
+    pub struct CosineSimilarityLoss {
+        /// Embedding axis. Default to [`CosineSimilarityLoss::DEFAULT_AXIS`]
+        #[optional(default_value = CosineSimilarityLoss::DEFAULT_AXIS)]
+        pub axis: i32,
 
-    /// minimum value of the denominator used for numerical stability. Default to
-    /// [`CosineSimilarityLoss::DEFAULT_EPS`]
-    #[optional(default_value = CosineSimilarityLoss::DEFAULT_EPS)]
-    pub eps: f32,
+        /// minimum value of the denominator used for numerical stability. Default to
+        /// [`CosineSimilarityLoss::DEFAULT_EPS`]
+        #[optional(default_value = CosineSimilarityLoss::DEFAULT_EPS)]
+        pub eps: f32,
 
-    /// Reduction type. Default to [`CosineSimilarityLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = CosineSimilarityLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`CosineSimilarityLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = CosineSimilarityLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl CosineSimilarityLoss {
@@ -805,17 +831,19 @@ impl CosineSimilarityLoss {
     }
 }
 
-/// Computes the margin ranking loss.
-#[derive(Debug, Clone, GenerateBuilder)]
-pub struct MarginRankingLoss {
-    /// The margin by which the scores should be separated. Default to
-    /// [`MarginRankingLoss::DEFAULT_MARGIN`]
-    #[optional(default_value = MarginRankingLoss::DEFAULT_MARGIN)]
-    pub margin: f32,
+generate_builder! {
+    /// Computes the margin ranking loss.
+    #[derive(Debug, Clone)]
+    pub struct MarginRankingLoss {
+        /// The margin by which the scores should be separated. Default to
+        /// [`MarginRankingLoss::DEFAULT_MARGIN`]
+        #[optional(default_value = MarginRankingLoss::DEFAULT_MARGIN)]
+        pub margin: f32,
 
-    /// Reduction type. Default to [`MarginRankingLoss::DEFAULT_REDUCTION`]
-    #[optional(default_value = MarginRankingLoss::DEFAULT_REDUCTION)]
-    pub reduction: LossReduction,
+        /// Reduction type. Default to [`MarginRankingLoss::DEFAULT_REDUCTION`]
+        #[optional(default_value = MarginRankingLoss::DEFAULT_REDUCTION)]
+        pub reduction: LossReduction,
+    }
 }
 
 impl MarginRankingLoss {

--- a/mlx-nn/src/optimizers/rmsprop.rs
+++ b/mlx-nn/src/optimizers/rmsprop.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use mlx_internal_macros::GenerateBuilder;
+use mlx_internal_macros::generate_builder;
 use mlx_rs::{
     array,
     ops::{sqrt, square},
@@ -11,27 +11,29 @@ use crate::{error::RmsPropBuildError, utils::get_mut_or_insert_with};
 
 use super::*;
 
-/// The RMSprop optimizer [1].
-///
-/// [1]: Tieleman, T. and Hinton, G. 2012. Lecture 6.5-rmsprop, coursera: Neural networks for
-///     machine learning
-#[derive(Debug, Clone, GenerateBuilder)]
-#[generate_builder(generate_build_fn = false)]
-pub struct RmsProp {
-    /// Learning rate
-    pub lr: f32,
+generate_builder! {
+    /// The RMSprop optimizer [1].
+    ///
+    /// [1]: Tieleman, T. and Hinton, G. 2012. Lecture 6.5-rmsprop, coursera: Neural networks for
+    ///     machine learning
+    #[derive(Debug, Clone)]
+    #[generate_builder(generate_build_fn = false)]
+    pub struct RmsProp {
+        /// Learning rate
+        pub lr: f32,
 
-    /// The smoothing constant. Default to [`RmsProp::DEFAULT_ALPHA`] if not specified.
-    #[optional]
-    pub alpha: f32,
+        /// The smoothing constant. Default to [`RmsProp::DEFAULT_ALPHA`] if not specified.
+        #[optional]
+        pub alpha: f32,
 
-    /// The epsilon added to the denominator to improve numerical stability. Default to
-    /// [`RmsProp::DEFAULT_EPSILON`] if not specified.
-    #[optional]
-    pub epsilon: f32,
+        /// The epsilon added to the denominator to improve numerical stability. Default to
+        /// [`RmsProp::DEFAULT_EPSILON`] if not specified.
+        #[optional]
+        pub epsilon: f32,
 
-    /// Inner state
-    pub state: OptimizerState,
+        /// Inner state
+        pub state: OptimizerState,
+    }
 }
 
 impl RmsPropBuilder {

--- a/mlx-nn/src/optimizers/sgd.rs
+++ b/mlx-nn/src/optimizers/sgd.rs
@@ -1,37 +1,39 @@
 use std::rc::Rc;
 
-use mlx_internal_macros::GenerateBuilder;
+use mlx_internal_macros::generate_builder;
 use mlx_rs::{array, Array};
 
 use crate::utils::get_mut_or_insert_with;
 
 use super::*;
 
-/// Stochastic gradient descent optimizer.
-#[derive(Debug, Clone, GenerateBuilder)]
-#[generate_builder(generate_build_fn = false)]
-pub struct Sgd {
-    /// Learning rate
-    pub lr: f32,
+generate_builder! {
+    /// Stochastic gradient descent optimizer.
+    #[derive(Debug, Clone)]
+    #[generate_builder(generate_build_fn = false)]
+    pub struct Sgd {
+        /// Learning rate
+        pub lr: f32,
 
-    /// Momentum strength. Default to [`Sgd::DEFAULT_MOMENTUM`] if not specified.
-    #[optional]
-    pub momentum: f32,
+        /// Momentum strength. Default to [`Sgd::DEFAULT_MOMENTUM`] if not specified.
+        #[optional]
+        pub momentum: f32,
 
-    /// Weight decay (L2 penalty). Default to [`Sgd::DEFAULT_WEIGHT_DECAY`] if not specified.
-    #[optional]
-    pub weight_decay: f32,
+        /// Weight decay (L2 penalty). Default to [`Sgd::DEFAULT_WEIGHT_DECAY`] if not specified.
+        #[optional]
+        pub weight_decay: f32,
 
-    /// Dampening for momentum. Default to [`Sgd::DEFAULT_DAMPENING`] if not specified.
-    #[optional]
-    pub dampening: f32,
+        /// Dampening for momentum. Default to [`Sgd::DEFAULT_DAMPENING`] if not specified.
+        #[optional]
+        pub dampening: f32,
 
-    /// Enables nesterov momentum. Default to [`Sgd::DEFAULT_NESTEROV`] if not specified.
-    #[optional]
-    pub nesterov: bool,
+        /// Enables nesterov momentum. Default to [`Sgd::DEFAULT_NESTEROV`] if not specified.
+        #[optional]
+        pub nesterov: bool,
 
-    /// Inner state
-    pub state: OptimizerState,
+        /// Inner state
+        pub state: OptimizerState,
+    }
 }
 
 impl SgdBuilder {

--- a/mlx-rs/src/dtype.rs
+++ b/mlx-rs/src/dtype.rs
@@ -1,33 +1,34 @@
-use mlx_internal_macros::GenerateDtypeTestCases;
+use mlx_internal_macros::generate_test_cases;
 use strum::EnumIter;
 
-/// Array element type
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    num_enum::IntoPrimitive,
-    num_enum::TryFromPrimitive,
-    EnumIter,
-    GenerateDtypeTestCases,
-)]
-#[repr(u32)]
-pub enum Dtype {
-    Bool = mlx_sys::mlx_array_dtype__MLX_BOOL,
-    Uint8 = mlx_sys::mlx_array_dtype__MLX_UINT8,
-    Uint16 = mlx_sys::mlx_array_dtype__MLX_UINT16,
-    Uint32 = mlx_sys::mlx_array_dtype__MLX_UINT32,
-    Uint64 = mlx_sys::mlx_array_dtype__MLX_UINT64,
-    Int8 = mlx_sys::mlx_array_dtype__MLX_INT8,
-    Int16 = mlx_sys::mlx_array_dtype__MLX_INT16,
-    Int32 = mlx_sys::mlx_array_dtype__MLX_INT32,
-    Int64 = mlx_sys::mlx_array_dtype__MLX_INT64,
-    Float16 = mlx_sys::mlx_array_dtype__MLX_FLOAT16,
-    Float32 = mlx_sys::mlx_array_dtype__MLX_FLOAT32,
-    Bfloat16 = mlx_sys::mlx_array_dtype__MLX_BFLOAT16,
-    Complex64 = mlx_sys::mlx_array_dtype__MLX_COMPLEX64,
+generate_test_cases! {
+    /// Array element type
+    #[derive(
+        Debug,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        num_enum::IntoPrimitive,
+        num_enum::TryFromPrimitive,
+        EnumIter,
+    )]
+    #[repr(u32)]
+    pub enum Dtype {
+        Bool = mlx_sys::mlx_array_dtype__MLX_BOOL,
+        Uint8 = mlx_sys::mlx_array_dtype__MLX_UINT8,
+        Uint16 = mlx_sys::mlx_array_dtype__MLX_UINT16,
+        Uint32 = mlx_sys::mlx_array_dtype__MLX_UINT32,
+        Uint64 = mlx_sys::mlx_array_dtype__MLX_UINT64,
+        Int8 = mlx_sys::mlx_array_dtype__MLX_INT8,
+        Int16 = mlx_sys::mlx_array_dtype__MLX_INT16,
+        Int32 = mlx_sys::mlx_array_dtype__MLX_INT32,
+        Int64 = mlx_sys::mlx_array_dtype__MLX_INT64,
+        Float16 = mlx_sys::mlx_array_dtype__MLX_FLOAT16,
+        Float32 = mlx_sys::mlx_array_dtype__MLX_FLOAT32,
+        Bfloat16 = mlx_sys::mlx_array_dtype__MLX_BFLOAT16,
+        Complex64 = mlx_sys::mlx_array_dtype__MLX_COMPLEX64,
+    }
 }
 
 impl Dtype {


### PR DESCRIPTION
I think a derive macro generally implies implementation of a trait of the same name, which is not true in the case of `GenerateBuilder` and `GenerateTestCases`. This PR changes them to function-like proc_macro to avoid such confusion. Functional changes include:

1. The `generate_builder!()` macro now checks if the struct it's applied to derives Default and triggers a panic if it does.