### PR TITLE
refactor: Remove as complex64

### DIFF
--- a/mlx-rs/src/fft/fftn.rs
+++ b/mlx-rs/src/fft/fftn.rs
@@ -7,10 +7,7 @@ use crate::{
     Stream,
 };
 
-use super::{
-    as_complex64,
-    utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked},
-};
+use super::utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked};
 
 /// One dimensional discrete Fourier Transform.
 ///
@@ -28,9 +25,8 @@ pub fn fft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-
-    let (n, axis) = resolve_size_and_axis_unchecked(&a, n.into(), axis.into());
+    let a = a.as_ref();
+    let (n, axis) = resolve_size_and_axis_unchecked(a, n.into(), axis.into());
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_fft_fft(res, a.as_ptr(), n, axis, stream.as_ref().as_ptr())
     })
@@ -52,9 +48,9 @@ pub fn fft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), Some(axes));
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), Some(axes));
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -93,8 +89,8 @@ pub fn fftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), axes.into_option());
+    let a = a.as_ref();
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), axes.into_option());
     let num_s = s.len();
     let num_axes = axes.len();
 
@@ -130,8 +126,8 @@ pub fn ifft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (n, axis) = resolve_size_and_axis_unchecked(&a, n.into(), axis.into());
+    let a = a.as_ref();
+    let (n, axis) = resolve_size_and_axis_unchecked(a, n.into(), axis.into());
 
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_fft_ifft(res, a.as_ptr(), n, axis, stream.as_ref().as_ptr())
@@ -154,9 +150,9 @@ pub fn ifft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), Some(axes));
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), Some(axes));
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -195,8 +191,8 @@ pub fn ifftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), axes.into_option());
+    let a = a.as_ref();
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), axes.into_option());
     let num_s = s.len();
     let num_axes = axes.len();
 

--- a/mlx-rs/src/fft/mod.rs
+++ b/mlx-rs/src/fft/mod.rs
@@ -164,17 +164,3 @@ pub use self::{fftn::*, rfftn::*};
 /* -------------------------------------------------------------------------- */
 /*                              Helper functions                              */
 /* -------------------------------------------------------------------------- */
-
-use crate::{complex64, error::Exception, Array, Dtype};
-use std::borrow::Cow;
-
-fn as_complex64(src: &Array) -> Result<Cow<'_, Array>, Exception> {
-    match src.dtype() {
-        Dtype::Complex64 => Ok(Cow::Borrowed(src)),
-        _ => {
-            let new_array = src.as_type::<complex64>()?;
-            new_array.eval()?;
-            Ok(Cow::Owned(new_array))
-        }
-    }
-}

--- a/mlx-rs/src/fft/rfftn.rs
+++ b/mlx-rs/src/fft/rfftn.rs
@@ -6,10 +6,7 @@ use crate::{
     Array, Stream,
 };
 
-use super::{
-    as_complex64,
-    utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked},
-};
+use super::utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked};
 
 /// One dimensional discrete Fourier Transform on a real input.
 ///
@@ -30,8 +27,8 @@ pub fn rfft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (n, axis) = resolve_size_and_axis_unchecked(&a, n.into(), axis.into());
+    let a = a.as_ref();
+    let (n, axis) = resolve_size_and_axis_unchecked(a, n.into(), axis.into());
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_fft_rfft(res, a.as_ptr(), n, axis, stream.as_ref().as_ptr())
     })
@@ -57,9 +54,9 @@ pub fn rfft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), Some(axes));
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), Some(axes));
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -101,8 +98,8 @@ pub fn rfftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), axes.into_option());
+    let a = a.as_ref();
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), axes.into_option());
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -141,11 +138,11 @@ pub fn irfft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let n = n.into();
     let axis = axis.into();
     let modify_n = n.is_none();
-    let (mut n, axis) = resolve_size_and_axis_unchecked(&a, n, axis);
+    let (mut n, axis) = resolve_size_and_axis_unchecked(a, n, axis);
     if modify_n {
         n = (n - 1) * 2;
     }
@@ -176,12 +173,12 @@ pub fn irfft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let s = s.into_option();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
     let modify_last_axis = s.is_none();
 
-    let (mut s, axes) = resolve_sizes_and_axes_unchecked(&a, s, Some(axes));
+    let (mut s, axes) = resolve_sizes_and_axes_unchecked(a, s, Some(axes));
     if modify_last_axis {
         let end = s.len() - 1;
         s[end] = (s[end] - 1) * 2;
@@ -228,12 +225,12 @@ pub fn irfftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let s = s.into_option();
     let axes = axes.into_option();
     let modify_last_axis = s.is_none();
 
-    let (mut s, axes) = resolve_sizes_and_axes_unchecked(&a, s, axes);
+    let (mut s, axes) = resolve_sizes_and_axes_unchecked(a, s, axes);
     if modify_last_axis {
         let end = s.len() - 1;
         s[end] = (s[end] - 1) * 2;


### PR DESCRIPTION
Removes unnecessary `as_complex64` before calling the corresponding fft C API. This avoids unnecessary evaluation in the fft ops.

Closes #236 