### PR TITLE
feat: Place state as the last argument in `compile_with_state`

### DIFF
--- a/mlx-rs/src/transforms/compile/compile_with_state.rs
+++ b/mlx-rs/src/transforms/compile/compile_with_state.rs
@@ -432,7 +432,7 @@ impl<F> CompiledState<F> {
         state: &mut U,
     ) -> Result<Vec<Array>, Exception>
     where
-        F: FnMut(&mut U, &[Array]) -> Vec<Array>,
+        F: FnMut(&[Array], &mut U) -> Vec<Array>,
         U: Updatable,
     {
         self.call_mut_with_state(args, state).or_else(|_e| {
@@ -452,7 +452,7 @@ impl<F> CompiledState<F> {
         state: &mut U,
     ) -> Result<Vec<Array>, Exception>
     where
-        F: FnMut(&mut U, &[Array]) -> Result<Vec<Array>, Exception>,
+        F: FnMut(&[Array], &mut U) -> Result<Vec<Array>, Exception>,
         U: Updatable,
     {
         self.fallible_call_mut_with_state(args, state)
@@ -473,7 +473,7 @@ impl<F> CompiledState<F> {
         state: &mut U,
     ) -> Result<Vec<Array>, Exception>
     where
-        F: FnMut(&mut U, &[Array]) -> Vec<Array>,
+        F: FnMut(&[Array], &mut U) -> Vec<Array>,
         U: Updatable,
     {
         let args_len = args.len();
@@ -543,7 +543,7 @@ impl<F> CompiledState<F> {
         state: &mut U,
     ) -> Result<Vec<Array>, Exception>
     where
-        F: FnMut(&mut U, &[Array]) -> Result<Vec<Array>, Exception>,
+        F: FnMut(&[Array], &mut U) -> Result<Vec<Array>, Exception>,
         U: Updatable,
     {
         let args_len = args.len();

--- a/mlx-rs/src/transforms/compile/compile_with_state.rs
+++ b/mlx-rs/src/transforms/compile/compile_with_state.rs
@@ -507,7 +507,7 @@ impl<F> CompiledState<F> {
             }
 
             // call the function with the tracer arguments and the state holding tracers
-            let mut result = (f)(*state_clone.borrow_mut(), tracer_args);
+            let mut result = (f)(tracer_args, *state_clone.borrow_mut());
 
             // recapture the state as it may have changed
             let mut state_output_tracers = state_clone
@@ -534,7 +534,7 @@ impl<F> CompiledState<F> {
         };
 
         let inner_closure = Closure::new(inner);
-        call_mut_with_state_inner(inner_closure, self.id, self.shapeless, state, args)
+        call_mut_with_state_inner(inner_closure, self.id, self.shapeless, args, state)
     }
 
     fn fallible_call_mut_with_state<U>(
@@ -577,7 +577,7 @@ impl<F> CompiledState<F> {
             }
 
             // call the function with the tracer arguments and the state holding tracers
-            let mut result = (f)(*state_clone.borrow_mut(), tracer_args)?;
+            let mut result = (f)(tracer_args, *state_clone.borrow_mut())?;
 
             // recapture the state as it may have changed
             let mut state_output_tracers = state_clone

--- a/mlx-rs/src/transforms/compile/compile_with_state.rs
+++ b/mlx-rs/src/transforms/compile/compile_with_state.rs
@@ -162,7 +162,7 @@ where
     fn compile<'args>(
         self,
         shapeless: bool,
-    ) -> impl CallMutWithState<U, Self::Args<'args>, Vec<Array>, Exception> {
+    ) -> impl CallMutWithState<Self::Args<'args>, U, Vec<Array>, Exception> {
         let id = type_id_to_usize(&self);
         let state = CompiledState {
             f: self,
@@ -186,7 +186,7 @@ where
     fn compile<'args>(
         mut self,
         shapeless: bool,
-    ) -> impl CallMutWithState<U, Self::Args<'args>, Array, Exception> {
+    ) -> impl CallMutWithState<Self::Args<'args>, U, Array, Exception> {
         let id = type_id_to_usize(&self);
         let f = move |args: &[Array], state: &mut U| -> Result<Vec<Array>, Exception> {
             let result = (self)(&args[0], state)?;
@@ -210,7 +210,7 @@ where
     fn compile<'args>(
         mut self,
         shapeless: bool,
-    ) -> impl CallMutWithState<U, Self::Args<'args>, Array, Exception> {
+    ) -> impl CallMutWithState<Self::Args<'args>, U, Array, Exception> {
         let id = type_id_to_usize(&self);
         let f = move |args: &[Array], state: &mut U| -> Result<Vec<Array>, Exception> {
             let result = (self)((&args[0], &args[1]), state)?;
@@ -332,7 +332,7 @@ where
     }
 }
 
-impl<U, F, G> CallMutWithState<U, (&Array, &Array), Array, Exception> for Compiled<F, G>
+impl<U, F, G> CallMutWithState<(&Array, &Array), U, Array, Exception> for Compiled<F, G>
 where
     F: FnMut((&Array, &Array), &mut U) -> Result<Array, Exception>,
     G: FnMut(&[Array], &mut U) -> Result<Vec<Array>, Exception>,
@@ -345,7 +345,7 @@ where
     }
 }
 
-impl<U, F, G> CallMutWithState<U, (&Array, &Array, &Array), Array, Exception> for Compiled<F, G>
+impl<U, F, G> CallMutWithState<(&Array, &Array, &Array), U, Array, Exception> for Compiled<F, G>
 where
     F: FnMut((&Array, &Array, &Array), &mut U) -> Result<Array, Exception>,
     G: FnMut(&[Array], &mut U) -> Result<Vec<Array>, Exception>,

--- a/mlx-tests/tests/test_compile_with_state.rs
+++ b/mlx-tests/tests/test_compile_with_state.rs
@@ -70,13 +70,13 @@ fn test_compile_module_and_optimizer() {
     let mut compiled = compile_with_state(step, None);
 
     // Check that the original function works
-    let original = step(x.as_slice(), &mut model);
+    let original = step(x.as_slice(), &mut state);
 
     // Make sure the compiled function produces the same result
-    let result = compiled(x.as_slice(), &mut model).unwrap();
+    let result = compiled(x.as_slice(), &mut state).unwrap();
     assert_array_eq!(&original[0], &result[0]);
     eval_params(state.0.parameters()).unwrap();
-    let result = compiled(x.as_slice(), &mut model).unwrap();
+    let result = compiled(x.as_slice(), &mut state).unwrap();
     assert_array_eq!(&original[0], &result[0]);
     eval_params(state.0.parameters()).unwrap();
 }


### PR DESCRIPTION
This PR moves state to the last argument in `compile_with_state`. This is to be consistent with other functions that have a `_with_x` variant where the `x` arg is often placed as the last argument