### PR TITLE
feat: Separate `grad` into two functions

### DIFF
--- a/mlx-rs/examples/linear_regression.rs
+++ b/mlx-rs/examples/linear_regression.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Ok(loss)
     };
 
-    let mut grad_fn = transforms::grad(loss_fn, &[0]);
+    let mut grad_fn = transforms::grad(loss_fn);
 
     let now = std::time::Instant::now();
     let mut inputs = [w, x, y];

--- a/mlx-rs/examples/tutorial.rs
+++ b/mlx-rs/examples/tutorial.rs
@@ -80,7 +80,7 @@ fn automatic_differentiation() {
     }
 
     fn calculate_grad(func: impl Fn(&Array) -> Result<Array>, arg: &Array) -> Result<Array> {
-        grad(&func, &[0])(arg)
+        grad(&func)(arg)
     }
 
     let x = Array::from(1.5);

--- a/mlx-rs/src/transforms/grad.rs
+++ b/mlx-rs/src/transforms/grad.rs
@@ -13,12 +13,7 @@ fn build_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<Vec<Array>> + 'a {
     move |arrays: &[Array]| -> Result<Vec<Array>> {
         let cvg = ClosureValueAndGrad::try_from_op(|res| unsafe {
-            mlx_sys::mlx_value_and_grad(
-                res,
-                closure.as_ptr(),
-                argnums.as_ptr(),
-                argnums.len(),
-            )
+            mlx_sys::mlx_value_and_grad(res, closure.as_ptr(), argnums.as_ptr(), argnums.len())
         })?;
         let result = value_and_gradient(cvg.as_ptr(), arrays.iter())?;
         Ok(result.1)
@@ -207,12 +202,10 @@ where
 
 /// Returns a function which computes the gradient of `f` with the default
 /// argument numbers `&[0]`.
-/// 
+///
 /// See also [`grad_with_arg_nums`] for a version that allows specifying the
 /// argument numbers
-pub fn grad<'a, F, Args, Output, Err>(
-    f: F
-) -> impl FnMut(Args) -> Result<Output> + 'a
+pub fn grad<'a, F, Args, Output, Err>(f: F) -> impl FnMut(Args) -> Result<Output> + 'a
 where
     F: IntoGrad<'a, Args, Output, Err>,
 {
@@ -220,7 +213,7 @@ where
 }
 
 /// Returns a function which computes the gradient of `f`.
-/// 
+///
 /// See also [`grad`] for a version that uses the default argument numbers
 /// `&[0]`.
 pub fn grad_with_argnums<'a, F, Args, Output, Err>(
@@ -249,7 +242,8 @@ mod tests {
         let argnums = &[0];
 
         // TODO: how to make this more "functional"?
-        let grad_fn = move |args: &[Array]| -> Vec<Array> { grad_with_argnums(fun, argnums)(args).unwrap() };
+        let grad_fn =
+            move |args: &[Array]| -> Vec<Array> { grad_with_argnums(fun, argnums)(args).unwrap() };
         let (z, d2fdx2) = value_and_grad_with_argnums(grad_fn, argnums)(x).unwrap();
 
         assert_eq!(z[0].item::<f32>(), 1.0);

--- a/mlx-rs/src/transforms/grad.rs
+++ b/mlx-rs/src/transforms/grad.rs
@@ -9,15 +9,15 @@ use super::{value_and_gradient, ClosureValueAndGrad};
 #[inline]
 fn build_gradient_inner<'a>(
     closure: Closure<'a>,
-    argument_numbers: &'a [i32],
+    argnums: &'a [i32],
 ) -> impl FnMut(&[Array]) -> Result<Vec<Array>> + 'a {
     move |arrays: &[Array]| -> Result<Vec<Array>> {
         let cvg = ClosureValueAndGrad::try_from_op(|res| unsafe {
             mlx_sys::mlx_value_and_grad(
                 res,
                 closure.as_ptr(),
-                argument_numbers.as_ptr(),
-                argument_numbers.len(),
+                argnums.as_ptr(),
+                argnums.len(),
             )
         })?;
         let result = value_and_gradient(cvg.as_ptr(), arrays.iter())?;
@@ -27,25 +27,25 @@ fn build_gradient_inner<'a>(
 
 fn build_gradient<'a, F>(
     f: F,
-    argument_numbers: &'a [i32],
+    argnums: &'a [i32],
 ) -> impl FnMut(&[Array]) -> Result<Vec<Array>> + 'a
 where
     F: FnMut(&[Array]) -> Vec<Array> + 'a,
 {
-    let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
+    let argnums = argnums.into_option().unwrap_or(&[0]);
     let closure = Closure::new(f);
-    build_gradient_inner(closure, argument_numbers)
+    build_gradient_inner(closure, argnums)
 }
 
 fn build_fallible_gradient<'a, F>(
     f: F,
-    argument_numbers: &'a [i32],
+    argnums: &'a [i32],
 ) -> impl FnMut(&[Array]) -> Result<Vec<Array>> + 'a
 where
     F: FnMut(&[Array]) -> Result<Vec<Array>> + 'a,
 {
     let closure = Closure::new_fallible(f);
-    build_gradient_inner(closure, argument_numbers)
+    build_gradient_inner(closure, argnums)
 }
 
 /// Trait for functions/closures that can be converted into a closure that computes the gradient.
@@ -53,7 +53,7 @@ pub trait IntoGrad<'a, Args, Output, Err> {
     /// Convert the function/closure into a closure that computes the gradient.
     fn into_grad(
         self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(Args) -> Result<Output> + 'a;
 }
 
@@ -66,10 +66,10 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&[Array]) -> Result<Vec<Array>> + 'a {
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        build_gradient(self, argument_numbers)
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        build_gradient(self, argnums)
     }
 }
 
@@ -80,10 +80,10 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&[Array]) -> Result<Vec<Array>> + 'a {
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        build_fallible_gradient(self, argument_numbers)
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        build_fallible_gradient(self, argnums)
     }
 }
 
@@ -94,11 +94,11 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         mut self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&Array) -> Result<Array> + 'a {
         let f = move |args: &[Array]| -> Vec<Array> { vec![self(&args[0])] };
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        let mut g = build_gradient(f, argument_numbers);
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        let mut g = build_gradient(f, argnums);
         move |args: &Array| -> Result<Array> {
             let args_clone = &[args.clone()];
             let result = g(args_clone)?;
@@ -114,11 +114,11 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         mut self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&Array) -> Result<Array> + 'a {
         let f = move |args: &[Array]| -> Result<Vec<Array>> { self(&args[0]).map(|res| vec![res]) };
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        let mut g = build_fallible_gradient(f, argument_numbers);
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        let mut g = build_fallible_gradient(f, argnums);
         move |args: &Array| -> Result<Array> {
             let args_clone = &[args.clone()];
             let result = g(args_clone)?;
@@ -134,11 +134,11 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         mut self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&[Array]) -> Result<Array> + 'a {
         let f = move |args: &[Array]| -> Vec<Array> { vec![self(args)] };
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        let mut g = build_gradient(f, argument_numbers);
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        let mut g = build_gradient(f, argnums);
         move |args: &[Array]| -> Result<Array> {
             let result = g(args)?;
             Ok(result.into_iter().next().unwrap())
@@ -153,11 +153,11 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         mut self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&[Array]) -> Result<Array> + 'a {
         let f = move |args: &[Array]| -> Result<Vec<Array>> { self(args).map(|res| vec![res]) };
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        let mut g = build_fallible_gradient(f, argument_numbers);
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        let mut g = build_fallible_gradient(f, argnums);
         move |args: &[Array]| -> Result<Array> {
             let result = g(args)?;
             Ok(result.into_iter().next().unwrap())
@@ -172,11 +172,11 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         mut self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&Array) -> Result<Vec<Array>> + 'a {
         let f = move |args: &[Array]| -> Vec<Array> { self(&args[0]) };
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        let mut g = build_gradient(f, argument_numbers);
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        let mut g = build_gradient(f, argnums);
         move |args: &Array| -> Result<Vec<Array>> {
             let args_clone = &[args.clone()];
             let result = g(args_clone)?;
@@ -192,11 +192,11 @@ where
     #[allow(refining_impl_trait)]
     fn into_grad(
         mut self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&Array) -> Result<Vec<Array>> + 'a {
         let f = move |args: &[Array]| -> Result<Vec<Array>> { self(&args[0]) };
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        let mut g = build_fallible_gradient(f, argument_numbers);
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        let mut g = build_fallible_gradient(f, argnums);
         move |args: &Array| -> Result<Vec<Array>> {
             let args_clone = &[args.clone()];
             let result = g(args_clone)?;
@@ -205,22 +205,39 @@ where
     }
 }
 
-/// Returns a function which computes the gradient of `f`.
+/// Returns a function which computes the gradient of `f` with the default
+/// argument numbers `&[0]`.
+/// 
+/// See also [`grad_with_arg_nums`] for a version that allows specifying the
+/// argument numbers
 pub fn grad<'a, F, Args, Output, Err>(
-    f: F,
-    argument_numbers: impl IntoOption<&'a [i32]>,
+    f: F
 ) -> impl FnMut(Args) -> Result<Output> + 'a
 where
     F: IntoGrad<'a, Args, Output, Err>,
 {
-    f.into_grad(argument_numbers)
+    f.into_grad(None)
+}
+
+/// Returns a function which computes the gradient of `f`.
+/// 
+/// See also [`grad`] for a version that uses the default argument numbers
+/// `&[0]`.
+pub fn grad_with_argnums<'a, F, Args, Output, Err>(
+    f: F,
+    argnums: impl IntoOption<&'a [i32]>,
+) -> impl FnMut(Args) -> Result<Output> + 'a
+where
+    F: IntoGrad<'a, Args, Output, Err>,
+{
+    f.into_grad(argnums)
 }
 
 #[cfg(test)]
 mod tests {
 
     use crate::{
-        transforms::{grad, value_and_grad},
+        transforms::{grad, grad_with_argnums, value_and_grad, value_and_grad_with_argnums},
         Array,
     };
 
@@ -232,8 +249,14 @@ mod tests {
         let argnums = &[0];
 
         // TODO: how to make this more "functional"?
-        let grad_fn = move |args: &[Array]| -> Vec<Array> { grad(fun, argnums)(args).unwrap() };
-        let (z, d2fdx2) = value_and_grad(grad_fn, argnums)(x).unwrap();
+        let grad_fn = move |args: &[Array]| -> Vec<Array> { grad_with_argnums(fun, argnums)(args).unwrap() };
+        let (z, d2fdx2) = value_and_grad_with_argnums(grad_fn, argnums)(x).unwrap();
+
+        assert_eq!(z[0].item::<f32>(), 1.0);
+        assert_eq!(d2fdx2[0].item::<f32>(), 0.0);
+
+        let grad_fn = move |args: &[Array]| -> Vec<Array> { grad(fun)(args).unwrap() };
+        let (z, d2fdx2) = value_and_grad(grad_fn)(x).unwrap();
 
         assert_eq!(z[0].item::<f32>(), 1.0);
         assert_eq!(d2fdx2[0].item::<f32>(), 0.0);

--- a/mlx-rs/src/transforms/value_and_grad.rs
+++ b/mlx-rs/src/transforms/value_and_grad.rs
@@ -8,15 +8,15 @@ use super::{value_and_gradient, ClosureValueAndGrad};
 
 fn build_value_and_gradient_inner<'a>(
     closure: Closure<'a>,
-    argument_numbers: &'a [i32],
+    argnums: &'a [i32],
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a {
     move |arrays: &[Array]| unsafe {
         let cvg = ClosureValueAndGrad::try_from_op(|res| {
             mlx_sys::mlx_value_and_grad(
                 res,
                 closure.as_ptr(),
-                argument_numbers.as_ptr(),
-                argument_numbers.len(),
+                argnums.as_ptr(),
+                argnums.len(),
             )
         })?;
         value_and_gradient(cvg.as_ptr(), arrays.iter())
@@ -25,24 +25,24 @@ fn build_value_and_gradient_inner<'a>(
 
 fn build_value_and_gradient<'a, F>(
     f: F,
-    argument_numbers: &'a [i32],
+    argnums: &'a [i32],
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a
 where
     F: FnMut(&[Array]) -> Vec<Array> + 'a,
 {
     let closure = Closure::new(f);
-    build_value_and_gradient_inner(closure, argument_numbers)
+    build_value_and_gradient_inner(closure, argnums)
 }
 
 fn build_fallible_value_and_gradient<'a, F>(
     f: F,
-    argument_numbers: &'a [i32],
+    argnums: &'a [i32],
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a
 where
     F: FnMut(&[Array]) -> Result<Vec<Array>> + 'a,
 {
     let closure = Closure::new_fallible(f);
-    build_value_and_gradient_inner(closure, argument_numbers)
+    build_value_and_gradient_inner(closure, argnums)
 }
 
 /// Trait for functions/closures that can be converted into a closure that computes the value and
@@ -51,7 +51,7 @@ pub trait IntoValueAndGrad<'a, Err> {
     /// Convert the function/closure into a closure that computes the value and gradient.
     fn into_value_and_grad(
         self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a;
 }
 
@@ -64,10 +64,10 @@ where
     #[allow(refining_impl_trait)]
     fn into_value_and_grad(
         self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a {
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        build_value_and_gradient(self, argument_numbers)
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        build_value_and_gradient(self, argnums)
     }
 }
 
@@ -78,23 +78,41 @@ where
     #[allow(refining_impl_trait)]
     fn into_value_and_grad(
         self,
-        argument_numbers: impl IntoOption<&'a [i32]>,
+        argnums: impl IntoOption<&'a [i32]>,
     ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a {
-        let argument_numbers = argument_numbers.into_option().unwrap_or(&[0]);
-        build_fallible_value_and_gradient(self, argument_numbers)
+        let argnums = argnums.into_option().unwrap_or(&[0]);
+        build_fallible_value_and_gradient(self, argnums)
     }
 }
 
-/// Returns a function which computes the value and gradient of `f`.
+/// Returns a function which computes the value and gradient of `f` with a
+/// default argument number `&[0]`.
+/// 
+/// See also [`value_and_grad_with_arg_nums`] for a version that allows
+/// specifying the argument numbers
 pub fn value_and_grad<'a, F, Err>(
     f: F,
-    argument_numbers: impl IntoOption<&'a [i32]>,
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a
 where
     F: IntoValueAndGrad<'a, Err> + 'a,
 {
-    f.into_value_and_grad(argument_numbers)
+    f.into_value_and_grad(None)
 }
+
+/// Returns a function which computes the value and gradient of `f`.
+/// 
+/// See also [`value_and_grad`] for a version that uses the default argument
+/// numbers `&[0]`.
+pub fn value_and_grad_with_argnums<'a, F, Err>(
+    f: F,
+    argnums: impl IntoOption<&'a [i32]>,
+) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a
+where
+    F: IntoValueAndGrad<'a, Err> + 'a,
+{
+    f.into_value_and_grad(argnums)
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -109,8 +127,11 @@ mod tests {
         let x = &[Array::from_f32(1.0)];
         let fun = |argin: &[Array]| -> Vec<Array> { vec![&argin[0] + 1.0] };
         let argnums = &[0];
-        let (y, dfdx) = value_and_grad(fun, argnums)(x).unwrap();
+        let (y, dfdx) = value_and_grad_with_argnums(fun, argnums)(x).unwrap();
+        assert_eq!(y[0].item::<f32>(), 2.0);
+        assert_eq!(dfdx[0].item::<f32>(), 1.0);
 
+        let (y, dfdx) = value_and_grad(fun)(x).unwrap();
         assert_eq!(y[0].item::<f32>(), 2.0);
         assert_eq!(dfdx[0].item::<f32>(), 1.0);
     }
@@ -125,14 +146,20 @@ mod tests {
         let argnums = &[0];
         let x = array!(1.0f32);
         let y = array!(1.0f32);
-        let result = value_and_grad(fun, argnums)(&[x, y]);
+        let args = &[x, y];
+        let result = value_and_grad_with_argnums(fun, argnums)(args);
+        assert!(result.is_ok());
+        let result = value_and_grad(fun)(args);
         assert!(result.is_ok());
 
         // Error case
         // Use non-broadcastable shapes
         let a = array!([1.0, 2.0, 3.0]);
         let b = array!([4.0, 5.0]);
-        let result = value_and_grad(fun, argnums)(&[a, b]);
+        let args = &[a, b];
+        let result = value_and_grad_with_argnums(fun, argnums)(args);
+        assert!(result.is_err());
+        let result = value_and_grad(fun)(args);
         assert!(result.is_err());
 
         // Check that the error is not just "mlx_closure returned a non-zero value"

--- a/mlx-rs/src/transforms/value_and_grad.rs
+++ b/mlx-rs/src/transforms/value_and_grad.rs
@@ -12,12 +12,7 @@ fn build_value_and_gradient_inner<'a>(
 ) -> impl FnMut(&[Array]) -> Result<(Vec<Array>, Vec<Array>)> + 'a {
     move |arrays: &[Array]| unsafe {
         let cvg = ClosureValueAndGrad::try_from_op(|res| {
-            mlx_sys::mlx_value_and_grad(
-                res,
-                closure.as_ptr(),
-                argnums.as_ptr(),
-                argnums.len(),
-            )
+            mlx_sys::mlx_value_and_grad(res, closure.as_ptr(), argnums.as_ptr(), argnums.len())
         })?;
         value_and_gradient(cvg.as_ptr(), arrays.iter())
     }
@@ -87,7 +82,7 @@ where
 
 /// Returns a function which computes the value and gradient of `f` with a
 /// default argument number `&[0]`.
-/// 
+///
 /// See also [`value_and_grad_with_arg_nums`] for a version that allows
 /// specifying the argument numbers
 pub fn value_and_grad<'a, F, Err>(
@@ -100,7 +95,7 @@ where
 }
 
 /// Returns a function which computes the value and gradient of `f`.
-/// 
+///
 /// See also [`value_and_grad`] for a version that uses the default argument
 /// numbers `&[0]`.
 pub fn value_and_grad_with_argnums<'a, F, Err>(
@@ -112,7 +107,6 @@ where
 {
     f.into_value_and_grad(argnums)
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR separates `grad` into two functions, one `grad` and the other `grad_with_argnums` where the former uses the default argnums `&[0]` and the latter allows the user to specify the `argnums`. Same is applied to `value_and_grad`