### PR TITLE
chore(mlx-c): Update MLX-C to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # workspace local dependencies
-mlx-sys = { version = "0.0.9", path = "mlx-sys" }
+mlx-sys = { version = "0.0.10", path = "mlx-sys" }
 mlx-macros = { version = "0.1.0", path = "mlx-macros" }
 mlx-internal-macros = { version = "0.1.0", path = "mlx-internal-macros" }
 mlx-rs = { version = "0.14.0", path = "mlx-rs" }

--- a/mlx-rs/src/linalg.rs
+++ b/mlx-rs/src/linalg.rs
@@ -1,5 +1,5 @@
 use crate::error::Exception;
-use crate::utils::{IntoOption, MlxString, VectorArray};
+use crate::utils::{IntoOption, MlxString, TupleArrayArray, VectorArray};
 use crate::{Array, Stream, StreamOrDevice};
 use mlx_internal_macros::default_device;
 use smallvec::SmallVec;
@@ -257,14 +257,10 @@ pub fn qr_device(a: &Array, stream: impl AsRef<Stream>) -> Result<(Array, Array)
             mlx_sys::mlx_linalg_qr(a.as_ptr(), stream.as_ref().as_ptr())
         };
 
-        let v = VectorArray::from_ptr(c_vec);
+        let v = TupleArrayArray::from_ptr(c_vec);
+        let vals = v.into_values();
 
-        let vals: SmallVec<[Array; 2]> = v.into_values();
-        let mut iter = vals.into_iter();
-        let q = iter.next().unwrap();
-        let r = iter.next().unwrap();
-
-        Ok((q, r))
+        Ok((vals.0, vals.1))
     }
 }
 

--- a/mlx-rs/src/linalg.rs
+++ b/mlx-rs/src/linalg.rs
@@ -260,7 +260,7 @@ pub fn qr_device(a: &Array, stream: impl AsRef<Stream>) -> Result<(Array, Array)
         let v = TupleArrayArray::from_ptr(c_vec);
         let vals = v.into_values();
 
-        Ok((vals.0, vals.1))
+        Ok(vals)
     }
 }
 

--- a/mlx-rs/src/ops/quantization.rs
+++ b/mlx-rs/src/ops/quantization.rs
@@ -41,7 +41,7 @@ pub fn quantize_device(
         let vec = TupleArrayArrayArray::from_ptr(c_vec);
         let vals = vec.into_values();
 
-        Ok((vals.0, vals.1, vals.2))
+        Ok(vals)
     }
 }
 

--- a/mlx-rs/src/ops/quantization.rs
+++ b/mlx-rs/src/ops/quantization.rs
@@ -3,9 +3,8 @@
 // dequantized(_:scales:biases:groupSize:bits:stream:)
 
 use mlx_internal_macros::default_device;
-use smallvec::SmallVec;
 
-use crate::{error::Exception, utils::VectorArray, Array, Stream, StreamOrDevice};
+use crate::{error::Exception, utils::TupleArrayArrayArray, Array, Stream, StreamOrDevice};
 
 /// Quantize the matrix `w` using `bits` bits per element.
 ///
@@ -39,15 +38,10 @@ pub fn quantize_device(
             mlx_sys::mlx_quantize(w.as_ptr(), group_size, bits, stream.as_ref().as_ptr())
         };
 
-        let vec = VectorArray::from_ptr(c_vec);
+        let vec = TupleArrayArrayArray::from_ptr(c_vec);
+        let vals = vec.into_values();
 
-        let vals: SmallVec<[Array; 3]> = vec.into_values();
-        let mut iter = vals.into_iter();
-        let wq = iter.next().unwrap();
-        let scales = iter.next().unwrap();
-        let biases = iter.next().unwrap();
-
-        Ok((wq, scales, biases))
+        Ok((vals.0, vals.1, vals.2))
     }
 }
 

--- a/mlx-rs/src/ops/shapes.rs
+++ b/mlx-rs/src/ops/shapes.rs
@@ -1183,10 +1183,10 @@ mod tests {
     #[test]
     fn test_pad() {
         let x = Array::zeros::<f32>(&[1, 2, 3]).unwrap();
-        assert_eq!(pad(&x, 1, None).unwrap().shape(), &[3, 4, 5]);
-        assert_eq!(pad(&x, (0, 1), None).unwrap().shape(), &[2, 3, 4]);
+        assert_eq!(pad(&x, 1, None, None).unwrap().shape(), &[3, 4, 5]);
+        assert_eq!(pad(&x, (0, 1), None, None).unwrap().shape(), &[2, 3, 4]);
         assert_eq!(
-            pad(&x, &[(1, 1), (1, 2), (3, 1)], None).unwrap().shape(),
+            pad(&x, &[(1, 1), (1, 2), (3, 1)], None, None).unwrap().shape(),
             &[3, 5, 7]
         );
     }

--- a/mlx-rs/src/ops/shapes.rs
+++ b/mlx-rs/src/ops/shapes.rs
@@ -660,6 +660,24 @@ impl<'a> PadWidth<'a> {
     }
 }
 
+#[derive(Debug)]
+pub enum PadMode {
+    Constant,
+    Edge,
+}
+
+impl PadMode {
+    fn as_mlx_string(&self) -> mlx_sys::mlx_string {
+        static CONSTANT: &[u8] = b"constant\0";
+        static EDGE: &[u8] = b"edge\0";
+
+        match self {
+            PadMode::Constant => unsafe { mlx_sys::mlx_string_new(CONSTANT.as_ptr() as *const _) },
+            PadMode::Edge => unsafe { mlx_sys::mlx_string_new(EDGE.as_ptr() as *const _) },
+        }
+    }
+}
+
 /// Pad an array with a constant value. Returns an error if the width is invalid.
 ///
 /// # Params
@@ -677,13 +695,14 @@ impl<'a> PadWidth<'a> {
 /// use mlx_rs::{prelude::*, ops::*};
 ///
 /// let a = Array::from_iter(0..4, &[2, 2]);
-/// let result = pad(&a, 1, Array::from_int(0));
+/// let result = pad(&a, 1, Array::from_int(0), PadMode::Constant);
 /// ```
 #[default_device]
 pub fn pad_device<'a>(
     a: &Array,
     width: impl Into<PadWidth<'a>>,
     value: impl Into<Option<Array>>,
+    mode: impl Into<Option<PadMode>>,
     stream: impl AsRef<Stream>,
 ) -> Result<Array, Exception> {
     let width = width.into();
@@ -694,6 +713,8 @@ pub fn pad_device<'a>(
     let value = value
         .into()
         .unwrap_or_else(|| Array::from_int(0).as_dtype(a.dtype()));
+
+    let mode = mode.into().unwrap_or(PadMode::Constant);
 
     unsafe {
         let c_array = try_catch_c_ptr_expr! {
@@ -706,6 +727,7 @@ pub fn pad_device<'a>(
                 high_pads.as_ptr(),
                 high_pads.len(),
                 value.c_array,
+                mode.as_mlx_string(),
                 stream.as_ref().as_ptr(),
             )
         };

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -1,14 +1,14 @@
 use std::{collections::HashMap, rc::Rc};
 
 use mlx_sys::{mlx_closure_value_and_grad, mlx_closure_value_and_grad_apply};
-use smallvec::SmallVec;
 
+use crate::utils::TupleVectorArrayVectorArray;
 use crate::{
     error::{
         get_and_clear_last_mlx_error, is_mlx_error_handler_set, setup_mlx_error_handler, Exception,
     },
     module::ModuleParamRef,
-    utils::{Closure, IntoOption, VectorArray, VectorVectorArray},
+    utils::{Closure, IntoOption, VectorArray},
     Array,
 };
 
@@ -77,15 +77,11 @@ fn jvp_inner(
                 c_tangents.as_ptr(),
             )
         };
-        VectorVectorArray::from_ptr(c_vector_pair)
+        TupleVectorArrayVectorArray::from_ptr(c_vector_pair)
     };
 
-    let vector_pair_values: SmallVec<[VectorArray; 2]> = vector_pair.into_values();
-    let mut iter = vector_pair_values.into_iter();
-    let v1 = iter.next().unwrap().into_values();
-    let v2 = iter.next().unwrap().into_values();
-
-    Ok((v1, v2))
+    let vector_pair_values = vector_pair.into_values();
+    Ok(vector_pair_values)
 }
 
 /// Compute the Jacobian-vector product.
@@ -147,15 +143,11 @@ fn vjp_inner(
                 c_cotangents.as_ptr(),
             )
         };
-        VectorVectorArray::from_ptr(c_vector_pair)
+        TupleVectorArrayVectorArray::from_ptr(c_vector_pair)
     };
 
-    let vector_pair_values: SmallVec<[VectorArray; 2]> = vector_pair.into_values();
-    let mut iter = vector_pair_values.into_iter();
-    let v1 = iter.next().unwrap().into_values();
-    let v2 = iter.next().unwrap().into_values();
-
-    Ok((v1, v2))
+    let vector_pair_values = vector_pair.into_values();
+    Ok(vector_pair_values)
 }
 
 /// Compute the vector-Jacobian product.
@@ -209,15 +201,11 @@ fn value_and_gradient(
         let c_vector_pair = try_catch_mlx_closure_error! {
             mlx_closure_value_and_grad_apply(value_and_grad, input_vector.as_ptr())
         };
-        VectorVectorArray::from_ptr(c_vector_pair)
+        TupleVectorArrayVectorArray::from_ptr(c_vector_pair)
     };
 
-    let vector_pair_values: SmallVec<[VectorArray; 2]> = vector_pair.into_values();
-    let mut iter = vector_pair_values.into_iter();
-    let values_vec = iter.next().unwrap().into_values();
-    let gradients_vec = iter.next().unwrap().into_values();
-
-    Ok((values_vec, gradients_vec))
+    let vector_pair_values = vector_pair.into_values();
+    Ok(vector_pair_values)
 }
 
 #[inline]

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-sys"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Minghua Wu <michael.wu1107@gmail.com>", "David Chavez <david@dcvz.io>"]
 edition = "2021"
 

--- a/mlx-sys/src/shim/closure.cpp
+++ b/mlx-sys/src/shim/closure.cpp
@@ -7,9 +7,11 @@
 #include "mlx/c/private/closure.h"
 #include "mlx/c/private/string.h"
 #include "mlx/c/private/utils.h"
+#include "mlx/c/private/vector.h"
 
 #include "closure.h"
 #include "result.h"
+
 
 extern "C" mlx_closure mlx_fallible_closure_new_with_payload(
     mlx_vector_array_result (*fun)(const mlx_vector_array, void*),
@@ -17,20 +19,21 @@ extern "C" mlx_closure mlx_fallible_closure_new_with_payload(
     void (*dtor)(void*)
 ) {
     auto cpp_payload = std::shared_ptr<void>(payload, dtor);
-    auto cpp_closure = [fun, cpp_payload](const std::vector<mlx::core::array>& input) {
-        auto c_input = new mlx_vector_array_(input);
-        auto c_res = fun(c_input, cpp_payload.get());
-        mlx_free(c_input);
-        if (mlx_vector_array_result_is_err(&c_res)) {
-            auto err = mlx_vector_array_result_into_err(c_res);
+    auto cpp_closure =
+      [fun, cpp_payload](const std::vector<mlx::core::array>& cpp_input) {
+        auto input = new mlx_vector_array_(cpp_input);
+        auto res = fun(input, cpp_payload.get());
+        mlx_free(input);
+        if (mlx_vector_array_result_is_err(&res)) {
+            auto err = mlx_vector_array_result_into_err(res);
             std::string msg = std::move(err->ctx);
             mlx_free(err);
             throw std::runtime_error(msg);
         }
-        auto c_ok = mlx_vector_array_result_into_ok(c_res);
-        auto res = c_ok->ctx;
+        auto c_ok = mlx_vector_array_result_into_ok(res);
+        auto cpp_res = c_ok->ctx;
         mlx_free(c_ok);
-        return res;
+        return cpp_res;
     };
     MLX_TRY_CATCH(return new mlx_closure_(cpp_closure), return nullptr);
 }

--- a/mlx-sys/src/shim/closure.h
+++ b/mlx-sys/src/shim/closure.h
@@ -3,6 +3,7 @@
 
 #include "mlx/c/array.h"
 #include "mlx/c/closure.h"
+#include "mlx/c/vector.h"
 
 #include "result.h"
 

--- a/mlx-sys/src/shim/result.cpp
+++ b/mlx-sys/src/shim/result.cpp
@@ -8,8 +8,7 @@ extern "C" mlx_vector_array_result mlx_vector_array_result_new_ok(
   return result;
 }
 
-extern "C" mlx_vector_array_result mlx_vector_array_result_new_err(
-    mlx_string err) {
+extern "C" mlx_vector_array_result mlx_vector_array_result_new_err(mlx_string err) {
   mlx_vector_array_result result;
   result.tag = mlx_result_tag_err;
   result.err = err;

--- a/mlx-sys/src/shim/result.h
+++ b/mlx-sys/src/shim/result.h
@@ -1,8 +1,8 @@
 #ifndef MLC_X_SHIM_RESULT_H
 #define MLC_X_SHIM_RESULT_H
 
-#include "mlx/c/array.h"
 #include "mlx/c/string.h"
+#include "mlx/c/vector.h"
 
 #ifdef __cplusplus
 #include <stdexcept>


### PR DESCRIPTION
Updates MLX-C to 0.0.10:
- fixes shims
- adds new types for changed methods
- adds padding mode for pad methods

It does not add new additions, those will be tackled separately.