### PR TITLE
fix: Fix error with checking if parameter is frozen on empty module

### DIFF
--- a/mlx-nn/tests/test_module_parameters.rs
+++ b/mlx-nn/tests/test_module_parameters.rs
@@ -181,6 +181,26 @@ fn test_unit_struct_module_trainable_parameters() {
 }
 
 #[test]
+fn test_unit_struct_module_freeze_parameters() {
+    let mut m = UnitStructModule;
+
+    m.freeze_parameters(true);
+    assert_eq!(m.all_frozen(), None);
+    assert_eq!(m.any_frozen(), None);
+    assert_eq!(m.is_frozen(), None);
+}
+
+#[test]
+fn test_unit_struct_module_unfreeze_parameters() {
+    let mut m = UnitStructModule;
+
+    m.unfreeze_parameters(true);
+    assert_eq!(m.all_frozen(), None);
+    assert_eq!(m.any_frozen(), None);
+    assert_eq!(m.is_frozen(), None);
+}
+
+#[test]
 fn test_nested_module_parameters() {
     let m = NestedStructModule {
         a: Param::new(array!(1.0)),

--- a/mlx-nn/tests/test_module_parameters.rs
+++ b/mlx-nn/tests/test_module_parameters.rs
@@ -1,6 +1,7 @@
-use mlx_macros::ModuleParameters;
 use mlx_rs::module::{ModuleParameters, Param, Parameter};
 use mlx_rs::{array, Array};
+
+use mlx_nn::macros::ModuleParameters;
 
 #[derive(ModuleParameters)]
 pub struct StructModule {
@@ -16,6 +17,18 @@ pub struct StructModule {
 
 #[derive(ModuleParameters)]
 pub struct UnitStructModule;
+
+#[derive(ModuleParameters)]
+struct NestedStructModule {
+    #[param]
+    a: Param<Array>,
+
+    #[param]
+    nested: StructModule,
+
+    #[param]
+    neste_no_param: UnitStructModule,
+}
 
 #[test]
 fn test_module_parameters() {
@@ -167,24 +180,16 @@ fn test_unit_struct_module_trainable_parameters() {
     assert_eq!(flattened.len(), 0);
 }
 
-#[derive(ModuleParameters)]
-struct StructModuleWithNested {
-    #[param]
-    a: Param<Array>,
-
-    #[param]
-    nested: StructModule,
-}
-
 #[test]
 fn test_nested_module_parameters() {
-    let m = StructModuleWithNested {
+    let m = NestedStructModule {
         a: Param::new(array!(1.0)),
         nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
+        neste_no_param: UnitStructModule,
     };
 
     let flattened = m.parameters().flatten();
@@ -196,13 +201,14 @@ fn test_nested_module_parameters() {
 
 #[test]
 fn test_nested_module_parameters_mut() {
-    let mut m = StructModuleWithNested {
+    let mut m = NestedStructModule {
         a: Param::new(array!(1.0)),
         nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
+        neste_no_param: UnitStructModule,
     };
 
     let flattened = m.parameters_mut().flatten();
@@ -214,17 +220,18 @@ fn test_nested_module_parameters_mut() {
 
 #[test]
 fn test_nested_module_recursive_freeze() {
-    let mut m = StructModuleWithNested {
+    let mut m = NestedStructModule {
         a: Param::new(array!(1.0)),
         nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
+        neste_no_param: UnitStructModule,
     };
 
     m.freeze_parameters(true);
-    assert!(m.all_frozen());
+    assert_eq!(m.all_frozen(), Some(true));
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 0);
@@ -232,19 +239,20 @@ fn test_nested_module_recursive_freeze() {
 
 #[test]
 fn test_nested_module_freeze_submodule() {
-    let mut m = StructModuleWithNested {
+    let mut m = NestedStructModule {
         a: Param::new(array!(1.0)),
         nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
+        neste_no_param: UnitStructModule,
     };
 
     m.nested.freeze_parameters(true);
-    assert!(m.nested.all_frozen());
-    assert!(m.any_frozen());
-    assert!(!m.all_frozen());
+    assert_eq!(m.nested.all_frozen(), Some(true));
+    assert_eq!(m.any_frozen(), Some(true));
+    assert_eq!(m.all_frozen(), Some(false));
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 1);
@@ -253,18 +261,20 @@ fn test_nested_module_freeze_submodule() {
 
 #[test]
 fn test_nested_module_unfreeze_submodule() {
-    let mut m = StructModuleWithNested {
+    let mut m = NestedStructModule {
         a: Param::new(array!(1.0)),
         nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
+        neste_no_param: UnitStructModule,
     };
 
     m.nested.freeze_parameters(true);
     m.nested.unfreeze_parameters(true);
-    assert!(!m.any_frozen());
+
+    assert_eq!(m.any_frozen(), Some(false));
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 3);
@@ -275,18 +285,19 @@ fn test_nested_module_unfreeze_submodule() {
 
 #[test]
 fn test_nested_module_recursive_unfreeze() {
-    let mut m = StructModuleWithNested {
+    let mut m = NestedStructModule {
         a: Param::new(array!(1.0)),
         nested: StructModule {
             a: Param::new(array!(2.0)),
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
+        neste_no_param: UnitStructModule,
     };
 
     m.freeze_parameters(true);
     m.unfreeze_parameters(true);
-    assert!(!m.all_frozen());
+    assert_eq!(m.all_frozen(), Some(false));
 
     let flattened = m.trainable_parameters().flatten();
     assert_eq!(flattened.len(), 3);

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -168,7 +168,7 @@ where
             match module.all_frozen() {
                 Some(true) => result = Some(true),
                 Some(false) => return Some(false),
-                None => {},
+                None => {}
             }
         }
         result
@@ -180,7 +180,7 @@ where
             match module.any_frozen() {
                 Some(true) => return Some(true),
                 Some(false) => result = Some(false),
-                None => {},
+                None => {}
             }
         }
         result

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -64,11 +64,11 @@ pub trait ModuleParameters {
     /// Unfreeze all parameters in the module.
     fn unfreeze_parameters(&mut self, recursive: bool);
 
-    /// Check if all parameters in the module are frozen.
-    fn all_frozen(&self) -> bool;
+    /// Check if all parameters in the module are frozen. Returns `None` if there are no parameters.
+    fn all_frozen(&self) -> Option<bool>;
 
-    /// Check if any parameter in the module is frozen.
-    fn any_frozen(&self) -> bool;
+    /// Check if any parameter in the module is frozen. Returns `None` if there are no parameters.
+    fn any_frozen(&self) -> Option<bool>;
 }
 
 /// Update the module parameters from an iterator of flattened parameters.
@@ -110,11 +110,11 @@ where
         self.as_mut().unfreeze_parameters(recursive);
     }
 
-    fn all_frozen(&self) -> bool {
+    fn all_frozen(&self) -> Option<bool> {
         self.as_ref().all_frozen()
     }
 
-    fn any_frozen(&self) -> bool {
+    fn any_frozen(&self) -> Option<bool> {
         self.as_ref().any_frozen()
     }
 }
@@ -162,11 +162,27 @@ where
         });
     }
 
-    fn all_frozen(&self) -> bool {
-        self.iter().all(|module| module.all_frozen())
+    fn all_frozen(&self) -> Option<bool> {
+        let mut result = None;
+        for module in self.iter() {
+            match module.all_frozen() {
+                Some(true) => result = Some(true),
+                Some(false) => return Some(false),
+                None => {},
+            }
+        }
+        result
     }
 
-    fn any_frozen(&self) -> bool {
-        self.iter().any(|module| module.any_frozen())
+    fn any_frozen(&self) -> Option<bool> {
+        let mut result = None;
+        for module in self.iter() {
+            match module.any_frozen() {
+                Some(true) => return Some(true),
+                Some(false) => result = Some(false),
+                None => {},
+            }
+        }
+        result
     }
 }

--- a/mlx-rs/src/module/param.rs
+++ b/mlx-rs/src/module/param.rs
@@ -15,8 +15,9 @@ pub trait Parameter {
     /// Unfreeze the parameter.
     fn unfreeze(&mut self, recursive: bool);
 
-    /// Check if the parameter is frozen.
-    fn is_frozen(&self) -> bool;
+    /// Check if the parameter is frozen. Returns `None` if the parameter is a module that has no
+    /// parameters.
+    fn is_frozen(&self) -> Option<bool>;
 
     /// Get the parameter as a nested value.
     fn as_nested_value<'a>(&self) -> NestedValue<&'a str, &Array>;
@@ -91,8 +92,8 @@ impl Parameter for Param<Array> {
         self.is_frozen = false;
     }
 
-    fn is_frozen(&self) -> bool {
-        self.is_frozen
+    fn is_frozen(&self) -> Option<bool> {
+        Some(self.is_frozen)
     }
 
     fn as_nested_value<'a>(&self) -> NestedValue<&'a str, &Array> {
@@ -120,8 +121,8 @@ impl Parameter for Param<Option<Array>> {
         self.is_frozen = false;
     }
 
-    fn is_frozen(&self) -> bool {
-        self.is_frozen
+    fn is_frozen(&self) -> Option<bool> {
+        Some(self.is_frozen)
     }
 
     fn as_nested_value<'a>(&self) -> NestedValue<&'a str, &Array> {
@@ -160,7 +161,7 @@ where
         self.unfreeze_parameters(recursive);
     }
 
-    fn is_frozen(&self) -> bool {
+    fn is_frozen(&self) -> Option<bool> {
         self.all_frozen()
     }
 


### PR DESCRIPTION
`Parameter::is_frozen()`, `ModuleParameters::all_frozen()`, and `ModuleParameters::any_frozen()` now returns `None` if the module contains no trainable parameter