### PR TITLE
chore: Improve closure error message

### DIFF
--- a/mlx-nn/src/value_and_grad.rs
+++ b/mlx-nn/src/value_and_grad.rs
@@ -212,4 +212,24 @@ mod tests {
         assert_ne!(g["weight"].sum(None, None).unwrap(), array!(0.0));
         assert_ne!(g["bias"].sum(None, None).unwrap(), array!(0.0));
     }
+
+    #[test]
+    fn test_module_value_and_grad_with_error() {
+        let mut model = Linear::new(2, 2).unwrap();
+        // Use a shape that is not compatible with the model
+        let x = mlx_rs::random::uniform::<_, f32>(1.0, 2.0, &[3, 3], None).unwrap();
+
+        let loss = |model: &mut Linear, x: &Array| -> Result<Vec<Array>, Exception> {
+            Ok(vec![model.forward(x)?.sum(None, None)?])
+        };
+
+        let mut vg = module_value_and_grad(loss);
+        let result = vg(&mut model, &x);
+
+        assert!(result.is_err());
+
+        // Check that the error message is not just "mlx_closure returned a non-zero value"
+        let err = result.unwrap_err();
+        assert!(!err.what().contains("non-zero value"))
+    }
 }

--- a/mlx-rs/src/error.rs
+++ b/mlx-rs/src/error.rs
@@ -97,6 +97,7 @@ impl From<Infallible> for Exception {
 }
 
 thread_local! {
+    static CLOSURE_ERROR: Cell<Option<Exception>> = Cell::new(None);
     static LAST_MLX_ERROR: Cell<*const c_char> = const { Cell::new(std::ptr::null()) };
     pub(crate) static INIT_ERR_HANDLER: Once = const { Once::new() };
 }
@@ -120,6 +121,14 @@ pub fn setup_mlx_error_handler() {
     unsafe {
         mlx_sys::mlx_set_error_handler(Some(handler), data_ptr, Some(dtor));
     }
+}
+
+pub(crate) fn set_closure_error(err: Exception) {
+    CLOSURE_ERROR.with(|closure_error| closure_error.set(Some(err)));
+}
+
+pub(crate) fn get_and_clear_closure_error() -> Option<Exception> {
+    CLOSURE_ERROR.with(|closure_error| closure_error.replace(None))
 }
 
 pub(crate) fn get_and_clear_last_mlx_error() -> Option<Exception> {

--- a/mlx-rs/src/error.rs
+++ b/mlx-rs/src/error.rs
@@ -97,7 +97,7 @@ impl From<Infallible> for Exception {
 }
 
 thread_local! {
-    static CLOSURE_ERROR: Cell<Option<Exception>> = Cell::new(None);
+    static CLOSURE_ERROR: Cell<Option<Exception>> = const { Cell::new(None) };
     static LAST_MLX_ERROR: Cell<*const c_char> = const { Cell::new(std::ptr::null()) };
     pub(crate) static INIT_ERR_HANDLER: Once = const { Once::new() };
 }

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -627,6 +627,10 @@ mod tests {
         let b = array!([4.0, 5.0]);
         let result = fallible_jvp(f, &[a, b], &[array!(1.0f32), array!(3.0f32)]);
         assert!(result.is_err());
+
+        // Check that the error is not just "mlx_closure returned a non-zero value"
+        let err = result.unwrap_err();
+        assert!(!err.what().contains("non-zero value"))
     }
 
     #[test]
@@ -662,6 +666,10 @@ mod tests {
         let b = array!([4.0, 5.0]);
         let result = fallible_vjp(f, &[a, b], &[array!(1.0f32)]);
         assert!(result.is_err());
+
+        // Check that the error is not just "mlx_closure returned a non-zero value"
+        let err = result.unwrap_err();
+        assert!(!err.what().contains("non-zero value"))
     }
 
     #[test]
@@ -723,5 +731,9 @@ mod tests {
         let b = array!([4.0, 5.0]);
         let result = value_and_grad(fun, argnums)(&[a, b]);
         assert!(result.is_err());
+
+        // Check that the error is not just "mlx_closure returned a non-zero value"
+        let err = result.unwrap_err();
+        assert!(!err.what().contains("non-zero value"))
     }
 }

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -57,11 +57,9 @@ fn jvp_inner(
             c_tangents.as_ptr(),
         )
     })
-    .map_err(|e| {
-        match get_and_clear_closure_error() {
-            Some(err) => err,
-            None => e,
-        }
+    .map_err(|e| match get_and_clear_closure_error() {
+        Some(err) => err,
+        None => e,
     })
 }
 
@@ -121,11 +119,9 @@ fn vjp_inner(
             c_cotangents.as_ptr(),
         )
     })
-    .map_err(|e| {
-        match get_and_clear_closure_error() {
-            Some(err) => err,
-            None => e,
-        }
+    .map_err(|e| match get_and_clear_closure_error() {
+        Some(err) => err,
+        None => e,
     })
 }
 
@@ -179,11 +175,10 @@ fn value_and_gradient(
             value_and_grad,
             input_vector.as_ptr(),
         )
-    }).map_err(|e| {
-        match get_and_clear_closure_error() {
-            Some(err) => err,
-            None => e,
-        }
+    })
+    .map_err(|e| match get_and_clear_closure_error() {
+        Some(err) => err,
+        None => e,
     })
 }
 

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, rc::Rc};
 use mlx_sys::mlx_closure_value_and_grad;
 
 use crate::{
-    error::{Exception, Result},
+    error::{get_and_clear_closure_error, Exception, Result},
     module::ModuleParamRef,
     utils::{guard::Guarded, Closure, IntoOption, VectorArray},
     Array,
@@ -56,6 +56,12 @@ fn jvp_inner(
             c_primals.as_ptr(),
             c_tangents.as_ptr(),
         )
+    })
+    .map_err(|e| {
+        match get_and_clear_closure_error() {
+            Some(err) => err,
+            None => e,
+        }
     })
 }
 
@@ -115,6 +121,12 @@ fn vjp_inner(
             c_cotangents.as_ptr(),
         )
     })
+    .map_err(|e| {
+        match get_and_clear_closure_error() {
+            Some(err) => err,
+            None => e,
+        }
+    })
 }
 
 /// Compute the vector-Jacobian product.
@@ -167,6 +179,11 @@ fn value_and_gradient(
             value_and_grad,
             input_vector.as_ptr(),
         )
+    }).map_err(|e| {
+        match get_and_clear_closure_error() {
+            Some(err) => err,
+            None => e,
+        }
     })
 }
 

--- a/mlx-rs/src/utils/mod.rs
+++ b/mlx-rs/src/utils/mod.rs
@@ -336,7 +336,7 @@ where
             Err(err) => {
                 set_closure_error(err);
                 FAILURE
-            },
+            }
         }
     }
 }

--- a/mlx-rs/src/utils/mod.rs
+++ b/mlx-rs/src/utils/mod.rs
@@ -1,6 +1,7 @@
 use guard::Guarded;
 use mlx_sys::mlx_vector_array;
 
+use crate::error::set_closure_error;
 use crate::{complex64, error::Exception, Array, FromNested};
 use std::collections::HashMap;
 use std::{marker::PhantomData, rc::Rc};
@@ -321,7 +322,8 @@ where
         let mut closure = Box::from_raw(raw_closure);
         let arrays = match mlx_vector_array_values(vector_array) {
             Ok(arrays) => arrays,
-            Err(_) => {
+            Err(e) => {
+                set_closure_error(e);
                 return FAILURE;
             }
         };
@@ -331,7 +333,10 @@ where
                 *ret = new_mlx_vector_array(result);
                 SUCCESS
             }
-            Err(_) => FAILURE,
+            Err(err) => {
+                set_closure_error(err);
+                FAILURE
+            },
         }
     }
 }


### PR DESCRIPTION
The default error message yielded from the revamped c binding isn't very helpful (`"mlx_closure returned a non-zero value"`). This PR caches the error caught in the execution of the closure and return that instead.

Fixes: #158 