### PR TITLE
chore: bump and unify version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,18 @@
 [workspace.package]
-version = "0.14.0"
+# All but mlx-sys should follow the same version. mlx-sys should follow 
+# the version of mlx-c.
+version = "0.21.0"
+edition = "2021"
 authors = [
     "Minghua Wu <michael.wu1107@gmail.com>",
     "David Chavez <david@dcvz.io>",
 ]
+
+repository = "https://github.com/oxideai/mlx-rs"
+keywords = ["mlx", "deep-learning", "machine-learning"]
+categories = ["science"]
+license = "MIT OR Apache-2.0"
+documentation = "https://oxideai.github.io/mlx-rs/mlx_rs/"
 
 [workspace]
 members = [
@@ -20,10 +29,9 @@ resolver = "2"
 [workspace.dependencies]
 # workspace local dependencies
 mlx-sys = { version = "0.1.0", path = "mlx-sys" }
-mlx-macros = { version = "0.1.0", path = "mlx-macros" }
-mlx-internal-macros = { version = "0.1.0", path = "mlx-internal-macros" }
-mlx-rs = { version = "0.14.0", path = "mlx-rs" }
-mlx-nn = { version = "0.14.0", path = "mlx-nn" }
+mlx-macros = { version = "0.21.0", path = "mlx-macros" }
+mlx-internal-macros = { version = "0.21.0", path = "mlx-internal-macros" }
+mlx-rs = { version = "0.21.0", path = "mlx-rs" }
 
 # external dependencies
 thiserror = "1"

--- a/mlx-internal-macros/Cargo.toml
+++ b/mlx-internal-macros/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "mlx-internal-macros"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+documentation.workspace = true
+description = "Internal procedural macros for mlx-rs"
 
 [lib]
 proc-macro = true

--- a/mlx-macros/Cargo.toml
+++ b/mlx-macros/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "mlx-macros"
-version = "0.1.0"
-authors = ["Minghua Wu <michael.wu1107@gmail.com>", "David Chavez <david@dcvz.io>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+documentation.workspace = true
 
-description = "Code generation crate for mlx-rs"
-repository = "https://github.com/oxideai/mlx-rs"
-keywords = ["mlx", "deep-learning", "machine-learning"]
-categories = ["science"]
-license = "MIT OR Apache-2.0"
-
+description = "Procedural macros for mlx-rs"
 
 [lib]
 proc-macro = true

--- a/mlx-rs/Cargo.toml
+++ b/mlx-rs/Cargo.toml
@@ -2,13 +2,13 @@
 name = "mlx-rs"
 version.workspace = true
 authors.workspace = true
-edition = "2021"
-
+edition.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+documentation.workspace = true
 description = "Unofficial rust wrapper for Apple's mlx machine learning library."
-repository = "https://github.com/oxideai/mlx-rs"
-keywords = ["mlx", "deep-learning", "machine-learning"]
-categories = ["science"]
-license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [package.metadata.docs.rs]

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "mlx-sys"
-version = "0.1.0"
-authors = ["Minghua Wu <michael.wu1107@gmail.com>", "David Chavez <david@dcvz.io>"]
-edition = "2021"
+version = "0.1.0" # mlx-sys version should follow that of mlx-c
+authors.workspace = true
+edition.workspace = true
 
 description = "Low-level interface and binding generation for the mlx library"
-repository = "https://github.com/oxideai/mlx-rs"
-keywords = ["mlx", "deep-learning", "machine-learning"]
-categories = ["science"]
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
 readme = "README.md"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
@dcvz Shall we use the workspace version (whatever upstream `mlx` version that `mlx-c` depends on, `"0.21.0"` in this case) for all but `mlx-sys`? And `mlx-sys` will follow the version of `mlx-c` (`"0.1.0"` in this case).