### PR TITLE
Add generic type `Args` in `Module` trait to allow binary modules

### DIFF
--- a/examples/mnist/src/mlp.rs
+++ b/examples/mnist/src/mlp.rs
@@ -9,6 +9,7 @@ pub struct Mlp {
 
 impl<'a> Module<&'a Array> for Mlp {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         self.layers.forward(x)

--- a/examples/mnist/src/mlp.rs
+++ b/examples/mnist/src/mlp.rs
@@ -7,7 +7,7 @@ pub struct Mlp {
     pub layers: Sequential,
 }
 
-impl Module for Mlp {
+impl<'a> Module<&'a Array> for Mlp {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {

--- a/mlx-nn/src/activation.rs
+++ b/mlx-nn/src/activation.rs
@@ -280,7 +280,7 @@ impl Glu {
     pub const DEFAULT_AXIS: i32 = -1;
 }
 
-impl Module for Glu {
+impl<'a> Module<&'a Array> for Glu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -303,7 +303,7 @@ impl Module for Glu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Sigmoid;
 
-impl Module for Sigmoid {
+impl<'a> Module<&'a Array> for Sigmoid {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -327,7 +327,7 @@ impl Module for Sigmoid {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Mish;
 
-impl Module for Mish {
+impl<'a> Module<&'a Array> for Mish {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -347,7 +347,7 @@ impl Module for Mish {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Relu;
 
-impl Module for Relu {
+impl<'a> Module<&'a Array> for Relu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -378,7 +378,7 @@ impl LeakyRelu {
     pub const DEFAULT_NEG_SLOPE: f32 = 0.01;
 }
 
-impl Module for LeakyRelu {
+impl<'a> Module<&'a Array> for LeakyRelu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -398,7 +398,7 @@ impl Module for LeakyRelu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Relu6;
 
-impl Module for Relu6 {
+impl<'a> Module<&'a Array> for Relu6 {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -429,7 +429,7 @@ impl Softmax {
     pub const DEFAULT_AXIS: i32 = -1;
 }
 
-impl Module for Softmax {
+impl<'a> Module<&'a Array> for Softmax {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -449,7 +449,7 @@ impl Module for Softmax {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Softplus;
 
-impl Module for Softplus {
+impl<'a> Module<&'a Array> for Softplus {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -469,7 +469,7 @@ impl Module for Softplus {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Softsign;
 
-impl Module for Softsign {
+impl<'a> Module<&'a Array> for Softsign {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -501,7 +501,7 @@ impl Celu {
     pub const DEFAULT_ALPHA: f32 = 1.0;
 }
 
-impl Module for Celu {
+impl<'a> Module<&'a Array> for Celu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -521,7 +521,7 @@ impl Module for Celu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Silu;
 
-impl Module for Silu {
+impl<'a> Module<&'a Array> for Silu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -552,7 +552,7 @@ impl LogSoftmax {
     pub const DEFAULT_AXIS: i32 = -1;
 }
 
-impl Module for LogSoftmax {
+impl<'a> Module<&'a Array> for LogSoftmax {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -572,7 +572,7 @@ impl Module for LogSoftmax {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct LogSigmoid;
 
-impl Module for LogSigmoid {
+impl<'a> Module<&'a Array> for LogSigmoid {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -654,7 +654,7 @@ impl Prelu {
     }
 }
 
-impl Module for Prelu {
+impl<'a> Module<&'a Array> for Prelu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -694,7 +694,7 @@ generate_builder! {
     }
 }
 
-impl Module for Gelu {
+impl<'a> Module<&'a Array> for Gelu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -712,7 +712,7 @@ impl Module for Gelu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Tanh;
 
-impl Module for Tanh {
+impl<'a> Module<&'a Array> for Tanh {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -732,7 +732,7 @@ impl Module for Tanh {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct HardSwish;
 
-impl Module for HardSwish {
+impl<'a> Module<&'a Array> for HardSwish {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -766,7 +766,7 @@ impl Step {
     pub const DEFAULT_THRESHOLD: f32 = 0.0;
 }
 
-impl Module for Step {
+impl<'a> Module<&'a Array> for Step {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -786,7 +786,7 @@ impl Module for Step {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Selu;
 
-impl Module for Selu {
+impl<'a> Module<&'a Array> for Selu {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {

--- a/mlx-nn/src/activation.rs
+++ b/mlx-nn/src/activation.rs
@@ -282,6 +282,7 @@ impl Glu {
 
 impl<'a> Module<&'a Array> for Glu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         glu(x, self.axis).map_err(Into::into)
@@ -305,6 +306,7 @@ pub struct Sigmoid;
 
 impl<'a> Module<&'a Array> for Sigmoid {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         Ok(sigmoid(x))
@@ -329,6 +331,7 @@ pub struct Mish;
 
 impl<'a> Module<&'a Array> for Mish {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         mish(x).map_err(Into::into)
@@ -349,6 +352,7 @@ pub struct Relu;
 
 impl<'a> Module<&'a Array> for Relu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         relu(x).map_err(Into::into)
@@ -380,6 +384,7 @@ impl LeakyRelu {
 
 impl<'a> Module<&'a Array> for LeakyRelu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         leaky_relu(x, self.neg_slope).map_err(Into::into)
@@ -400,6 +405,7 @@ pub struct Relu6;
 
 impl<'a> Module<&'a Array> for Relu6 {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         relu6(x).map_err(Into::into)
@@ -431,6 +437,7 @@ impl Softmax {
 
 impl<'a> Module<&'a Array> for Softmax {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         Ok(mlx_rs::ops::softmax(x, &[self.axis], None))
@@ -451,6 +458,7 @@ pub struct Softplus;
 
 impl<'a> Module<&'a Array> for Softplus {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         softplus(x).map_err(Into::into)
@@ -471,6 +479,7 @@ pub struct Softsign;
 
 impl<'a> Module<&'a Array> for Softsign {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         softsign(x).map_err(Into::into)
@@ -503,6 +512,7 @@ impl Celu {
 
 impl<'a> Module<&'a Array> for Celu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         celu(x, self.alpha).map_err(Into::into)
@@ -523,6 +533,7 @@ pub struct Silu;
 
 impl<'a> Module<&'a Array> for Silu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         silu(x).map_err(Into::into)
@@ -554,6 +565,7 @@ impl LogSoftmax {
 
 impl<'a> Module<&'a Array> for LogSoftmax {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         log_softmax(x, self.axis).map_err(Into::into)
@@ -574,6 +586,7 @@ pub struct LogSigmoid;
 
 impl<'a> Module<&'a Array> for LogSigmoid {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         log_sigmoid(x).map_err(Into::into)
@@ -656,6 +669,7 @@ impl Prelu {
 
 impl<'a> Module<&'a Array> for Prelu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         prelu(x, &self.weight).map_err(Into::into)
@@ -696,6 +710,7 @@ generate_builder! {
 
 impl<'a> Module<&'a Array> for Gelu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         match self.approximate {
@@ -714,6 +729,7 @@ pub struct Tanh;
 
 impl<'a> Module<&'a Array> for Tanh {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         Ok(mlx_rs::ops::tanh(x))
@@ -734,6 +750,7 @@ pub struct HardSwish;
 
 impl<'a> Module<&'a Array> for HardSwish {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         hard_swish(x).map_err(Into::into)
@@ -768,6 +785,7 @@ impl Step {
 
 impl<'a> Module<&'a Array> for Step {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         step(x, self.threshold).map_err(Into::into)
@@ -788,6 +806,7 @@ pub struct Selu;
 
 impl<'a> Module<&'a Array> for Selu {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         selu(x).map_err(Into::into)

--- a/mlx-nn/src/container.rs
+++ b/mlx-nn/src/container.rs
@@ -1,17 +1,17 @@
 use std::borrow::Cow;
 
 use mlx_macros::ModuleParameters;
-use mlx_rs::module::Module;
+use mlx_rs::module::{Module, UnaryModule};
 use mlx_rs::{error::Exception, Array};
 
 /// Marker trait for items that can be used in a `Sequential` module.
 ///
 /// It is implemented for all types that implement [`Module`] and [`std::fmt::Debug`].
-pub trait SequentialModuleItem<Err>: Module<Error = Err> + std::fmt::Debug {}
+pub trait SequentialModuleItem<Err>: UnaryModule<Error = Err> + std::fmt::Debug {}
 
 impl<T, Err> SequentialModuleItem<Err> for T
 where
-    T: Module<Error = Err> + std::fmt::Debug,
+    T: UnaryModule<Error = Err> + std::fmt::Debug,
     Err: std::error::Error + 'static,
 {
 }
@@ -26,7 +26,7 @@ pub struct Sequential<Err = Exception> {
     pub layers: Vec<Box<dyn SequentialModuleItem<Err>>>,
 }
 
-impl Module for Sequential {
+impl<'a> Module<&'a Array> for Sequential {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -64,7 +64,7 @@ impl<Err> Sequential<Err> {
     /// Appends a layer to the sequential module.
     pub fn append<M>(mut self, layer: M) -> Self
     where
-        M: Module<Error = Err> + std::fmt::Debug + 'static,
+        M: UnaryModule<Error = Err> + std::fmt::Debug + 'static,
         Err: std::error::Error + 'static,
     {
         self.layers.push(Box::new(layer));

--- a/mlx-nn/src/container.rs
+++ b/mlx-nn/src/container.rs
@@ -28,6 +28,7 @@ pub struct Sequential<Err = Exception> {
 
 impl<'a> Module<&'a Array> for Sequential {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         let mut x = Cow::Borrowed(x);

--- a/mlx-nn/src/convolution.rs
+++ b/mlx-nn/src/convolution.rs
@@ -129,7 +129,7 @@ impl Conv1d {
     }
 }
 
-impl Module for Conv1d {
+impl<'a> Module<&'a Array> for Conv1d {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -283,7 +283,7 @@ impl Conv2d {
     }
 }
 
-impl Module for Conv2d {
+impl<'a> Module<&'a Array> for Conv2d {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -440,7 +440,7 @@ impl Conv3d {
     }
 }
 
-impl Module for Conv3d {
+impl<'a> Module<&'a Array> for Conv3d {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {

--- a/mlx-nn/src/convolution.rs
+++ b/mlx-nn/src/convolution.rs
@@ -131,6 +131,7 @@ impl Conv1d {
 
 impl<'a> Module<&'a Array> for Conv1d {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         let mut y = conv1d(
@@ -285,6 +286,7 @@ impl Conv2d {
 
 impl<'a> Module<&'a Array> for Conv2d {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         let mut y = conv2d(
@@ -442,6 +444,7 @@ impl Conv3d {
 
 impl<'a> Module<&'a Array> for Conv3d {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         let mut y = mlx_rs::ops::conv3d(

--- a/mlx-nn/src/dropout.rs
+++ b/mlx-nn/src/dropout.rs
@@ -94,7 +94,7 @@ impl Dropout {
     pub const DEFAULT_TRAINING: bool = true;
 }
 
-impl Module for Dropout {
+impl<'a> Module<&'a Array> for Dropout {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -155,7 +155,7 @@ impl Dropout2d {
     pub const DEFAULT_TRAINING: bool = true;
 }
 
-impl Module for Dropout2d {
+impl<'a> Module<&'a Array> for Dropout2d {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -228,7 +228,7 @@ impl Dropout3d {
     pub const DEFAULT_TRAINING: bool = true;
 }
 
-impl Module for Dropout3d {
+impl<'a> Module<&'a Array> for Dropout3d {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {

--- a/mlx-nn/src/dropout.rs
+++ b/mlx-nn/src/dropout.rs
@@ -96,6 +96,7 @@ impl Dropout {
 
 impl<'a> Module<&'a Array> for Dropout {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         if self.one_minus_p == 1.0 || !self.training {
@@ -157,6 +158,7 @@ impl Dropout2d {
 
 impl<'a> Module<&'a Array> for Dropout2d {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         let ndim = x.ndim();
@@ -230,6 +232,7 @@ impl Dropout3d {
 
 impl<'a> Module<&'a Array> for Dropout3d {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         let ndim = x.ndim();

--- a/mlx-nn/src/embedding.rs
+++ b/mlx-nn/src/embedding.rs
@@ -46,6 +46,7 @@ impl Embedding {
 
 impl<'a> Module<&'a Array> for Embedding {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         Ok(self.weight.index(x))

--- a/mlx-nn/src/embedding.rs
+++ b/mlx-nn/src/embedding.rs
@@ -44,7 +44,7 @@ impl Embedding {
     }
 }
 
-impl Module for Embedding {
+impl<'a> Module<&'a Array> for Embedding {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {

--- a/mlx-nn/src/linear.rs
+++ b/mlx-nn/src/linear.rs
@@ -87,6 +87,7 @@ impl Linear {
 
 impl<'a> Module<&'a Array> for Linear {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         match &self.bias.value {
@@ -181,6 +182,7 @@ impl Bilinear {
 
 impl<'a> Module<&'a Array> for Bilinear {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         let shape = self.weights.shape();

--- a/mlx-nn/src/linear.rs
+++ b/mlx-nn/src/linear.rs
@@ -85,7 +85,7 @@ impl Linear {
     }
 }
 
-impl Module for Linear {
+impl<'a> Module<&'a Array> for Linear {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
@@ -179,7 +179,7 @@ impl Bilinear {
     }
 }
 
-impl Module for Bilinear {
+impl<'a> Module<&'a Array> for Bilinear {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {

--- a/mlx-nn/src/value_and_grad.rs
+++ b/mlx-nn/src/value_and_grad.rs
@@ -3,7 +3,7 @@ use mlx_rs::{error::Exception, Array};
 
 use crate::module::{FlattenedModuleParam, FlattenedModuleParamRef, Module};
 
-fn trainable_params<'a>(model: &impl Module<&'a Array>) -> FlattenedModuleParam {
+fn trainable_params<MA>(model: &impl Module<MA>) -> FlattenedModuleParam {
     model
         .trainable_parameters()
         .flatten()
@@ -13,9 +13,9 @@ fn trainable_params<'a>(model: &impl Module<&'a Array>) -> FlattenedModuleParam 
 }
 
 /// Helper trait for [`value_and_grad`]
-pub trait IntoModuleValueAndGrad<'a, M, Args, Val, Err>
+pub trait IntoModuleValueAndGrad<'a, M, MA, Args, Val, Err>
 where
-    M: Module<&'a Array> + 'a,
+    M: Module<MA> + 'a,
     Args: Clone,
 {
     /// Computes the valud and gradient of the passed function `f(model, args)` with regard to the
@@ -25,9 +25,9 @@ where
     ) -> impl FnMut(&mut M, Args) -> Result<(Val, FlattenedModuleParam), Exception> + 'a;
 }
 
-impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Vec<Array>, ()> for F
+impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Vec<Array>, ()> for F
 where
-    M: Module<&'a Array> + 'a,
+    M: Module<MA> + 'a,
     F: FnMut(&mut M, Args) -> Vec<Array> + 'a,
     Args: Clone,
 {
@@ -51,9 +51,9 @@ where
     }
 }
 
-impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Vec<Array>, Exception> for F
+impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Vec<Array>, Exception> for F
 where
-    M: Module<&'a Array> + 'a,
+    M: Module<MA> + 'a,
     F: FnMut(&mut M, Args) -> Result<Vec<Array>, Exception> + 'a,
     Args: Clone,
 {
@@ -79,9 +79,9 @@ where
     }
 }
 
-impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Array, ()> for F
+impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Array, ()> for F
 where
-    M: Module<&'a Array> + 'a,
+    M: Module<MA> + 'a,
     F: FnMut(&mut M, Args) -> Array + 'a,
     Args: Clone,
 {
@@ -105,9 +105,9 @@ where
     }
 }
 
-impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Array, Exception> for F
+impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Array, Exception> for F
 where
-    M: Module<&'a Array> + 'a,
+    M: Module<MA> + 'a,
     F: FnMut(&mut M, Args) -> Result<Array, Exception> + 'a,
     Args: Clone,
 {
@@ -135,12 +135,12 @@ where
 
 /// Transform the passed function `f(model, args)` to a function that computes the gradients of `f`
 /// with regard to the model's trainable parameters and also its value.
-pub fn module_value_and_grad<'a, F, M, Args, Val, Err>(
+pub fn module_value_and_grad<'a, F, M, MA, Args, Val, Err>(
     f: F,
 ) -> impl FnMut(&mut M, Args) -> Result<(Val, FlattenedModuleParam), Exception> + 'a
 where
-    M: Module<&'a Array> + 'a,
-    F: IntoModuleValueAndGrad<'a, M, Args, Val, Err>,
+    M: Module<MA> + 'a,
+    F: IntoModuleValueAndGrad<'a, M, MA, Args, Val, Err>,
     Args: Clone,
 {
     f.into_module_value_and_grad()

--- a/mlx-nn/src/value_and_grad.rs
+++ b/mlx-nn/src/value_and_grad.rs
@@ -3,7 +3,7 @@ use mlx_rs::{error::Exception, Array};
 
 use crate::module::{FlattenedModuleParam, FlattenedModuleParamRef, Module};
 
-fn trainable_params(model: &impl Module) -> FlattenedModuleParam {
+fn trainable_params<'a>(model: &impl Module<&'a Array>) -> FlattenedModuleParam {
     model
         .trainable_parameters()
         .flatten()
@@ -15,7 +15,7 @@ fn trainable_params(model: &impl Module) -> FlattenedModuleParam {
 /// Helper trait for [`value_and_grad`]
 pub trait IntoModuleValueAndGrad<'a, M, Args, Val, Err>
 where
-    M: Module + 'a,
+    M: Module<&'a Array> + 'a,
     Args: Clone,
 {
     /// Computes the valud and gradient of the passed function `f(model, args)` with regard to the
@@ -27,7 +27,7 @@ where
 
 impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Vec<Array>, ()> for F
 where
-    M: Module + 'a,
+    M: Module<&'a Array> + 'a,
     F: FnMut(&mut M, Args) -> Vec<Array> + 'a,
     Args: Clone,
 {
@@ -53,7 +53,7 @@ where
 
 impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Vec<Array>, Exception> for F
 where
-    M: Module + 'a,
+    M: Module<&'a Array> + 'a,
     F: FnMut(&mut M, Args) -> Result<Vec<Array>, Exception> + 'a,
     Args: Clone,
 {
@@ -81,7 +81,7 @@ where
 
 impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Array, ()> for F
 where
-    M: Module + 'a,
+    M: Module<&'a Array> + 'a,
     F: FnMut(&mut M, Args) -> Array + 'a,
     Args: Clone,
 {
@@ -107,7 +107,7 @@ where
 
 impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Array, Exception> for F
 where
-    M: Module + 'a,
+    M: Module<&'a Array> + 'a,
     F: FnMut(&mut M, Args) -> Result<Array, Exception> + 'a,
     Args: Clone,
 {
@@ -139,7 +139,7 @@ pub fn module_value_and_grad<'a, F, M, Args, Val, Err>(
     f: F,
 ) -> impl FnMut(&mut M, Args) -> Result<(Val, FlattenedModuleParam), Exception> + 'a
 where
-    M: Module + 'a,
+    M: Module<&'a Array> + 'a,
     F: IntoModuleValueAndGrad<'a, M, Args, Val, Err>,
     Args: Clone,
 {

--- a/mlx-nn/src/value_and_grad.rs
+++ b/mlx-nn/src/value_and_grad.rs
@@ -1,9 +1,9 @@
-use mlx_rs::module::update_flattened_parameters;
+use mlx_rs::module::{update_flattened_parameters, ModuleParameters};
 use mlx_rs::{error::Exception, Array};
 
-use crate::module::{FlattenedModuleParam, FlattenedModuleParamRef, Module};
+use crate::module::{FlattenedModuleParam, FlattenedModuleParamRef};
 
-fn trainable_params<MA>(model: &impl Module<MA>) -> FlattenedModuleParam {
+fn trainable_params(model: &impl ModuleParameters) -> FlattenedModuleParam {
     model
         .trainable_parameters()
         .flatten()
@@ -13,9 +13,9 @@ fn trainable_params<MA>(model: &impl Module<MA>) -> FlattenedModuleParam {
 }
 
 /// Helper trait for [`value_and_grad`]
-pub trait IntoModuleValueAndGrad<'a, M, MA, Args, Val, Err>
+pub trait IntoModuleValueAndGrad<'a, M, Args, Val, Err>
 where
-    M: Module<MA> + 'a,
+    M: ModuleParameters + 'a,
     Args: Clone,
 {
     /// Computes the valud and gradient of the passed function `f(model, args)` with regard to the
@@ -25,9 +25,9 @@ where
     ) -> impl FnMut(&mut M, Args) -> Result<(Val, FlattenedModuleParam), Exception> + 'a;
 }
 
-impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Vec<Array>, ()> for F
+impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Vec<Array>, ()> for F
 where
-    M: Module<MA> + 'a,
+    M: ModuleParameters + 'a,
     F: FnMut(&mut M, Args) -> Vec<Array> + 'a,
     Args: Clone,
 {
@@ -51,9 +51,9 @@ where
     }
 }
 
-impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Vec<Array>, Exception> for F
+impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Vec<Array>, Exception> for F
 where
-    M: Module<MA> + 'a,
+    M: ModuleParameters + 'a,
     F: FnMut(&mut M, Args) -> Result<Vec<Array>, Exception> + 'a,
     Args: Clone,
 {
@@ -79,9 +79,9 @@ where
     }
 }
 
-impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Array, ()> for F
+impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Array, ()> for F
 where
-    M: Module<MA> + 'a,
+    M: ModuleParameters + 'a,
     F: FnMut(&mut M, Args) -> Array + 'a,
     Args: Clone,
 {
@@ -105,9 +105,9 @@ where
     }
 }
 
-impl<'a, F, M, MA, Args> IntoModuleValueAndGrad<'a, M, MA, Args, Array, Exception> for F
+impl<'a, F, M, Args> IntoModuleValueAndGrad<'a, M, Args, Array, Exception> for F
 where
-    M: Module<MA> + 'a,
+    M: ModuleParameters + 'a,
     F: FnMut(&mut M, Args) -> Result<Array, Exception> + 'a,
     Args: Clone,
 {
@@ -135,12 +135,12 @@ where
 
 /// Transform the passed function `f(model, args)` to a function that computes the gradients of `f`
 /// with regard to the model's trainable parameters and also its value.
-pub fn module_value_and_grad<'a, F, M, MA, Args, Val, Err>(
+pub fn module_value_and_grad<'a, F, M, Args, Val, Err>(
     f: F,
 ) -> impl FnMut(&mut M, Args) -> Result<(Val, FlattenedModuleParam), Exception> + 'a
 where
-    M: Module<MA> + 'a,
-    F: IntoModuleValueAndGrad<'a, M, MA, Args, Val, Err>,
+    M: ModuleParameters + 'a,
+    F: IntoModuleValueAndGrad<'a, M, Args, Val, Err>,
     Args: Clone,
 {
     f.into_module_value_and_grad()

--- a/mlx-nn/tests/test_module.rs
+++ b/mlx-nn/tests/test_module.rs
@@ -19,6 +19,7 @@ impl M {
 
 impl<'a> Module<&'a Array> for M {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         self.linear.forward(x)

--- a/mlx-nn/tests/test_module.rs
+++ b/mlx-nn/tests/test_module.rs
@@ -17,7 +17,7 @@ impl M {
     }
 }
 
-impl Module for M {
+impl<'a> Module<&'a Array> for M {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -37,40 +37,28 @@ pub trait Module<Args>: ModuleParameters {
 }
 
 /// Marker trait for a unary neural network module.
-/// 
+///
 /// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
 /// reference to the input.
-pub trait UnaryModule 
-where 
-    for<'a> Self: Module<&'a Array>
-{
-
-}
-
-impl<M> UnaryModule for M
+pub trait UnaryModule
 where
-    for<'a> M: Module<&'a Array> 
+    for<'a> Self: Module<&'a Array>,
 {
-
 }
+
+impl<M> UnaryModule for M where for<'a> M: Module<&'a Array> {}
 
 /// Marker trait for a binary neural network module.
-/// 
+///
 /// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
 /// tuple of references to the inputs.
-pub trait BinaryModule 
-where 
-    for<'a> Self: Module<(&'a Array, &'a Array)>
-{
-
-}
-
-impl<M> BinaryModule for M
+pub trait BinaryModule
 where
-    for<'a> M: Module<(&'a Array, &'a Array)> 
+    for<'a> Self: Module<(&'a Array, &'a Array)>,
 {
-
 }
+
+impl<M> BinaryModule for M where for<'a> M: Module<(&'a Array, &'a Array)> {}
 
 /// Trait for accessing and updating module parameters.
 pub trait ModuleParameters {

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -21,12 +21,12 @@ pub type FlattenedModuleParamRef<'a> = HashMap<Rc<str>, &'a Array>;
 pub type FlattenedModuleParamMut<'a> = HashMap<Rc<str>, &'a mut Array>;
 
 /// Trait for a neural network module.
-pub trait Module: ModuleParameters {
+pub trait Module<Args>: ModuleParameters {
     /// Error type for the module.
     type Error: std::error::Error;
 
     /// Forward pass of the module.
-    fn forward(&mut self, x: &Array) -> Result<Array, Self::Error>;
+    fn forward(&mut self, x: Args) -> Result<Array, Self::Error>;
 
     /// Set whether the module is in training mode.
     ///
@@ -34,6 +34,21 @@ pub trait Module: ModuleParameters {
     /// mask in training mode, but is the identity in evaluation mode. Implementations of nested
     /// modules should propagate the training mode to all child modules.
     fn training_mode(&mut self, mode: bool);
+}
+
+/// Trait for a unary neural network module.
+pub trait UnaryModule 
+where 
+    for<'a> Self: Module<&'a Array>
+{
+
+}
+
+impl<M> UnaryModule for M
+where
+    for<'a> M: Module<&'a Array> 
+{
+
 }
 
 /// Trait for accessing and updating module parameters.

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -25,8 +25,11 @@ pub trait Module<Args>: ModuleParameters {
     /// Error type for the module.
     type Error: std::error::Error;
 
+    /// Output type of the module.
+    type Output;
+
     /// Forward pass of the module.
-    fn forward(&mut self, x: Args) -> Result<Array, Self::Error>;
+    fn forward(&mut self, x: Args) -> Result<Self::Output, Self::Error>;
 
     /// Set whether the module is in training mode.
     ///
@@ -42,11 +45,11 @@ pub trait Module<Args>: ModuleParameters {
 /// reference to the input.
 pub trait UnaryModule
 where
-    for<'a> Self: Module<&'a Array>,
+    for<'a> Self: Module<&'a Array, Output = Array>,
 {
 }
 
-impl<M> UnaryModule for M where for<'a> M: Module<&'a Array> {}
+impl<M> UnaryModule for M where for<'a> M: Module<&'a Array, Output = Array> {}
 
 /// Trait for accessing and updating module parameters.
 pub trait ModuleParameters {

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -36,7 +36,10 @@ pub trait Module<Args>: ModuleParameters {
     fn training_mode(&mut self, mode: bool);
 }
 
-/// Trait for a unary neural network module.
+/// Marker trait for a unary neural network module.
+/// 
+/// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
+/// reference to the input.
 pub trait UnaryModule 
 where 
     for<'a> Self: Module<&'a Array>
@@ -47,6 +50,24 @@ where
 impl<M> UnaryModule for M
 where
     for<'a> M: Module<&'a Array> 
+{
+
+}
+
+/// Marker trait for a binary neural network module.
+/// 
+/// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
+/// tuple of references to the inputs.
+pub trait BinaryModule 
+where 
+    for<'a> Self: Module<(&'a Array, &'a Array)>
+{
+
+}
+
+impl<M> BinaryModule for M
+where
+    for<'a> M: Module<(&'a Array, &'a Array)> 
 {
 
 }

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -51,7 +51,7 @@ impl<M> UnaryModule for M where for<'a> M: Module<&'a Array> {}
 /// Marker trait for a binary neural network module.
 ///
 /// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
-/// tuple of references to the inputs.
+/// tuple of two references to the inputs.
 pub trait BinaryModule
 where
     for<'a> Self: Module<(&'a Array, &'a Array)>,
@@ -59,6 +59,18 @@ where
 }
 
 impl<M> BinaryModule for M where for<'a> M: Module<(&'a Array, &'a Array)> {}
+
+/// Marker trait for a terary neural network module.
+/// 
+/// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
+/// tuple of three references to the inputs.
+pub trait TeraryModule
+where
+    for<'a> Self: Module<(&'a Array, &'a Array, &'a Array)>,
+{
+}
+
+impl<M> TeraryModule for M where for<'a> M: Module<(&'a Array, &'a Array, &'a Array)> {}
 
 /// Trait for accessing and updating module parameters.
 pub trait ModuleParameters {

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -61,16 +61,16 @@ where
 impl<M> BinaryModule for M where for<'a> M: Module<(&'a Array, &'a Array)> {}
 
 /// Marker trait for a terary neural network module.
-/// 
+///
 /// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
 /// tuple of three references to the inputs.
-pub trait TeraryModule
+pub trait TernaryModule
 where
     for<'a> Self: Module<(&'a Array, &'a Array, &'a Array)>,
 {
 }
 
-impl<M> TeraryModule for M where for<'a> M: Module<(&'a Array, &'a Array, &'a Array)> {}
+impl<M> TernaryModule for M where for<'a> M: Module<(&'a Array, &'a Array, &'a Array)> {}
 
 /// Trait for accessing and updating module parameters.
 pub trait ModuleParameters {

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -48,30 +48,6 @@ where
 
 impl<M> UnaryModule for M where for<'a> M: Module<&'a Array> {}
 
-/// Marker trait for a binary neural network module.
-///
-/// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
-/// tuple of two references to the inputs.
-pub trait BinaryModule
-where
-    for<'a> Self: Module<(&'a Array, &'a Array)>,
-{
-}
-
-impl<M> BinaryModule for M where for<'a> M: Module<(&'a Array, &'a Array)> {}
-
-/// Marker trait for a terary neural network module.
-///
-/// This trait should not be implemented directly. Instead, implement [`Module`] with `Args` as a
-/// tuple of three references to the inputs.
-pub trait TernaryModule
-where
-    for<'a> Self: Module<(&'a Array, &'a Array, &'a Array)>,
-{
-}
-
-impl<M> TernaryModule for M where for<'a> M: Module<(&'a Array, &'a Array, &'a Array)> {}
-
 /// Trait for accessing and updating module parameters.
 pub trait ModuleParameters {
     /// Get references to the module parameters.

--- a/mlx-tests/tests/test_optimizers.rs
+++ b/mlx-tests/tests/test_optimizers.rs
@@ -38,6 +38,7 @@ struct LinearFunctionModel {
 
 impl<'a> Module<&'a Array> for LinearFunctionModel {
     type Error = Exception;
+    type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {
         self.m.multiply(x)?.add(&self.b)

--- a/mlx-tests/tests/test_optimizers.rs
+++ b/mlx-tests/tests/test_optimizers.rs
@@ -36,7 +36,7 @@ struct LinearFunctionModel {
     pub b: Param<Array>,
 }
 
-impl Module for LinearFunctionModel {
+impl<'a> Module<&'a Array> for LinearFunctionModel {
     type Error = Exception;
 
     fn forward(&mut self, x: &Array) -> Result<Array, Self::Error> {


### PR DESCRIPTION
This change is necessary to implement layers like RNN, which requires two inputs