### PR TITLE
Implement `AdaGrad` optimizer

### DIFF
--- a/examples/mnist/src/main.rs
+++ b/examples/mnist/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut loss_sum = array!(0.0);
         for (x, y) in loader.clone() {
             let (loss, grad) = loss_and_grad_fn(&mut model, (&x, &y))?;
-            optimizer.update(&mut model, grad);
+            optimizer.apply(&mut model, grad).unwrap();
             eval_params(model.parameters())?;
 
             loss_sum += loss;

--- a/mlx-internal-macros/src/generate_builder.rs
+++ b/mlx-internal-macros/src/generate_builder.rs
@@ -94,12 +94,9 @@ pub(crate) fn expand_generate_builder(
                     if generate_build_fn {
                         return Err("Type is not allowed when build function is generated".into());
                     }
-                    let ty = Type::Path(TypePath {
-                        qself: None,
-                        path,
-                    });
+                    let ty = Type::Path(TypePath { qself: None, path });
                     optional_field_types.push(ty)
-                },
+                }
                 None => optional_field_types.push(field.ty.clone()),
             }
 

--- a/mlx-internal-macros/src/generate_builder.rs
+++ b/mlx-internal-macros/src/generate_builder.rs
@@ -1,7 +1,7 @@
 use darling::FromAttributes;
 use proc_macro2::TokenTree;
 use quote::quote;
-use syn::{Attribute, Ident, ItemStruct, Path};
+use syn::{Attribute, Ident, ItemStruct, Path, Type, TypePath};
 
 #[derive(Debug, FromAttributes)]
 #[darling(attributes(generate_builder))]
@@ -14,6 +14,7 @@ struct StructAttr {
 struct FieldAttr {
     default_value: Option<Path>,
     skip: Option<bool>,
+    ty: Option<Path>,
 }
 
 fn struct_attr_derive_default(attrs: &[Attribute]) -> bool {
@@ -87,7 +88,21 @@ pub(crate) fn expand_generate_builder(
                     .as_ref()
                     .ok_or("Only named fields are supported")?,
             );
-            optional_field_types.push(&field.ty);
+
+            match field_attr.ty {
+                Some(path) => {
+                    if generate_build_fn {
+                        return Err("Type is not allowed when build function is generated".into());
+                    }
+                    let ty = Type::Path(TypePath {
+                        qself: None,
+                        path,
+                    });
+                    optional_field_types.push(ty)
+                },
+                None => optional_field_types.push(field.ty.clone()),
+            }
+
             if generate_build_fn {
                 optional_field_defaults.push(field_attr.default_value);
             }

--- a/mlx-internal-macros/src/lib.rs
+++ b/mlx-internal-macros/src/lib.rs
@@ -155,7 +155,7 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 /// The struct that this macro is applied to should NOT derive the `Default` trait.
 ///
 /// # Struct Attribute(s)
-/// 
+///
 /// This macro takes the following attributes:
 ///
 /// - `generate_builder`: This attribute should be applied on the struct.
@@ -171,7 +171,7 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 ///        will implement the `Default` trait for the struct.
 ///
 /// # Field Attribute(s)
-/// 
+///
 /// - `optional`: This attribute should be applied on the field. It indicates that the field is
 ///   optional. Behaviour of the generated builder struct depends on the argument of this attribute.
 ///   
@@ -184,7 +184,7 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 ///
 ///     The `build` function cannot be generated if any field is marked as `skip = true`, and an
 ///     error will be shown in that case.
-/// 
+///
 ///   - `ty = <Path>`: If set, the optional field in the builder will be of the type specified by
 ///     this argument. This is useful when the field is optional and the type is not the same as the
 ///     original field type.
@@ -194,14 +194,14 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 ///     (something that is interpreted as a `syn::Path`) to a constant or an enum variant.
 ///
 /// # Generate Build Function
-/// 
+///
 /// The following conditions have to be met to generate the `<Type>Builder::build` function and
 /// `<Type>::new` function:
-/// 
+///
 ///   1. `generate_build_fn = true` in the `generate_builder` attribute.
 ///   2. No optional field is marked as `skip = true`.
 ///   3. No optional field is marked as `ty = <Path>`.
-/// 
+///
 /// Otherwise, the user must implement the `<Type>Builder::build` function and `<Type>::new`
 /// manually.
 #[doc(hidden)]

--- a/mlx-internal-macros/src/lib.rs
+++ b/mlx-internal-macros/src/lib.rs
@@ -154,11 +154,13 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 ///
 /// The struct that this macro is applied to should NOT derive the `Default` trait.
 ///
+/// # Struct Attribute(s)
+/// 
 /// This macro takes the following attributes:
 ///
 /// - `generate_builder`: This attribute should be applied on the struct.
 ///
-///   ## Arguments
+///   Arguments
 ///
 ///   - `generate_build_fn = <bool>`: It defaults to `true` if not specified. If `true`, it will:
 ///     1. generate a `<Struct>Builder::build` function that takes the mandatory fields as arguments
@@ -168,10 +170,12 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 ///        `<Struct>Builder::new().build(...)`. Additionally, if there is NO mandatory field, it
 ///        will implement the `Default` trait for the struct.
 ///
+/// # Field Attribute(s)
+/// 
 /// - `optional`: This attribute should be applied on the field. It indicates that the field is
 ///   optional. Behaviour of the generated builder struct depends on the argument of this attribute.
 ///   
-///   ## Arguments
+///   Arguments
 ///   
 ///   - `skip = <bool>`: Default `false`. If `true`, the macro will NOT generate a setter for this
 ///     field in the builder struct. It will also NOT wrap the field in an `Option` in the struct,
@@ -180,13 +184,26 @@ pub fn generate_test_cases(input: TokenStream) -> TokenStream {
 ///
 ///     The `build` function cannot be generated if any field is marked as `skip = true`, and an
 ///     error will be shown in that case.
+/// 
+///   - `ty = <Path>`: If set, the optional field in the builder will be of the type specified by
+///     this argument. This is useful when the field is optional and the type is not the same as the
+///     original field type.
 ///
-///   - `default_value = <Path>`: This argument is required if no field is marked as `skip = true`.
-///     It specifies the default value for the field. The value should be a `Path` (something that
-///     is interpreted as a `syn::Path`) to a constant or an enum variant.
+///   - `default_value = <Path>`: This argument is required if a default build function were to be
+///     generated. It specifies the default value for the field. The value should be a `Path`
+///     (something that is interpreted as a `syn::Path`) to a constant or an enum variant.
 ///
-///     If either `generate_build_fn` is `false` or any field is marked as `skip = true`, this
-///     argument is not required.
+/// # Generate Build Function
+/// 
+/// The following conditions have to be met to generate the `<Type>Builder::build` function and
+/// `<Type>::new` function:
+/// 
+///   1. `generate_build_fn = true` in the `generate_builder` attribute.
+///   2. No optional field is marked as `skip = true`.
+///   3. No optional field is marked as `ty = <Path>`.
+/// 
+/// Otherwise, the user must implement the `<Type>Builder::build` function and `<Type>::new`
+/// manually.
 #[doc(hidden)]
 #[proc_macro]
 pub fn generate_builder(input: TokenStream) -> TokenStream {

--- a/mlx-nn/src/embedding.rs
+++ b/mlx-nn/src/embedding.rs
@@ -68,13 +68,13 @@ mod tests {
         assert_eq!(a.dtype(), mlx_rs::Dtype::Int32);
         float_eq!(
             a.mean(None, None).unwrap().item::<f32>(),
-            4.60546875,
-            abs <= 0.09210937500000001
+            4.605_468_8,
+            abs <= 0.092_109_375
         );
         float_eq!(
             a.sum(None, None).unwrap().item::<f32>(),
             2358.0,
-            abs <= 47.160000000000004
+            abs <= 47.16
         );
 
         let result = Embedding::new(10, 8).unwrap().forward(&a).unwrap();
@@ -82,13 +82,13 @@ mod tests {
         assert_eq!(result.dtype(), mlx_rs::Dtype::Float32);
         float_eq!(
             result.mean(None, None).unwrap().item::<f32>(),
-            -0.0011973462533205748,
-            abs <= 2.3946925066411497e-05
+            -0.001_197_346_3,
+            abs <= 2.394_692_5e-5
         );
         float_eq!(
             result.sum(None, None).unwrap().item::<f32>(),
-            -4.904330253601074,
-            abs <= 0.0980866050720215
+            -4.904_330_3,
+            abs <= 0.098_086_6
         );
     }
 }

--- a/mlx-nn/src/optimizers/adagrad.rs
+++ b/mlx-nn/src/optimizers/adagrad.rs
@@ -1,0 +1,70 @@
+use std::rc::Rc;
+
+use mlx_internal_macros::generate_builder;
+use mlx_rs::{array, error::Exception, ops::square, Array};
+
+use crate::utils::get_mut_or_insert_with;
+
+use super::{Optimizer, OptimizerState};
+
+generate_builder! {
+    /// The Adagrad optimizer.
+    /// 
+    /// Please refer to the original paper for more details:
+    /// 
+    /// [1]: Duchi, J., Hazan, E. and Singer, Y., 2011. Adaptive subgradient methods for online
+    ///     learning and stochastic optimization. JMLR 2011.
+    #[derive(Debug, Clone)]
+    #[generate_builder(generate_build_fn = false)]
+    pub struct AdaGrad {
+        /// Learning rate
+        pub lr: Array,
+
+        /// The epsilon added to the denominator to improve numerical stability. 
+        #[optional(ty = f32)]
+        pub eps: Array,
+
+        /// Inner state
+        pub state: OptimizerState,
+    }
+}
+
+impl AdaGradBuilder {
+    /// Builds a new [`AdaGrad`].
+    pub fn build(self, lr: f32) -> AdaGrad {
+        let eps = array!(self.eps.unwrap_or(AdaGrad::DEFAULT_EPS));
+
+        AdaGrad {
+            lr: array!(lr),
+            eps,
+            state: OptimizerState::new(),
+        }
+    }
+}
+
+impl AdaGrad {
+    /// Default value for `eps`.
+    pub const DEFAULT_EPS: f32 = 1e-8;
+
+    /// Creates a new AdaGrad optimizer with all optional parameters set to their default values.
+    pub fn new(lr: f32) -> AdaGrad {
+        Self::builder().build(lr)
+    }
+}
+
+impl Optimizer for AdaGrad {
+    fn update_single(&mut self, key: Rc<str>, gradient: Array, parameter: &mut Array) -> Result<(), Exception> {
+        let state = get_mut_or_insert_with(&mut self.state, &key, || array!(0.0));
+
+        let v = state.add(square(&gradient))?;
+
+        let num = self.lr.multiply(&gradient)?;
+        let den = v.sqrt().add(&self.eps)?;
+        let new_param = parameter.subtract(num.divide(&den)?)?;
+
+        *state = v;
+        *parameter = new_param;
+
+        Ok(())
+    }
+}

--- a/mlx-nn/src/optimizers/adagrad.rs
+++ b/mlx-nn/src/optimizers/adagrad.rs
@@ -5,7 +5,7 @@ use mlx_rs::{array, error::Exception, ops::square, Array};
 
 use crate::utils::get_mut_or_insert_with;
 
-use super::{Optimizer, OptimizerState};
+use super::*;
 
 generate_builder! {
     /// The Adagrad optimizer.
@@ -54,12 +54,12 @@ impl AdaGrad {
 }
 
 impl Optimizer for AdaGrad {
-    fn update_single(&mut self, key: Rc<str>, gradient: Array, parameter: &mut Array) -> Result<(), Exception> {
-        let state = get_mut_or_insert_with(&mut self.state, &key, || array!(0.0));
+    fn apply_single(&mut self, key: &Rc<str>, gradient: &Array, parameter: &mut Array) -> Result<(), Exception> {
+        let state = get_mut_or_insert_with(&mut self.state, key, || array!(0.0));
 
-        let v = state.add(square(&gradient))?;
+        let v = state.add(square(gradient))?;
 
-        let num = self.lr.multiply(&gradient)?;
+        let num = self.lr.multiply(gradient)?;
         let den = v.sqrt().add(&self.eps)?;
         let new_param = parameter.subtract(num.divide(&den)?)?;
 
@@ -67,5 +67,50 @@ impl Optimizer for AdaGrad {
         *parameter = new_param;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mlx_macros::ModuleParameters;
+    use mlx_rs::module::Param;
+    use mlx_rs::{assert_array_eq, Dtype};
+
+    use super::optim_test_util::*;
+    use super::*;
+
+    #[derive(Debug, ModuleParameters)]
+    struct Model {
+        #[param]
+        a: Param<Array>,
+    }
+
+    // This unit test is adapted from the swift binding unit test `testAdaGrad` in
+    #[test]
+    fn test_adagrad() {
+        mlx_rs::random::seed(958);
+        let a = mlx_rs::random::normal::<f32>(&[4, 3], None, None, None).unwrap();
+        assert_eq!(a.shape(), &[4, 3]);
+        assert_eq!(a.dtype(), Dtype::Float32);
+        assert_array_eq!(a.mean(None, None).unwrap(), array!(-0.04584333300590515), ATOL);
+        assert_array_eq!(a.sum(None, None).unwrap(), array!(-0.5501199960708618), ATOL);
+
+        let a_grad = mlx_rs::random::normal::<f32>(&[4, 3], None, None, None).unwrap();
+        assert_eq!(a_grad.shape(), &[4, 3]);
+        assert_eq!(a_grad.dtype(), Dtype::Float32);
+        assert_array_eq!(a_grad.mean(None, None).unwrap(), array!(0.23250393569469452), ATOL);
+        assert_array_eq!(a_grad.sum(None, None).unwrap(), array!(2.7900471687316895), ATOL);
+
+        let mut a_model = Model { a: Param::new(a.clone()) };
+        let mut a_grad_params = FlattenedModuleParam::new();
+        a_grad_params.insert("a".into(), a_grad.clone());
+
+        let mut optimizer = AdaGrad::new(0.1);
+
+        optimizer.apply(&mut a_model, a_grad_params).unwrap();
+        assert_eq!(a_model.a.shape(), &[4, 3]);
+        assert_eq!(a_model.a.dtype(), Dtype::Float32);
+        assert_array_eq!(a_model.a.mean(None, None).unwrap(), array!(-0.06250998377799988), ATOL);
+        assert_array_eq!(a_model.a.sum(None, None).unwrap(), array!(-0.7501198053359985), ATOL);
     }
 }

--- a/mlx-nn/src/optimizers/adagrad.rs
+++ b/mlx-nn/src/optimizers/adagrad.rs
@@ -9,9 +9,9 @@ use super::*;
 
 generate_builder! {
     /// The Adagrad optimizer.
-    /// 
+    ///
     /// Please refer to the original paper for more details:
-    /// 
+    ///
     /// [1]: Duchi, J., Hazan, E. and Singer, Y., 2011. Adaptive subgradient methods for online
     ///     learning and stochastic optimization. JMLR 2011.
     #[derive(Debug, Clone)]
@@ -54,7 +54,12 @@ impl AdaGrad {
 }
 
 impl Optimizer for AdaGrad {
-    fn apply_single(&mut self, key: &Rc<str>, gradient: &Array, parameter: &mut Array) -> Result<(), Exception> {
+    fn apply_single(
+        &mut self,
+        key: &Rc<str>,
+        gradient: &Array,
+        parameter: &mut Array,
+    ) -> Result<(), Exception> {
         let state = get_mut_or_insert_with(&mut self.state, key, || array!(0.0));
 
         let v = state.add(square(gradient))?;
@@ -92,16 +97,18 @@ mod tests {
         let a = mlx_rs::random::normal::<f32>(&[4, 3], None, None, None).unwrap();
         assert_eq!(a.shape(), &[4, 3]);
         assert_eq!(a.dtype(), Dtype::Float32);
-        assert_array_eq!(a.mean(None, None).unwrap(), array!(-0.04584333300590515), ATOL);
-        assert_array_eq!(a.sum(None, None).unwrap(), array!(-0.5501199960708618), ATOL);
+        assert_array_eq!(a.mean(None, None).unwrap(), array!(-0.045_843_333), ATOL);
+        assert_array_eq!(a.sum(None, None).unwrap(), array!(-0.550_12), ATOL);
 
         let a_grad = mlx_rs::random::normal::<f32>(&[4, 3], None, None, None).unwrap();
         assert_eq!(a_grad.shape(), &[4, 3]);
         assert_eq!(a_grad.dtype(), Dtype::Float32);
-        assert_array_eq!(a_grad.mean(None, None).unwrap(), array!(0.23250393569469452), ATOL);
-        assert_array_eq!(a_grad.sum(None, None).unwrap(), array!(2.7900471687316895), ATOL);
+        assert_array_eq!(a_grad.mean(None, None).unwrap(), array!(0.232_503_94), ATOL);
+        assert_array_eq!(a_grad.sum(None, None).unwrap(), array!(2.790_047_2), ATOL);
 
-        let mut a_model = Model { a: Param::new(a.clone()) };
+        let mut a_model = Model {
+            a: Param::new(a.clone()),
+        };
         let mut a_grad_params = FlattenedModuleParam::new();
         a_grad_params.insert("a".into(), a_grad.clone());
 
@@ -110,7 +117,15 @@ mod tests {
         optimizer.apply(&mut a_model, a_grad_params).unwrap();
         assert_eq!(a_model.a.shape(), &[4, 3]);
         assert_eq!(a_model.a.dtype(), Dtype::Float32);
-        assert_array_eq!(a_model.a.mean(None, None).unwrap(), array!(-0.06250998377799988), ATOL);
-        assert_array_eq!(a_model.a.sum(None, None).unwrap(), array!(-0.7501198053359985), ATOL);
+        assert_array_eq!(
+            a_model.a.mean(None, None).unwrap(),
+            array!(-0.062_509_984),
+            ATOL
+        );
+        assert_array_eq!(
+            a_model.a.sum(None, None).unwrap(),
+            array!(-0.750_119_8),
+            ATOL
+        );
     }
 }

--- a/mlx-nn/src/optimizers/adagrad.rs
+++ b/mlx-nn/src/optimizers/adagrad.rs
@@ -20,7 +20,8 @@ generate_builder! {
         /// Learning rate
         pub lr: Array,
 
-        /// The epsilon added to the denominator to improve numerical stability. 
+        /// The epsilon added to the denominator to improve numerical stability. Default to
+        /// [`AdaGrad::DEFAULT_EPS`].
         #[optional(ty = f32)]
         pub eps: Array,
 

--- a/mlx-nn/src/optimizers/mod.rs
+++ b/mlx-nn/src/optimizers/mod.rs
@@ -2,25 +2,32 @@
 
 use std::rc::Rc;
 
-use mlx_rs::module::{FlattenedModuleParam, ModuleParameters};
+use mlx_rs::{error::Exception, module::{FlattenedModuleParam, ModuleParameters}};
 
 mod rmsprop;
 mod sgd;
+mod adagrad;
 
-use mlx_rs::Array;
 pub use rmsprop::*;
 pub use sgd::*;
+pub use adagrad::*;
+
+use mlx_rs::Array;
 
 type OptimizerState = FlattenedModuleParam;
 
 /// Trait for optimizers.
 pub trait Optimizer {
     /// Update a single parameter with the given gradient.
-    fn update_single(&mut self, key: Rc<str>, gradient: Array, parameter: &mut Array);
+    /// 
+    /// The implementation should look up the state for the parameter using the key and update the
+    /// state and the parameter accordingly. The key is provided instead of the state because it
+    /// would otherwise create a mutable borrow conflict with the rest of the optimizer fields.
+    fn update_single(&mut self, key: Rc<str>, gradient: Array, parameter: &mut Array) -> Result<(), Exception>;
 
     /// Apply the gradients to the parameters of the model and update the model with the new
     /// parameters.
-    fn update<M>(&mut self, model: &mut M, gradients: FlattenedModuleParam)
+    fn update<M>(&mut self, model: &mut M, gradients: FlattenedModuleParam) -> Result<(), Exception>
     where
         M: ModuleParameters,
     {
@@ -28,9 +35,11 @@ pub trait Optimizer {
 
         for (key, gradient) in gradients {
             if let Some(parameter) = parameters.get_mut(&key) {
-                self.update_single(key, gradient, parameter);
+                self.update_single(key, gradient, parameter)?;
             }
         }
+
+        Ok(())
     }
 }
 
@@ -177,7 +186,7 @@ mod tests {
             // compute the loss and gradients.  use the optimizer
             // to adjust the parameters closer to the target
             let (loss, g) = lg(&mut model, (&x, &y))?;
-            optimizer.update(&mut model, g);
+            optimizer.update(&mut model, g)?;
 
             eval_params(model.parameters())?;
 

--- a/mlx-nn/src/optimizers/mod.rs
+++ b/mlx-nn/src/optimizers/mod.rs
@@ -1,6 +1,6 @@
 //! Trait and implementations for optimizers.
 
-use std::rc::Rc;
+use std::{borrow::Borrow, rc::Rc};
 
 use mlx_rs::{error::Exception, module::{FlattenedModuleParam, ModuleParameters}};
 
@@ -23,19 +23,19 @@ pub trait Optimizer {
     /// The implementation should look up the state for the parameter using the key and update the
     /// state and the parameter accordingly. The key is provided instead of the state because it
     /// would otherwise create a mutable borrow conflict with the rest of the optimizer fields.
-    fn update_single(&mut self, key: Rc<str>, gradient: Array, parameter: &mut Array) -> Result<(), Exception>;
+    fn apply_single(&mut self, key: &Rc<str>, gradient: &Array, parameter: &mut Array) -> Result<(), Exception>;
 
     /// Apply the gradients to the parameters of the model and update the model with the new
     /// parameters.
-    fn update<M>(&mut self, model: &mut M, gradients: FlattenedModuleParam) -> Result<(), Exception>
+    fn apply<M>(&mut self, model: &mut M, gradients: impl Borrow<FlattenedModuleParam>) -> Result<(), Exception>
     where
         M: ModuleParameters,
     {
         let mut parameters = model.parameters_mut().flatten();
 
-        for (key, gradient) in gradients {
-            if let Some(parameter) = parameters.get_mut(&key) {
-                self.update_single(key, gradient, parameter)?;
+        for (key, gradient) in gradients.borrow().iter() {
+            if let Some(parameter) = parameters.get_mut(key) {
+                self.apply_single(key, gradient, parameter)?;
             }
         }
 
@@ -186,7 +186,7 @@ mod tests {
             // compute the loss and gradients.  use the optimizer
             // to adjust the parameters closer to the target
             let (loss, g) = lg(&mut model, (&x, &y))?;
-            optimizer.update(&mut model, g)?;
+            optimizer.apply(&mut model, g)?;
 
             eval_params(model.parameters())?;
 

--- a/mlx-nn/src/optimizers/mod.rs
+++ b/mlx-nn/src/optimizers/mod.rs
@@ -2,15 +2,18 @@
 
 use std::{borrow::Borrow, rc::Rc};
 
-use mlx_rs::{error::Exception, module::{FlattenedModuleParam, ModuleParameters}};
+use mlx_rs::{
+    error::Exception,
+    module::{FlattenedModuleParam, ModuleParameters},
+};
 
+mod adagrad;
 mod rmsprop;
 mod sgd;
-mod adagrad;
 
+pub use adagrad::*;
 pub use rmsprop::*;
 pub use sgd::*;
-pub use adagrad::*;
 
 use mlx_rs::Array;
 
@@ -19,15 +22,24 @@ type OptimizerState = FlattenedModuleParam;
 /// Trait for optimizers.
 pub trait Optimizer {
     /// Update a single parameter with the given gradient.
-    /// 
+    ///
     /// The implementation should look up the state for the parameter using the key and update the
     /// state and the parameter accordingly. The key is provided instead of the state because it
     /// would otherwise create a mutable borrow conflict with the rest of the optimizer fields.
-    fn apply_single(&mut self, key: &Rc<str>, gradient: &Array, parameter: &mut Array) -> Result<(), Exception>;
+    fn apply_single(
+        &mut self,
+        key: &Rc<str>,
+        gradient: &Array,
+        parameter: &mut Array,
+    ) -> Result<(), Exception>;
 
     /// Apply the gradients to the parameters of the model and update the model with the new
     /// parameters.
-    fn apply<M>(&mut self, model: &mut M, gradients: impl Borrow<FlattenedModuleParam>) -> Result<(), Exception>
+    fn apply<M>(
+        &mut self,
+        model: &mut M,
+        gradients: impl Borrow<FlattenedModuleParam>,
+    ) -> Result<(), Exception>
     where
         M: ModuleParameters,
     {

--- a/mlx-nn/src/optimizers/rmsprop.rs
+++ b/mlx-nn/src/optimizers/rmsprop.rs
@@ -81,8 +81,13 @@ impl RmsProp {
 }
 
 impl Optimizer for RmsProp {
-    fn apply_single(&mut self, key: &Rc<str>, gradient: &Array, parameter: &mut Array)  -> Result<(), Exception> {
-        let state = get_mut_or_insert_with(&mut self.state, &key, || array!(0.0));
+    fn apply_single(
+        &mut self,
+        key: &Rc<str>,
+        gradient: &Array,
+        parameter: &mut Array,
+    ) -> Result<(), Exception> {
+        let state = get_mut_or_insert_with(&mut self.state, key, || array!(0.0));
 
         let lr = &self.lr;
         let alpha = &self.alpha;
@@ -90,11 +95,11 @@ impl Optimizer for RmsProp {
 
         let one_minus_alpha = array!(1.0).subtract(alpha)?;
         let first_term = alpha.multiply(&*state)?;
-        let second_term = one_minus_alpha.multiply(&square(&gradient))?;
+        let second_term = one_minus_alpha.multiply(square(gradient))?;
         let v = first_term.add(&second_term)?;
 
-        let num = lr.multiply(&gradient)?;
-        let den = sqrt(&v).add(&eps)?;
+        let num = lr.multiply(gradient)?;
+        let den = sqrt(&v).add(eps)?;
         let new_param = parameter.subtract(num.divide(&den)?)?;
 
         *parameter = new_param;

--- a/mlx-nn/src/optimizers/rmsprop.rs
+++ b/mlx-nn/src/optimizers/rmsprop.rs
@@ -81,7 +81,7 @@ impl RmsProp {
 }
 
 impl Optimizer for RmsProp {
-    fn update_single(&mut self, key: Rc<str>, gradient: Array, parameter: &mut Array)  -> Result<(), Exception> {
+    fn apply_single(&mut self, key: &Rc<str>, gradient: &Array, parameter: &mut Array)  -> Result<(), Exception> {
         let state = get_mut_or_insert_with(&mut self.state, &key, || array!(0.0));
 
         let lr = &self.lr;
@@ -123,7 +123,7 @@ mod tests {
         let (mut model, gradients) = create_default_test_model_and_grads();
 
         let mut optim = RmsProp::builder().alpha(ALPHA).build(LR).unwrap();
-        optim.update(&mut model, gradients).unwrap();
+        optim.apply(&mut model, gradients).unwrap();
 
         let expected_first_a = ones::<f32>(&[10]).unwrap() * -0.1;
         let expected_first_b = ones::<f32>(&[1]).unwrap() * -0.1;

--- a/mlx-nn/src/optimizers/rmsprop.rs
+++ b/mlx-nn/src/optimizers/rmsprop.rs
@@ -20,16 +20,16 @@ generate_builder! {
     #[generate_builder(generate_build_fn = false)]
     pub struct RmsProp {
         /// Learning rate
-        pub lr: f32,
+        pub lr: Array,
 
         /// The smoothing constant. Default to [`RmsProp::DEFAULT_ALPHA`] if not specified.
-        #[optional]
-        pub alpha: f32,
+        #[optional(ty = f32)]
+        pub alpha: Array,
 
         /// The epsilon added to the denominator to improve numerical stability. Default to
         /// [`RmsProp::DEFAULT_EPSILON`] if not specified.
-        #[optional]
-        pub epsilon: f32,
+        #[optional(ty = f32)]
+        pub epsilon: Array,
 
         /// Inner state
         pub state: OptimizerState,
@@ -55,9 +55,9 @@ impl RmsPropBuilder {
         }
 
         Ok(RmsProp {
-            lr,
-            alpha,
-            epsilon,
+            lr: array!(lr),
+            alpha: array!(alpha),
+            epsilon: array!(epsilon),
             state: OptimizerState::new(),
         })
     }
@@ -84,11 +84,11 @@ impl Optimizer for RmsProp {
     fn update_single(&mut self, key: Rc<str>, gradient: Array, parameter: &mut Array)  -> Result<(), Exception> {
         let state = get_mut_or_insert_with(&mut self.state, &key, || array!(0.0));
 
-        let lr = array!(self.lr);
-        let alpha = array!(self.alpha);
-        let eps = array!(self.epsilon);
+        let lr = &self.lr;
+        let alpha = &self.alpha;
+        let eps = &self.epsilon;
 
-        let one_minus_alpha = array!(1.0) - &alpha;
+        let one_minus_alpha = array!(1.0).subtract(alpha)?;
         let first_term = alpha.multiply(&*state)?;
         let second_term = one_minus_alpha.multiply(&square(&gradient))?;
         let v = first_term.add(&second_term)?;

--- a/mlx-nn/src/optimizers/sgd.rs
+++ b/mlx-nn/src/optimizers/sgd.rs
@@ -77,7 +77,12 @@ impl Sgd {
 impl Optimizer for Sgd {
     /// Apply SGD to a single parameter. Returns the updated parameter and the updated state.
     #[inline]
-    fn apply_single(&mut self, key: &Rc<str>, gradient: &Array, parameter: &mut Array) -> Result<(), Exception> {
+    fn apply_single(
+        &mut self,
+        key: &Rc<str>,
+        gradient: &Array,
+        parameter: &mut Array,
+    ) -> Result<(), Exception> {
         let state = get_mut_or_insert_with(&mut self.state, key, || array!(0.0));
 
         let zero = array!(0.0);

--- a/mlx-rs/src/ops/factory.rs
+++ b/mlx-rs/src/ops/factory.rs
@@ -371,7 +371,10 @@ pub fn zeros_device<T: ArrayElement>(
 
 /// An array of zeros like the input.
 #[default_device]
-pub fn zeros_like_device(input: impl AsRef<Array>, stream: impl AsRef<Stream>) -> Result<Array, Exception> {
+pub fn zeros_like_device(
+    input: impl AsRef<Array>,
+    stream: impl AsRef<Stream>,
+) -> Result<Array, Exception> {
     let a = input.as_ref();
     let shape = a.shape();
     let dtype = a.dtype();
@@ -399,7 +402,10 @@ pub fn ones_device<T: ArrayElement>(
 
 /// An array of ones like the input.
 #[default_device]
-pub fn ones_like_device(input: impl AsRef<Array>, stream: impl AsRef<Stream>) -> Result<Array, Exception> {
+pub fn ones_like_device(
+    input: impl AsRef<Array>,
+    stream: impl AsRef<Stream>,
+) -> Result<Array, Exception> {
     let a = input.as_ref();
     let shape = a.shape();
     let dtype = a.dtype();

--- a/mlx-rs/src/ops/factory.rs
+++ b/mlx-rs/src/ops/factory.rs
@@ -369,6 +369,25 @@ pub fn zeros_device<T: ArrayElement>(
     Array::zeros_device::<T>(shape, stream)
 }
 
+/// An array of zeros like the input.
+#[default_device]
+pub fn zeros_like_device(input: impl AsRef<Array>, stream: impl AsRef<Stream>) -> Result<Array, Exception> {
+    let a = input.as_ref();
+    let shape = a.shape();
+    let dtype = a.dtype();
+    unsafe {
+        let c_array = try_catch_c_ptr_expr! {
+            mlx_sys::mlx_zeros(
+                shape.as_ptr(),
+                shape.len(),
+                dtype.into(),
+                stream.as_ref().as_ptr(),
+            )
+        };
+        Ok(Array::from_ptr(c_array))
+    }
+}
+
 /// See [`Array::ones`]
 #[default_device]
 pub fn ones_device<T: ArrayElement>(
@@ -376,6 +395,25 @@ pub fn ones_device<T: ArrayElement>(
     stream: impl AsRef<Stream>,
 ) -> Result<Array, Exception> {
     Array::ones_device::<T>(shape, stream)
+}
+
+/// An array of ones like the input.
+#[default_device]
+pub fn ones_like_device(input: impl AsRef<Array>, stream: impl AsRef<Stream>) -> Result<Array, Exception> {
+    let a = input.as_ref();
+    let shape = a.shape();
+    let dtype = a.dtype();
+    unsafe {
+        let c_array = try_catch_c_ptr_expr! {
+            mlx_sys::mlx_ones(
+                shape.as_ptr(),
+                shape.len(),
+                dtype.into(),
+                stream.as_ref().as_ptr(),
+            )
+        };
+        Ok(Array::from_ptr(c_array))
+    }
 }
 
 /// See [`Array::eye`]


### PR DESCRIPTION
This PR add implementation of `AdaGrad` optimizer. Other changes include:

1. Added `zeros_like` and `ones_like` factory functions
2. Changed trait function `Optimizer::update` and `Optimizer::update_single` to `Optimizer::apply` and `Optimizer::apply_single`, and these fns now returns `Result<(), Exception>`
3. Added new field attribute argument `#[optional(ty = <Path>)]` to `generate_builder` proc macro