### PR TITLE
chore: Fix latest clippy warnings

### DIFF
--- a/examples/mnist/src/mlp.rs
+++ b/examples/mnist/src/mlp.rs
@@ -7,7 +7,7 @@ pub struct Mlp {
     pub layers: Sequential,
 }
 
-impl<'a> Module<&'a Array> for Mlp {
+impl Module<&Array> for Mlp {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-internal-macros/src/shared.rs
+++ b/mlx-internal-macros/src/shared.rs
@@ -34,7 +34,7 @@ pub(crate) struct BuilderStructAnalyzer<'a> {
     pub err: Option<&'a syn::Path>,
 }
 
-impl<'a> BuilderStructAnalyzer<'a> {
+impl BuilderStructAnalyzer<'_> {
     pub fn generate_builder_struct(&self) -> proc_macro2::TokenStream {
         let struct_ident = self.struct_ident;
         let builder_ident = self.builder_struct_ident;

--- a/mlx-nn/src/activation.rs
+++ b/mlx-nn/src/activation.rs
@@ -280,7 +280,7 @@ impl Glu {
     pub const DEFAULT_AXIS: i32 = -1;
 }
 
-impl<'a> Module<&'a Array> for Glu {
+impl Module<&Array> for Glu {
     type Error = Exception;
     type Output = Array;
 
@@ -304,7 +304,7 @@ impl<'a> Module<&'a Array> for Glu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Sigmoid;
 
-impl<'a> Module<&'a Array> for Sigmoid {
+impl Module<&Array> for Sigmoid {
     type Error = Exception;
     type Output = Array;
 
@@ -329,7 +329,7 @@ impl<'a> Module<&'a Array> for Sigmoid {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Mish;
 
-impl<'a> Module<&'a Array> for Mish {
+impl Module<&Array> for Mish {
     type Error = Exception;
     type Output = Array;
 
@@ -350,7 +350,7 @@ impl<'a> Module<&'a Array> for Mish {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Relu;
 
-impl<'a> Module<&'a Array> for Relu {
+impl Module<&Array> for Relu {
     type Error = Exception;
     type Output = Array;
 
@@ -382,7 +382,7 @@ impl LeakyRelu {
     pub const DEFAULT_NEG_SLOPE: f32 = 0.01;
 }
 
-impl<'a> Module<&'a Array> for LeakyRelu {
+impl Module<&Array> for LeakyRelu {
     type Error = Exception;
     type Output = Array;
 
@@ -403,7 +403,7 @@ impl<'a> Module<&'a Array> for LeakyRelu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Relu6;
 
-impl<'a> Module<&'a Array> for Relu6 {
+impl Module<&Array> for Relu6 {
     type Error = Exception;
     type Output = Array;
 
@@ -435,7 +435,7 @@ impl Softmax {
     pub const DEFAULT_AXIS: i32 = -1;
 }
 
-impl<'a> Module<&'a Array> for Softmax {
+impl Module<&Array> for Softmax {
     type Error = Exception;
     type Output = Array;
 
@@ -456,7 +456,7 @@ impl<'a> Module<&'a Array> for Softmax {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Softplus;
 
-impl<'a> Module<&'a Array> for Softplus {
+impl Module<&Array> for Softplus {
     type Error = Exception;
     type Output = Array;
 
@@ -477,7 +477,7 @@ impl<'a> Module<&'a Array> for Softplus {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Softsign;
 
-impl<'a> Module<&'a Array> for Softsign {
+impl Module<&Array> for Softsign {
     type Error = Exception;
     type Output = Array;
 
@@ -510,7 +510,7 @@ impl Celu {
     pub const DEFAULT_ALPHA: f32 = 1.0;
 }
 
-impl<'a> Module<&'a Array> for Celu {
+impl Module<&Array> for Celu {
     type Error = Exception;
     type Output = Array;
 
@@ -531,7 +531,7 @@ impl<'a> Module<&'a Array> for Celu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Silu;
 
-impl<'a> Module<&'a Array> for Silu {
+impl Module<&Array> for Silu {
     type Error = Exception;
     type Output = Array;
 
@@ -563,7 +563,7 @@ impl LogSoftmax {
     pub const DEFAULT_AXIS: i32 = -1;
 }
 
-impl<'a> Module<&'a Array> for LogSoftmax {
+impl Module<&Array> for LogSoftmax {
     type Error = Exception;
     type Output = Array;
 
@@ -584,7 +584,7 @@ impl<'a> Module<&'a Array> for LogSoftmax {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct LogSigmoid;
 
-impl<'a> Module<&'a Array> for LogSigmoid {
+impl Module<&Array> for LogSigmoid {
     type Error = Exception;
     type Output = Array;
 
@@ -643,7 +643,7 @@ impl Prelu {
     pub const DEFAULT_VALUE: f32 = 0.25;
 }
 
-impl<'a> Module<&'a Array> for Prelu {
+impl Module<&Array> for Prelu {
     type Error = Exception;
     type Output = Array;
 
@@ -684,7 +684,7 @@ generate_builder! {
     }
 }
 
-impl<'a> Module<&'a Array> for Gelu {
+impl Module<&Array> for Gelu {
     type Error = Exception;
     type Output = Array;
 
@@ -703,7 +703,7 @@ impl<'a> Module<&'a Array> for Gelu {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Tanh;
 
-impl<'a> Module<&'a Array> for Tanh {
+impl Module<&Array> for Tanh {
     type Error = Exception;
     type Output = Array;
 
@@ -724,7 +724,7 @@ impl<'a> Module<&'a Array> for Tanh {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct HardSwish;
 
-impl<'a> Module<&'a Array> for HardSwish {
+impl Module<&Array> for HardSwish {
     type Error = Exception;
     type Output = Array;
 
@@ -759,7 +759,7 @@ impl Step {
     pub const DEFAULT_THRESHOLD: f32 = 0.0;
 }
 
-impl<'a> Module<&'a Array> for Step {
+impl Module<&Array> for Step {
     type Error = Exception;
     type Output = Array;
 
@@ -780,7 +780,7 @@ impl<'a> Module<&'a Array> for Step {
 #[derive(Debug, Clone, ModuleParameters)]
 pub struct Selu;
 
-impl<'a> Module<&'a Array> for Selu {
+impl Module<&Array> for Selu {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-nn/src/container.rs
+++ b/mlx-nn/src/container.rs
@@ -26,7 +26,7 @@ pub struct Sequential<Err = Exception> {
     pub layers: Vec<Box<dyn SequentialModuleItem<Err>>>,
 }
 
-impl<'a> Module<&'a Array> for Sequential {
+impl Module<&Array> for Sequential {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-nn/src/convolution.rs
+++ b/mlx-nn/src/convolution.rs
@@ -104,7 +104,7 @@ impl Conv1d {
     pub const DEFAULT_STRIDE: i32 = 1;
 }
 
-impl<'a> Module<&'a Array> for Conv1d {
+impl Module<&Array> for Conv1d {
     type Error = Exception;
     type Output = Array;
 
@@ -226,7 +226,7 @@ impl Conv2d {
     pub const DEFAULT_STRIDE: SingleOrPair = SingleOrPair::Pair(1, 1);
 }
 
-impl<'a> Module<&'a Array> for Conv2d {
+impl Module<&Array> for Conv2d {
     type Error = Exception;
     type Output = Array;
 
@@ -350,7 +350,7 @@ impl Conv3d {
     pub const DEFAULT_STRIDE: SingleOrTriple<i32> = SingleOrTriple::Triple(1, 1, 1);
 }
 
-impl<'a> Module<&'a Array> for Conv3d {
+impl Module<&Array> for Conv3d {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-nn/src/dropout.rs
+++ b/mlx-nn/src/dropout.rs
@@ -56,7 +56,7 @@ impl Dropout {
     pub const DEFAULT_TRAINING: bool = true;
 }
 
-impl<'a> Module<&'a Array> for Dropout {
+impl Module<&Array> for Dropout {
     type Error = Exception;
     type Output = Array;
 
@@ -137,7 +137,7 @@ impl Dropout2d {
     pub const DEFAULT_TRAINING: bool = true;
 }
 
-impl<'a> Module<&'a Array> for Dropout2d {
+impl Module<&Array> for Dropout2d {
     type Error = Exception;
     type Output = Array;
 
@@ -230,7 +230,7 @@ impl Dropout3d {
     pub const DEFAULT_TRAINING: bool = true;
 }
 
-impl<'a> Module<&'a Array> for Dropout3d {
+impl Module<&Array> for Dropout3d {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-nn/src/embedding.rs
+++ b/mlx-nn/src/embedding.rs
@@ -44,7 +44,7 @@ impl Embedding {
     }
 }
 
-impl<'a> Module<&'a Array> for Embedding {
+impl Module<&Array> for Embedding {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-nn/src/linear.rs
+++ b/mlx-nn/src/linear.rs
@@ -76,7 +76,7 @@ impl Linear {
     }
 }
 
-impl<'a> Module<&'a Array> for Linear {
+impl Module<&Array> for Linear {
     type Error = Exception;
     type Output = Array;
 
@@ -159,7 +159,7 @@ impl Bilinear {
     pub const DEFAULT_BIAS: bool = true;
 }
 
-impl<'a> Module<&'a Array> for Bilinear {
+impl Module<&Array> for Bilinear {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-nn/tests/test_module.rs
+++ b/mlx-nn/tests/test_module.rs
@@ -17,7 +17,7 @@ impl M {
     }
 }
 
-impl<'a> Module<&'a Array> for M {
+impl Module<&Array> for M {
     type Error = Exception;
     type Output = Array;
 

--- a/mlx-rs/src/array/mod.rs
+++ b/mlx-rs/src/array/mod.rs
@@ -28,7 +28,7 @@ pub struct Array {
 
 impl Sealed for Array {}
 
-impl<'a> Sealed for &'a Array {}
+impl Sealed for &Array {}
 
 impl std::fmt::Debug for Array {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/mlx-rs/src/array/operators.rs
+++ b/mlx-rs/src/array/operators.rs
@@ -68,7 +68,7 @@ impl_binary_op!(Rem, rem, remainder);
 impl_binary_op_assign!(RemAssign, rem_assign, remainder);
 impl_binary_op!(Pow, pow, power);
 
-impl<'a> Neg for &'a Array {
+impl Neg for &Array {
     type Output = Array;
     fn neg(self) -> Self::Output {
         self.negative_device(StreamOrDevice::default()).unwrap()
@@ -81,7 +81,7 @@ impl Neg for Array {
     }
 }
 
-impl<'a> Not for &'a Array {
+impl Not for &Array {
     type Output = Array;
     fn not(self) -> Self::Output {
         self.logical_not_device(StreamOrDevice::default())

--- a/mlx-rs/src/fast.rs
+++ b/mlx-rs/src/fast.rs
@@ -159,7 +159,7 @@ pub fn layer_norm_device<'a>(
 }
 
 /// Quantize the matrix `w` using the provided `scales` and `biases` and the `groupSize` and `bits` configuration.
-
+///
 /// For details, please see
 /// [this documentation](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.fast.affine_quantize.html)
 ///

--- a/mlx-rs/src/linalg.rs
+++ b/mlx-rs/src/linalg.rs
@@ -11,13 +11,13 @@ pub enum Ord<'a> {
     P(f64),
 }
 
-impl<'a> Default for Ord<'a> {
+impl Default for Ord<'_> {
     fn default() -> Self {
         Ord::Str("fro")
     }
 }
 
-impl<'a> std::fmt::Display for Ord<'a> {
+impl std::fmt::Display for Ord<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Ord::Str(s) => write!(f, "{}", s),
@@ -32,7 +32,7 @@ impl<'a> From<&'a str> for Ord<'a> {
     }
 }
 
-impl<'a> From<f64> for Ord<'a> {
+impl From<f64> for Ord<'_> {
     fn from(value: f64) -> Self {
         Ord::P(value)
     }

--- a/mlx-rs/src/module/mod.rs
+++ b/mlx-rs/src/module/mod.rs
@@ -1,8 +1,8 @@
-/// This crate defines the traits for neural network modules and parameters.
-///
-/// This is to separate the trait definitions from the implementations, which are in the `mlx-nn`
-/// crate. This also allows using the `mlx_macros::ModuleParameters` derive macro in crates other
-/// than `mlx-nn`.
+//! This mod defines the traits for neural network modules and parameters.
+//!
+//! This is to separate the trait definitions from the implementations, which are in the `mlx-nn`
+//! crate. This also allows using the `mlx_macros::ModuleParameters` derive macro in crates other
+//! than `mlx-nn`.
 
 #[allow(clippy::module_inception)]
 mod module;

--- a/mlx-rs/src/ops/indexing/mod.rs
+++ b/mlx-rs/src/ops/indexing/mod.rs
@@ -249,7 +249,7 @@ pub enum ArrayIndexOp<'a> {
     ExpandDims,
 }
 
-impl<'a> ArrayIndexOp<'a> {
+impl ArrayIndexOp<'_> {
     fn is_array_or_index(&self) -> bool {
         // Using the full match syntax to avoid forgetting to add new variants
         match self {

--- a/mlx-rs/src/ops/shapes.rs
+++ b/mlx-rs/src/ops/shapes.rs
@@ -644,7 +644,7 @@ impl<'a, const N: usize> From<&'a [(i32, i32); N]> for PadWidth<'a> {
     }
 }
 
-impl<'a> PadWidth<'a> {
+impl PadWidth<'_> {
     fn low_pads(&self, ndim: usize) -> SmallVec<[i32; DEFAULT_STACK_VEC_LEN]> {
         match self {
             PadWidth::Same((low, _high)) => (0..ndim).map(|_| *low).collect(),

--- a/mlx-rs/src/transforms/compile.rs
+++ b/mlx-rs/src/transforms/compile.rs
@@ -593,7 +593,7 @@ impl<'a, F> CompiledState<'a, F> {
     }
 }
 
-impl<'a, F> Drop for CompiledState<'a, F> {
+impl<F> Drop for CompiledState<'_, F> {
     fn drop(&mut self) {
         unsafe {
             // remove the compiled structure from the back end

--- a/mlx-rs/src/utils/mod.rs
+++ b/mlx-rs/src/utils/mod.rs
@@ -161,7 +161,7 @@ pub trait ScalarOrArray<'a> {
     fn into_owned_or_ref_array(self) -> Self::Array;
 }
 
-impl<'a> ScalarOrArray<'a> for Array {
+impl ScalarOrArray<'_> for Array {
     type Array = Array;
 
     fn into_owned_or_ref_array(self) -> Array {
@@ -262,7 +262,7 @@ impl<'a> Closure<'a> {
     }
 }
 
-impl<'a> Drop for Closure<'a> {
+impl Drop for Closure<'_> {
     fn drop(&mut self) {
         unsafe { mlx_sys::mlx_free(self.c_closure as *mut _) }
     }

--- a/mlx-tests/tests/test_optimizers.rs
+++ b/mlx-tests/tests/test_optimizers.rs
@@ -38,7 +38,7 @@ struct LinearFunctionModel {
     pub b: Param<Array>,
 }
 
-impl<'a> Module<&'a Array> for LinearFunctionModel {
+impl Module<&Array> for LinearFunctionModel {
     type Error = Exception;
     type Output = Array;
 


### PR DESCRIPTION
Seems there's a lot new lints added upstream. This PR simply fixes the new warnings