### PR TITLE
Allow indexing with `&Array`

### DIFF
--- a/mlx-rs/src/ops/indexing/mod.rs
+++ b/mlx-rs/src/ops/indexing/mod.rs
@@ -293,21 +293,6 @@ pub trait IndexMutOp<Idx, Val> {
     }
 }
 
-// /// A marker trait for range bounds that are `i32`.
-// pub trait IndexBounds: RangeBounds<i32> {}
-
-// impl IndexBounds for std::ops::Range<i32> {}
-
-// impl IndexBounds for std::ops::RangeFrom<i32> {}
-
-// // impl IndexBounds for std::ops::RangeFull {}
-
-// impl IndexBounds for std::ops::RangeInclusive<i32> {}
-
-// impl IndexBounds for std::ops::RangeTo<i32> {}
-
-// impl IndexBounds for std::ops::RangeToInclusive<i32> {}
-
 /// Trait for custom indexing operations.
 pub trait ArrayIndex<'a> {
     /// `mlx` allows out of bounds indexing.


### PR DESCRIPTION
This PR adds support for using `&Array` as index. Other changes include removing the marker trait `IndexBounds` and replaced with impls with explicit types instead of `T: IndexBounds`