### PR TITLE
feat: Allow recursive freeze/unfreeze

### DIFF
--- a/examples/mnist/src/mlp.rs
+++ b/examples/mnist/src/mlp.rs
@@ -1,10 +1,10 @@
-use mlx_nn::{macros::ModuleParameters, module::Param, Linear, Relu, Sequential};
+use mlx_nn::{macros::ModuleParameters, Linear, Relu, Sequential};
 use mlx_rs::{error::Exception, module::Module, Array};
 
 #[derive(Debug, ModuleParameters)]
 pub struct Mlp {
     #[param]
-    pub layers: Param<Sequential>,
+    pub layers: Sequential,
 }
 
 impl Module for Mlp {
@@ -43,8 +43,6 @@ impl Mlp {
         // Add the output layer
         layers = layers.append(Linear::new(hidden_dim, output_dim)?);
 
-        Ok(Self {
-            layers: Param::new(layers),
-        })
+        Ok(Self { layers })
     }
 }

--- a/mlx-macros/src/lib.rs
+++ b/mlx-macros/src/lib.rs
@@ -26,16 +26,16 @@ mod module_parameters;
 ///     optional: Param<Option<Array>>,
 ///
 ///     #[param]
-///     nested: Param<Inner>,
+///     nested: Inner,
 ///
 ///     #[param]
-///     vec_nested: Param<Vec<Inner>>,
+///     vec_nested: Vec<Inner>,
 ///
 ///     #[param]
-///     trait_object: Param<Box<dyn Module>>,
+///     trait_object: Box<dyn Module>,
 ///
 ///     #[param]
-///     trait_object_vec: Param<Vec<Box<dyn Module>>>,
+///     trait_object_vec: Vec<Box<dyn Module>>,
 /// }
 ///
 /// #[derive(ModuleParameters)]

--- a/mlx-macros/src/module_parameters.rs
+++ b/mlx-macros/src/module_parameters.rs
@@ -51,6 +51,16 @@ fn impl_module_parameters_for_struct(
     let field_names: Vec<_> = fields.iter().map(|field| &field.ident).collect();
     quote::quote! {
         impl #impl_generics _mlx_rs::module::ModuleParameters for #ident #ty_generics #where_clause {
+            fn freeze_parameters(&mut self, recursive: bool) {
+                use _mlx_rs::module::Parameter;
+                #(self.#field_names.freeze(recursive);)*
+            }
+
+            fn unfreeze_parameters(&mut self, recursive: bool) {
+                use _mlx_rs::module::Parameter;
+                #(self.#field_names.unfreeze(recursive);)*
+            }
+
             fn parameters(&self) -> _mlx_rs::module::ModuleParamRef<'_> {
                 let mut parameters = _mlx_rs::nested::NestedHashMap::new();
                 #(parameters.insert(stringify!(#field_names), _mlx_rs::module::Parameter::as_nested_value(&self.#field_names));)*

--- a/mlx-macros/src/module_parameters.rs
+++ b/mlx-macros/src/module_parameters.rs
@@ -82,6 +82,26 @@ fn impl_module_parameters_for_struct(
                 )*
                 parameters
             }
+
+            fn all_frozen(&self) -> bool {
+                use _mlx_rs::module::Parameter;
+                #(
+                    if !self.#field_names.is_frozen() {
+                        return false;
+                    }
+                )*
+                true
+            }
+
+            fn any_frozen(&self) -> bool {
+                use _mlx_rs::module::Parameter;
+                #(
+                    if self.#field_names.is_frozen() {
+                        return true;
+                    }
+                )*
+                false
+            }
         }
     }
 }

--- a/mlx-nn/src/container.rs
+++ b/mlx-nn/src/container.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use mlx_macros::ModuleParameters;
-use mlx_rs::module::{Module, Param};
+use mlx_rs::module::Module;
 use mlx_rs::{error::Exception, Array};
 
 /// Marker trait for items that can be used in a `Sequential` module.
@@ -23,7 +23,7 @@ where
 pub struct Sequential<Err = Exception> {
     /// The layers to be called in sequence.
     #[param]
-    pub layers: Param<Vec<Box<dyn SequentialModuleItem<Err>>>>,
+    pub layers: Vec<Box<dyn SequentialModuleItem<Err>>>,
 }
 
 impl Module for Sequential {
@@ -32,7 +32,7 @@ impl Module for Sequential {
     fn forward(&self, x: &Array) -> Result<Array, Self::Error> {
         let mut x = Cow::Borrowed(x);
 
-        for layer in &self.layers.value {
+        for layer in &self.layers {
             x = Cow::Owned(layer.forward(x.as_ref())?);
         }
 
@@ -58,9 +58,7 @@ impl Default for Sequential {
 impl<Err> Sequential<Err> {
     /// Creates a new [`Sequential`] module.
     pub fn new() -> Self {
-        Self {
-            layers: Param::new(Vec::new()),
-        }
+        Self { layers: Vec::new() }
     }
 
     /// Appends a layer to the sequential module.

--- a/mlx-nn/tests/test_module.rs
+++ b/mlx-nn/tests/test_module.rs
@@ -1,18 +1,18 @@
 use mlx_macros::ModuleParameters;
 use mlx_nn::Linear;
-use mlx_rs::module::{Module, Param};
+use mlx_rs::module::Module;
 use mlx_rs::{error::Exception, Array};
 
 #[derive(Debug, Clone, ModuleParameters)]
 struct M {
     #[param]
-    linear: Param<Linear>,
+    linear: Linear,
 }
 
 impl M {
     pub fn new() -> Self {
         Self {
-            linear: Param::new(Linear::new(5, 5).unwrap()),
+            linear: Linear::new(5, 5).unwrap(),
         }
     }
 }

--- a/mlx-nn/tests/test_module_parameters.rs
+++ b/mlx-nn/tests/test_module_parameters.rs
@@ -173,18 +173,18 @@ struct StructModuleWithNested {
     a: Param<Array>,
 
     #[param]
-    nested: Param<StructModule>,
+    nested: StructModule,
 }
 
 #[test]
 fn test_nested_module_parameters() {
     let m = StructModuleWithNested {
         a: Param::new(array!(1.0)),
-        nested: Param::new(StructModule {
+        nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
-        }),
+        },
     };
 
     let flattened = m.parameters().flatten();
@@ -198,11 +198,11 @@ fn test_nested_module_parameters() {
 fn test_nested_module_parameters_mut() {
     let mut m = StructModuleWithNested {
         a: Param::new(array!(1.0)),
-        nested: Param::new(StructModule {
+        nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
-        }),
+        },
     };
 
     let flattened = m.parameters_mut().flatten();

--- a/mlx-nn/tests/test_module_parameters.rs
+++ b/mlx-nn/tests/test_module_parameters.rs
@@ -104,21 +104,21 @@ fn test_module_trainable_parameters_partial_freeze() {
     };
 
     // Freeze one parameter that is not optional
-    m.a.freeze();
+    m.a.freeze(true);
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 1);
     assert_eq!(flattened["b"], &array!(2.0));
 
     // Now freeze the optional parameter
-    m.c.freeze();
+    m.c.freeze(true);
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 1);
     assert_eq!(flattened["b"], &array!(2.0));
 
     // Unfreeze the non-optional parameter
-    m.a.unfreeze();
+    m.a.unfreeze(true);
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 2);
@@ -134,7 +134,7 @@ fn test_module_trainable_parameters_partial_freeze() {
     assert_eq!(flattened["b"], &array!(2.0));
 
     // Unfreeze the optional parameter
-    m.c.unfreeze();
+    m.c.unfreeze(true);
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 3);

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -63,6 +63,12 @@ pub trait ModuleParameters {
 
     /// Unfreeze all parameters in the module.
     fn unfreeze_parameters(&mut self, recursive: bool);
+
+    /// Check if all parameters in the module are frozen.
+    fn all_frozen(&self) -> bool;
+
+    /// Check if any parameter in the module is frozen.
+    fn any_frozen(&self) -> bool;
 }
 
 /// Update the module parameters from an iterator of flattened parameters.
@@ -102,6 +108,14 @@ where
 
     fn unfreeze_parameters(&mut self, recursive: bool) {
         self.as_mut().unfreeze_parameters(recursive);
+    }
+
+    fn all_frozen(&self) -> bool {
+        self.as_ref().all_frozen()
+    }
+
+    fn any_frozen(&self) -> bool {
+        self.as_ref().any_frozen()
     }
 }
 
@@ -146,5 +160,13 @@ where
         self.iter_mut().for_each(|module| {
             module.unfreeze_parameters(recursive);
         });
+    }
+
+    fn all_frozen(&self) -> bool {
+        self.iter().all(|module| module.all_frozen())
+    }
+
+    fn any_frozen(&self) -> bool {
+        self.iter().any(|module| module.any_frozen())
     }
 }

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -57,6 +57,12 @@ pub trait ModuleParameters {
     fn update_flattened(&mut self, flattened_parameters: FlattenedModuleParam) {
         update_flattened_parameters(self, flattened_parameters)
     }
+
+    /// Freeze all parameters in the module.
+    fn freeze_parameters(&mut self, recursive: bool);
+
+    /// Unfreeze all parameters in the module.
+    fn unfreeze_parameters(&mut self, recursive: bool);
 }
 
 /// Update the module parameters from an iterator of flattened parameters.
@@ -89,6 +95,14 @@ where
     fn trainable_parameters(&self) -> ModuleParamRef<'_> {
         self.as_ref().trainable_parameters()
     }
+
+    fn freeze_parameters(&mut self, recursive: bool) {
+        self.as_mut().freeze_parameters(recursive);
+    }
+
+    fn unfreeze_parameters(&mut self, recursive: bool) {
+        self.as_mut().unfreeze_parameters(recursive);
+    }
 }
 
 impl<T> ModuleParameters for Vec<T>
@@ -120,5 +134,17 @@ where
             parameters.entries.extend(module_parameters.entries);
         });
         parameters
+    }
+
+    fn freeze_parameters(&mut self, recursive: bool) {
+        self.iter_mut().for_each(|module| {
+            module.freeze_parameters(recursive);
+        });
+    }
+
+    fn unfreeze_parameters(&mut self, recursive: bool) {
+        self.iter_mut().for_each(|module| {
+            module.unfreeze_parameters(recursive);
+        });
     }
 }

--- a/mlx-rs/src/module/param.rs
+++ b/mlx-rs/src/module/param.rs
@@ -148,22 +148,20 @@ impl Parameter for Param<Option<Array>> {
     }
 }
 
-impl<T> Parameter for Param<T>
+impl<T> Parameter for T
 where
     T: ModuleParameters,
 {
     fn freeze(&mut self, recursive: bool) {
-        self.value.freeze_parameters(recursive);
-        self.is_frozen = true;
+        self.freeze_parameters(recursive);
     }
 
     fn unfreeze(&mut self, recursive: bool) {
-        self.value.unfreeze_parameters(recursive);
-        self.is_frozen = false;
+        self.unfreeze_parameters(recursive);
     }
 
     fn is_frozen(&self) -> bool {
-        self.is_frozen
+        self.all_frozen()
     }
 
     fn as_nested_value<'a>(&self) -> NestedValue<&'a str, &Array> {
@@ -175,9 +173,6 @@ where
     }
 
     fn as_trainable_nested_value<'a>(&self) -> Option<NestedValue<&'a str, &Array>> {
-        match self.is_frozen {
-            true => None,
-            false => Some(self.trainable_parameters().into()),
-        }
+        Some(self.trainable_parameters().into())
     }
 }

--- a/mlx-rs/src/module/param.rs
+++ b/mlx-rs/src/module/param.rs
@@ -10,10 +10,10 @@ use super::ModuleParameters;
 /// Trait for a module parameter.
 pub trait Parameter {
     /// Freeze the parameter.
-    fn freeze(&mut self);
+    fn freeze(&mut self, recursive: bool);
 
     /// Unfreeze the parameter.
-    fn unfreeze(&mut self);
+    fn unfreeze(&mut self, recursive: bool);
 
     /// Check if the parameter is frozen.
     fn is_frozen(&self) -> bool;
@@ -35,7 +35,9 @@ pub struct Param<T> {
     pub value: T,
 
     /// Whether the parameter is frozen.
-    pub is_frozen: bool,
+    ///
+    /// This is no longer public because it should be accessed through the `Parameter` trait.
+    is_frozen: bool,
 }
 
 impl<T> Param<T> {
@@ -81,11 +83,11 @@ impl<T> AsMut<T> for Param<T> {
 }
 
 impl Parameter for Param<Array> {
-    fn freeze(&mut self) {
+    fn freeze(&mut self, _recursive: bool) {
         self.is_frozen = true;
     }
 
-    fn unfreeze(&mut self) {
+    fn unfreeze(&mut self, _recursive: bool) {
         self.is_frozen = false;
     }
 
@@ -110,11 +112,11 @@ impl Parameter for Param<Array> {
 }
 
 impl Parameter for Param<Option<Array>> {
-    fn freeze(&mut self) {
+    fn freeze(&mut self, _recursive: bool) {
         self.is_frozen = true;
     }
 
-    fn unfreeze(&mut self) {
+    fn unfreeze(&mut self, _recursive: bool) {
         self.is_frozen = false;
     }
 
@@ -150,11 +152,13 @@ impl<T> Parameter for Param<T>
 where
     T: ModuleParameters,
 {
-    fn freeze(&mut self) {
+    fn freeze(&mut self, recursive: bool) {
+        self.value.freeze_parameters(recursive);
         self.is_frozen = true;
     }
 
-    fn unfreeze(&mut self) {
+    fn unfreeze(&mut self, recursive: bool) {
+        self.value.unfreeze_parameters(recursive);
         self.is_frozen = false;
     }
 

--- a/mlx-tests/tests/test_optimizers.rs
+++ b/mlx-tests/tests/test_optimizers.rs
@@ -154,7 +154,7 @@ struct First {
 #[derive(Debug, ModuleParameters)]
 struct NestedModel {
     #[param]
-    pub first: Param<First>,
+    pub first: First,
 
     #[param]
     pub second: Param<Array>,
@@ -168,7 +168,7 @@ fn create_default_test_model_and_grads() -> (NestedModel, GradsMap) {
         b: Param::new(zeros::<f32>(&[1]).unwrap()),
     };
     let model = NestedModel {
-        first: Param::new(first),
+        first,
         second: Param::new(zeros::<f32>(&[1]).unwrap()),
     };
 


### PR DESCRIPTION
This PR brings changes to the `Parameter` and `ModuleParameter` traits and the macro to allow recursively freezing parameters. To avoid confusion with freezing a `Module` and `Param<Module>`, the `Parameter` trait is no longer implemented for `Param<T> where T: Module`, and the trait is instead implemetned for `T: Module`.