### PR TITLE
Adding mlx_real and mlx_imag functions support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 # All but mlx-sys should follow the same version. mlx-sys should follow 
 # the version of mlx-c.
-version = "0.25.0-alpha.1"
+version = "0.25.0"
 edition = "2021"
 authors = [
     "Minghua Wu <michael.wu1107@gmail.com>",
@@ -28,10 +28,10 @@ resolver = "2"
 
 [workspace.dependencies]
 # workspace local dependencies
-mlx-sys = { version = "=0.2.0-alpha.2", path = "mlx-sys" }
-mlx-macros = { version = "0.25.0-alpha.1", path = "mlx-macros" }
-mlx-internal-macros = { version = "0.25.0-alpha.1", path = "mlx-internal-macros" }
-mlx-rs = { version = "0.25.0-alpha.1", path = "mlx-rs" }
+mlx-sys = { version = "=0.2.0", path = "mlx-sys" }
+mlx-macros = { version = "0.25.0", path = "mlx-macros" }
+mlx-internal-macros = { version = "0.25.0", path = "mlx-internal-macros" }
+mlx-rs = { version = "0.25.0", path = "mlx-rs" }
 
 # external dependencies
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # workspace local dependencies
-mlx-sys = { version = "=0.1.2-release", path = "mlx-sys" }
+mlx-sys = { version = "=0.2.0-alpha", path = "mlx-sys" }
 mlx-macros = { version = "0.23", path = "mlx-macros" }
 mlx-internal-macros = { version = "0.23", path = "mlx-internal-macros" }
 mlx-rs = { version = "0.23", path = "mlx-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 # All but mlx-sys should follow the same version. mlx-sys should follow 
 # the version of mlx-c.
-version = "0.23.0"
+version = "0.25.0-alpha.1"
 edition = "2021"
 authors = [
     "Minghua Wu <michael.wu1107@gmail.com>",
@@ -28,13 +28,13 @@ resolver = "2"
 
 [workspace.dependencies]
 # workspace local dependencies
-mlx-sys = { version = "=0.2.0-alpha", path = "mlx-sys" }
-mlx-macros = { version = "0.23", path = "mlx-macros" }
-mlx-internal-macros = { version = "0.23", path = "mlx-internal-macros" }
-mlx-rs = { version = "0.23", path = "mlx-rs" }
+mlx-sys = { version = "=0.2.0-alpha.1", path = "mlx-sys" }
+mlx-macros = { version = "0.25.0-alpha.1", path = "mlx-macros" }
+mlx-internal-macros = { version = "0.25.0-alpha.1", path = "mlx-internal-macros" }
+mlx-rs = { version = "0.25.0-alpha.1", path = "mlx-rs" }
 
 # external dependencies
-thiserror = "1"
+thiserror = "2"
 float_eq = "1"
 pretty_assertions = "1.4.0"
 dyn-clone = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # workspace local dependencies
-mlx-sys = { version = "=0.2.0-alpha.1", path = "mlx-sys" }
+mlx-sys = { version = "=0.2.0-alpha.2", path = "mlx-sys" }
 mlx-macros = { version = "0.25.0-alpha.1", path = "mlx-macros" }
 mlx-internal-macros = { version = "0.25.0-alpha.1", path = "mlx-internal-macros" }
 mlx-rs = { version = "0.25.0-alpha.1", path = "mlx-rs" }

--- a/examples/mistral/Cargo.toml
+++ b/examples/mistral/Cargo.toml
@@ -18,3 +18,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 safetensors.workspace = true
+
+# Fix idna-adapter version so that it works with rustc 1.81
+idna_adapter = "=1.2.0"

--- a/examples/mistral/src/main.rs
+++ b/examples/mistral/src/main.rs
@@ -5,7 +5,7 @@ use hf_hub::{
 use mlx_rs::{
     array,
     module::{Module, ModuleParametersExt},
-    ops::indexing::{argmax, IndexOp, NewAxis},
+    ops::indexing::{argmax_axis, IndexOp, NewAxis},
     random::categorical,
     transforms::eval,
     Array,
@@ -81,7 +81,7 @@ fn load_model(repo: &ApiRepo) -> Result<Mistral> {
 
 fn sample(logits: &Array, temp: f32) -> Result<Array> {
     match temp {
-        0.0 => argmax(logits, -1, None).map_err(Into::into),
+        0.0 => argmax_axis(logits, -1, None).map_err(Into::into),
         _ => {
             let logits = logits.multiply(array!(1.0 / temp))?;
             categorical(logits, None, None, None).map_err(Into::into)
@@ -156,7 +156,7 @@ impl Iterator for Generate<'_> {
                     cache: new_cache,
                 } = tri!(self.model.forward(input));
 
-                let logits = tri!(logits.squeeze(&[1]));
+                let logits = tri!(logits.squeeze_axes(&[1]));
                 let y = tri!(sample(&logits, self.temp));
 
                 self.state = GenerateState::Continue {

--- a/examples/mistral/src/main.rs
+++ b/examples/mistral/src/main.rs
@@ -210,14 +210,14 @@ fn main() -> Result<()> {
             eval(&tokens)?;
             let slice: Vec<u32> = tokens.drain(..).map(|t| t.item::<u32>()).collect();
             let s = tokenizer.decode(&slice, true)?;
-            print!("{}", s);
+            print!("{s}");
         }
     }
 
     eval(&tokens)?;
     let slice: Vec<u32> = tokens.drain(..).map(|t| t.item::<u32>()).collect();
     let s = tokenizer.decode(&slice, true)?;
-    println!("{}", s);
+    println!("{s}");
 
     println!("------");
 

--- a/examples/mistral/src/model.rs
+++ b/examples/mistral/src/model.rs
@@ -1,7 +1,7 @@
 use mlx_rs::{
     builder::Builder,
     error::Exception,
-    fast::scaled_dot_product_attention,
+    fast::{scaled_dot_product_attention, ScaledDotProductAttentionMask},
     macros::{ModuleParameters, Quantizable},
     module::Module,
     nn,
@@ -95,7 +95,7 @@ impl Attention {
 
 struct AttentionInput<'a> {
     x: &'a Array,
-    mask: Option<&'a Array>,
+    mask: Option<ScaledDotProductAttentionMask<'a>>,
     cache: Option<(&'a Array, &'a Array)>,
 }
 
@@ -380,7 +380,7 @@ impl Module<MistralInput<'_>> for Mistral {
             let cache_entry = cache.get(i).and_then(Option::as_ref).map(|(k, v)| (k, v));
             let input = AttentionInput {
                 x: &h,
-                mask: mask.as_ref(),
+                mask: mask.as_ref().map(Into::into),
                 cache: cache_entry,
             };
             let output = layer.forward(input)?;

--- a/examples/mnist/src/data.rs
+++ b/examples/mnist/src/data.rs
@@ -1,6 +1,6 @@
 // TODO
 
-use mlx_rs::{error::Exception, ops::stack, Array};
+use mlx_rs::{error::Exception, ops::stack_axis, Array};
 use mnist::{Mnist, MnistBuilder};
 
 const IMAGE_SIZE: usize = 28 * 28;
@@ -36,7 +36,7 @@ pub fn read_data() -> (Vec<Array>, Vec<u8>, Array, Array) {
         .chunks_exact(IMAGE_SIZE)
         .map(|chunk| Array::from_slice(chunk, &[IMAGE_SIZE as i32]))
         .collect::<Vec<_>>();
-    let test_images = stack(&test_images, 0).unwrap();
+    let test_images = stack_axis(&test_images, 0).unwrap();
 
     let test_labels = Array::from_slice(&tst_lbl, &[tst_lbl.len() as i32]);
 
@@ -53,7 +53,7 @@ pub fn iterate_data<'a>(
         .chunks_exact(batch_size)
         .zip(labels.chunks_exact(batch_size))
         .map(move |(images, labels)| {
-            let images = stack(images, 0)?;
+            let images = stack_axis(images, 0)?;
             let labels = Array::from_slice(labels, &[batch_size as i32]);
             Ok((images, labels))
         })

--- a/examples/mnist/src/main.rs
+++ b/examples/mnist/src/main.rs
@@ -4,7 +4,7 @@ use mlx_rs::{
     losses::{CrossEntropyBuilder, LossReduction},
     module::{Module, ModuleParameters},
     nn,
-    ops::{eq, indexing::argmax, mean},
+    ops::{eq, indexing::argmax_axis, mean},
     optimizers::{Optimizer, Sgd},
     transforms::eval_params,
     Array,
@@ -18,7 +18,7 @@ mod data;
 
 fn eval_fn(model: &mut mlp::Mlp, (x, y): (&Array, &Array)) -> Result<Array, Exception> {
     let y_pred = model.forward(x)?;
-    let accuracy = mean(&eq(&argmax(&y_pred, 1, None)?, y)?, None, None)?;
+    let accuracy = mean(&eq(&argmax_axis(&y_pred, 1, None)?, y)?, None)?;
     Ok(accuracy)
 }
 

--- a/mlx-internal-macros/src/derive_buildable.rs
+++ b/mlx-internal-macros/src/derive_buildable.rs
@@ -22,7 +22,7 @@ pub(crate) fn expand_derive_buildable(input: DeriveInput) -> Result<proc_macro2:
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 
     let struct_ident = &struct_prop.ident;
-    let builder_ident = syn::Ident::new(&format!("{}Builder", struct_ident), struct_ident.span());
+    let builder_ident = syn::Ident::new(&format!("{struct_ident}Builder"), struct_ident.span());
     let root = match struct_prop.root {
         Some(path) => path,
         None => syn::parse_quote!(::mlx_rs),

--- a/mlx-internal-macros/src/generate_builder.rs
+++ b/mlx-internal-macros/src/generate_builder.rs
@@ -23,7 +23,7 @@ pub(crate) fn expand_generate_builder(input: &DeriveInput) -> Result<proc_macro2
 
     let struct_ident = &struct_prop.ident;
     let builder_struct_ident =
-        syn::Ident::new(&format!("{}Builder", struct_ident), struct_ident.span());
+        syn::Ident::new(&format!("{struct_ident}Builder"), struct_ident.span());
     let root = match struct_prop.root {
         Some(path) => path,
         None => syn::parse_quote!(::mlx_rs),

--- a/mlx-internal-macros/src/generate_macro.rs
+++ b/mlx-internal-macros/src/generate_macro.rs
@@ -200,8 +200,7 @@ fn generate_macro(
     );
 
     let macro_docs = format!(
-        "Macro generated for the function [`{}::{}`]. See the function documentation for more details.",
-        doc_mod_path, trimmed_fn_ident
+        "Macro generated for the function [`{doc_mod_path}::{trimmed_fn_ident}`]. See the function documentation for more details."
     );
 
     let generated = quote! {

--- a/mlx-internal-macros/src/lib.rs
+++ b/mlx-internal-macros/src/lib.rs
@@ -82,13 +82,13 @@ pub fn default_device(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Prepend default stream initialization
     let default_stream_stmt = match input.map(|input| input.device) {
         Some(DeviceType::Cpu) => parse_quote! {
-            let stream = StreamOrDevice::cpu();
+            let stream = crate::StreamOrDevice::cpu();
         },
         Some(DeviceType::Gpu) => parse_quote! {
-            let stream = StreamOrDevice::gpu();
+            let stream = crate::StreamOrDevice::gpu();
         },
         None => parse_quote! {
-            let stream = StreamOrDevice::default();
+            let stream = crate::StreamOrDevice::default();
         },
     };
     input_fn.block.stmts.insert(0, default_stream_stmt);

--- a/mlx-internal-macros/src/lib.rs
+++ b/mlx-internal-macros/src/lib.rs
@@ -82,13 +82,13 @@ pub fn default_device(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Prepend default stream initialization
     let default_stream_stmt = match input.map(|input| input.device) {
         Some(DeviceType::Cpu) => parse_quote! {
-            let stream = crate::StreamOrDevice::cpu();
+            let stream = crate::Stream::task_local_or_cpu();
         },
         Some(DeviceType::Gpu) => parse_quote! {
-            let stream = crate::StreamOrDevice::gpu();
+            let stream = crate::Stream::task_local_or_gpu();
         },
         None => parse_quote! {
-            let stream = crate::StreamOrDevice::default();
+            let stream = crate::Stream::task_local_or_default();
         },
     };
     input_fn.block.stmts.insert(0, default_stream_stmt);

--- a/mlx-internal-macros/src/shared.rs
+++ b/mlx-internal-macros/src/shared.rs
@@ -52,9 +52,9 @@ impl BuilderStructAnalyzer<'_> {
         let optional_field_tys = self.optional_fields.iter().map(|field| &field.ty);
         let optional_field_defaults = self.optional_fields.iter().map(|field| &field.default);
 
-        let doc = format!("Builder for `{}`.", struct_ident);
+        let doc = format!("Builder for `{struct_ident}`.");
 
-        let mandatory_field_doc = format!("See [`{}`] for more information.", struct_ident);
+        let mandatory_field_doc = format!("See [`{struct_ident}`] for more information.");
         let optional_field_doc =
             optional_field_idents
                 .iter()
@@ -97,7 +97,7 @@ impl BuilderStructAnalyzer<'_> {
         let optional_field_idents = self.optional_fields.iter().map(|field| &field.ident);
         let optional_field_defaults = self.optional_fields.iter().map(|field| &field.default);
 
-        let doc = format!("Creates a new [`{}`].", builder_struct_ident);
+        let doc = format!("Creates a new [`{builder_struct_ident}`].");
 
         quote! {
             impl #impl_generics #builder_struct_ident #type_generics #where_clause {
@@ -124,7 +124,7 @@ impl BuilderStructAnalyzer<'_> {
 
             let ident = &field.ident;
             let ty = &field.ty;
-            let doc = format!("Sets the value of [`{}`].", ident);
+            let doc = format!("Sets the value of [`{ident}`].");
             Some(quote! {
                 #[doc = #doc]
                 pub fn #ident(mut self, #ident: impl Into<#ty>) -> Self {
@@ -205,7 +205,7 @@ impl BuilderStructAnalyzer<'_> {
             .collect::<Vec<_>>();
         let mandatory_field_types = self.mandatory_fields.iter().map(|field| &field.ty);
 
-        let doc = format!("Creates a new instance of `{}`.", struct_ident);
+        let doc = format!("Creates a new instance of `{struct_ident}`.");
 
         // TODO: do we want to generate different code for infallible and fallible cases
         let ret = if is_default_infallible {
@@ -318,7 +318,7 @@ fn parse_fields(fields: &syn::Fields) -> Result<(Vec<MandatoryField>, Vec<Option
                 Some(default) => default,
                 None => {
                     return Err(
-                        format!("Field {} is optional but has no default value", ident).into(),
+                        format!("Field {ident} is optional but has no default value").into(),
                     )
                 }
             };

--- a/mlx-macros/src/module_parameters.rs
+++ b/mlx-macros/src/module_parameters.rs
@@ -75,6 +75,15 @@ fn impl_module_parameters_for_struct(
         const _: () = {
             #extern_import
             impl #impl_generics #root::module::ModuleParameters for #ident #ty_generics #where_clause {
+                fn num_parameters(&self) -> usize {
+                    use #root::module::Parameter;
+                    let mut count = 0;
+                    #(
+                        count += self.#field_names.count();
+                    )*
+                    count
+                }
+
                 fn freeze_parameters(&mut self, recursive: bool) {
                     use #root::module::Parameter;
                     #(self.#field_names.freeze(recursive);)*

--- a/mlx-rs/CHANGELOG.md
+++ b/mlx-rs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.25.0-alpha.1
+
+- Update `mlx-c` to version "0.2.0-alpha" and changes function signatures to
+  match the new API
+- Update `thiserror` to version "2"
+- Fix wrong states number in `compile_with_state`
+- Remove unnecessary evaluation in fft ops
+
+## 0.23.0
+
+- Update `mlx-c` to "0.1.2"
+- Added `dilation` and `groups` parameters to the convolution layer
+
 ## 0.21.1
 
 - Fix `mlx-sys` dependency to patch version in workspace

--- a/mlx-rs/examples/linear_regression.rs
+++ b/mlx-rs/examples/linear_regression.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let y = &inputs[2];
 
         let y_pred = x.matmul(w)?;
-        let loss = Array::from_f32(0.5) * ops::mean(&ops::square(y_pred - y)?, None, None)?;
+        let loss = Array::from_f32(0.5) * ops::mean(&ops::square(y_pred - y)?, None)?;
         Ok(loss)
     };
 
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let elapsed = now.elapsed();
 
     let loss = loss_fn(&inputs)?;
-    let error_norm = ops::sum(&ops::square(&(&inputs[0] - &w_star))?, None, None)?.sqrt()?;
+    let error_norm = ops::sum(&ops::square(&(&inputs[0] - &w_star))?, None)?.sqrt()?;
     let throughput = num_iterations as f32 / elapsed.as_secs_f32();
 
     println!(

--- a/mlx-rs/examples/tutorial.rs
+++ b/mlx-rs/examples/tutorial.rs
@@ -69,7 +69,7 @@ fn array_basics() {
     z.item::<f32>(); // implicit evaluation
 
     z = Array::ones::<f32>(&[2, 2]).unwrap();
-    println!("{}", z); // implicit evaluation
+    println!("{z}"); // implicit evaluation
 }
 
 fn automatic_differentiation() {

--- a/mlx-rs/src/array/mod.rs
+++ b/mlx-rs/src/array/mod.rs
@@ -41,7 +41,7 @@ impl Sealed for &Array {}
 
 impl std::fmt::Debug for Array {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/mlx-rs/src/array/mod.rs
+++ b/mlx-rs/src/array/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     error::AsSliceError,
     sealed::Sealed,
     utils::{guard::Guarded, SUCCESS},
-    Stream, StreamOrDevice,
+    Stream,
 };
 use element::FromSliceElement;
 use mlx_internal_macros::default_device;

--- a/mlx-rs/src/array/mod.rs
+++ b/mlx-rs/src/array/mod.rs
@@ -120,12 +120,11 @@ impl Array {
         Array { c_array }
     }
 
-    // // TODO: This is bugged right now. See https://github.com/ml-explore/mlx/issues/1994
-    // /// New array from a f64 scalar.
-    // pub fn from_f64(val: f64) -> Array {
-    //     let c_array = unsafe { mlx_sys::mlx_array_new_float64(val) };
-    //     Array { c_array }
-    // }
+    /// New array from a f64 scalar.
+    pub fn from_f64(val: f64) -> Array {
+        let c_array = unsafe { mlx_sys::mlx_array_new_float64(val) };
+        Array { c_array }
+    }
 
     /// New array from a complex scalar.
     pub fn from_complex(val: complex64) -> Array {
@@ -298,7 +297,6 @@ impl Array {
         Dtype::try_from(dtype).unwrap()
     }
 
-    // TODO: document that mlx is lazy
     /// Evaluate the array.
     pub fn eval(&self) -> crate::error::Result<()> {
         <() as Guarded>::try_from_op(|_| unsafe { mlx_sys::mlx_array_eval(self.as_ptr()) })
@@ -944,19 +942,18 @@ mod tests {
         assert_eq!(array.dtype(), Dtype::Float32);
     }
 
-    // TODO: this is bugged right now. See https://github.com/ml-explore/mlx/issues/1994
-    // #[test]
-    // fn new_scalar_array_from_f64() {
-    //     let array = Array::from_f64(3.14).as_dtype(Dtype::Float64).unwrap();
-    //     float_eq::assert_float_eq!(array.item::<f64>(), 3.14, abs <= 1e-5);
-    //     assert_eq!(array.item_size(), 8);
-    //     assert_eq!(array.size(), 1);
-    //     assert!(array.strides().is_empty());
-    //     assert_eq!(array.nbytes(), 8);
-    //     assert_eq!(array.ndim(), 0);
-    //     assert!(array.shape().is_empty());
-    //     assert_eq!(array.dtype(), Dtype::Float64);
-    // }
+    #[test]
+    fn new_scalar_array_from_f64() {
+        let array = Array::from_f64(3.14).as_dtype(Dtype::Float64).unwrap();
+        float_eq::assert_float_eq!(array.item::<f64>(), 3.14, abs <= 1e-5);
+        assert_eq!(array.item_size(), 8);
+        assert_eq!(array.size(), 1);
+        assert!(array.strides().is_empty());
+        assert_eq!(array.nbytes(), 8);
+        assert_eq!(array.ndim(), 0);
+        assert!(array.shape().is_empty());
+        assert_eq!(array.dtype(), Dtype::Float64);
+    }
 
     #[test]
     fn new_array_from_slice_f64() {

--- a/mlx-rs/src/array/mod.rs
+++ b/mlx-rs/src/array/mod.rs
@@ -55,7 +55,7 @@ impl std::fmt::Display for Array {
             }
             let ptr = mlx_sys::mlx_string_data(mlx_str);
             let c_str = CStr::from_ptr(ptr);
-            write!(f, "{:?}", c_str)?;
+            write!(f, "{}", c_str.to_str().map_err(|_| std::fmt::Error)?)?;
             mlx_sys::mlx_string_free(mlx_str);
             Ok(())
         }

--- a/mlx-rs/src/device.rs
+++ b/mlx-rs/src/device.rs
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn test_fmt() {
         let device = Device::default();
-        let description = format!("{}", device);
+        let description = format!("{device}");
         assert_eq!(description, "Device(gpu, 0)");
     }
 }

--- a/mlx-rs/src/error.rs
+++ b/mlx-rs/src/error.rs
@@ -289,7 +289,7 @@ pub enum CrossEntropyBuildError {
 
 impl From<CrossEntropyBuildError> for Exception {
     fn from(value: CrossEntropyBuildError) -> Self {
-        Exception::custom(format!("{}", value))
+        Exception::custom(format!("{value}"))
     }
 }
 

--- a/mlx-rs/src/fast.rs
+++ b/mlx-rs/src/fast.rs
@@ -1,8 +1,11 @@
 //! Fast implementations of commonly used multi-op functions.
 
-use crate::error::Result;
+use std::ffi::CString;
+
+use crate::error::{Exception, Result};
 use crate::utils::guard::Guarded;
-use crate::{Array, Stream, StreamOrDevice};
+use crate::utils::VectorArray;
+use crate::{Array, Stream};
 use mlx_internal_macros::default_device;
 
 /// Optimized implementation of `NN.RoPE`.
@@ -57,13 +60,12 @@ pub fn scaled_dot_product_attention_device<'a>(
     values: impl AsRef<Array>,
     scale: f32,
     mask: impl Into<Option<&'a Array>>,
-    memory_efficient_threshold: impl Into<Option<i32>>,
     stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let memory_efficient_threshold = memory_efficient_threshold.into();
-    let memory_efficient_threshold = mlx_sys::mlx_optional_int {
-        value: memory_efficient_threshold.unwrap_or(0),
-        has_value: memory_efficient_threshold.is_some(),
+    let mask_mode = CString::new("").map_err(|e| Exception::custom(format!("{}", e)))?;
+    let masks = match mask.into() {
+        Some(m) => VectorArray::try_from_iter([m].iter())?,
+        None => unsafe { VectorArray::from_ptr(mlx_sys::mlx_vector_array_new()) },
     };
 
     Array::try_from_op(|res| unsafe {
@@ -73,10 +75,8 @@ pub fn scaled_dot_product_attention_device<'a>(
             keys.as_ref().as_ptr(),
             values.as_ref().as_ptr(),
             scale,
-            mask.into()
-                .map(|a| a.as_ptr())
-                .unwrap_or(mlx_sys::mlx_array_new()),
-            memory_efficient_threshold,
+            mask_mode.as_ptr(),
+            masks.as_ptr(),
             stream.as_ref().as_ptr(),
         )
     })
@@ -166,12 +166,12 @@ mod tests {
         assert_eq!(result.shape(), [2, 8, 16]);
         assert_eq!(result.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.456_253_77,
             abs <= 0.009_125_075
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             116.800_964,
             abs <= 2.336_019_3
         );
@@ -189,12 +189,12 @@ mod tests {
         assert_eq!(result.shape(), [2, 8, 16]);
         assert_eq!(result.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.872_938_75,
             abs <= 0.017_458_774
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             223.472_32,
             abs <= 4.469_446
         );
@@ -214,12 +214,12 @@ mod tests {
         assert_eq!(result.shape(), [2, 8]);
         assert_eq!(result.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.290_990_38,
             abs <= 0.005_819_807_8
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             4.655_846,
             abs <= 0.093_116_924
         );

--- a/mlx-rs/src/fft/fftn.rs
+++ b/mlx-rs/src/fft/fftn.rs
@@ -7,10 +7,7 @@ use crate::{
     Stream,
 };
 
-use super::{
-    as_complex64,
-    utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked},
-};
+use super::utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked};
 
 /// One dimensional discrete Fourier Transform.
 ///
@@ -28,9 +25,8 @@ pub fn fft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-
-    let (n, axis) = resolve_size_and_axis_unchecked(&a, n.into(), axis.into());
+    let a = a.as_ref();
+    let (n, axis) = resolve_size_and_axis_unchecked(a, n.into(), axis.into());
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_fft_fft(res, a.as_ptr(), n, axis, stream.as_ref().as_ptr())
     })
@@ -52,9 +48,9 @@ pub fn fft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), Some(axes));
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), Some(axes));
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -93,8 +89,8 @@ pub fn fftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), axes.into_option());
+    let a = a.as_ref();
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), axes.into_option());
     let num_s = s.len();
     let num_axes = axes.len();
 
@@ -130,8 +126,8 @@ pub fn ifft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (n, axis) = resolve_size_and_axis_unchecked(&a, n.into(), axis.into());
+    let a = a.as_ref();
+    let (n, axis) = resolve_size_and_axis_unchecked(a, n.into(), axis.into());
 
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_fft_ifft(res, a.as_ptr(), n, axis, stream.as_ref().as_ptr())
@@ -154,9 +150,9 @@ pub fn ifft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), Some(axes));
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), Some(axes));
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -195,8 +191,8 @@ pub fn ifftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), axes.into_option());
+    let a = a.as_ref();
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), axes.into_option());
     let num_s = s.len();
     let num_axes = axes.len();
 

--- a/mlx-rs/src/fft/fftn.rs
+++ b/mlx-rs/src/fft/fftn.rs
@@ -3,7 +3,6 @@ use mlx_internal_macros::{default_device, generate_macro};
 use crate::{
     array::Array,
     error::Result,
-    stream::StreamOrDevice,
     utils::{guard::Guarded, IntoOption},
     Stream,
 };

--- a/mlx-rs/src/fft/mod.rs
+++ b/mlx-rs/src/fft/mod.rs
@@ -164,17 +164,3 @@ pub use self::{fftn::*, rfftn::*};
 /* -------------------------------------------------------------------------- */
 /*                              Helper functions                              */
 /* -------------------------------------------------------------------------- */
-
-use crate::{complex64, error::Exception, Array, Dtype};
-use std::borrow::Cow;
-
-fn as_complex64(src: &Array) -> Result<Cow<'_, Array>, Exception> {
-    match src.dtype() {
-        Dtype::Complex64 => Ok(Cow::Borrowed(src)),
-        _ => {
-            let new_array = src.as_type::<complex64>()?;
-            new_array.eval()?;
-            Ok(Cow::Owned(new_array))
-        }
-    }
-}

--- a/mlx-rs/src/fft/rfftn.rs
+++ b/mlx-rs/src/fft/rfftn.rs
@@ -3,7 +3,7 @@ use mlx_internal_macros::{default_device, generate_macro};
 use crate::{
     error::Result,
     utils::{guard::Guarded, IntoOption},
-    Array, Stream, StreamOrDevice,
+    Array, Stream,
 };
 
 use super::{

--- a/mlx-rs/src/fft/rfftn.rs
+++ b/mlx-rs/src/fft/rfftn.rs
@@ -6,10 +6,7 @@ use crate::{
     Array, Stream,
 };
 
-use super::{
-    as_complex64,
-    utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked},
-};
+use super::utils::{resolve_size_and_axis_unchecked, resolve_sizes_and_axes_unchecked};
 
 /// One dimensional discrete Fourier Transform on a real input.
 ///
@@ -30,8 +27,8 @@ pub fn rfft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (n, axis) = resolve_size_and_axis_unchecked(&a, n.into(), axis.into());
+    let a = a.as_ref();
+    let (n, axis) = resolve_size_and_axis_unchecked(a, n.into(), axis.into());
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_fft_rfft(res, a.as_ptr(), n, axis, stream.as_ref().as_ptr())
     })
@@ -57,9 +54,9 @@ pub fn rfft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), Some(axes));
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), Some(axes));
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -101,8 +98,8 @@ pub fn rfftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
-    let (s, axes) = resolve_sizes_and_axes_unchecked(&a, s.into_option(), axes.into_option());
+    let a = a.as_ref();
+    let (s, axes) = resolve_sizes_and_axes_unchecked(a, s.into_option(), axes.into_option());
 
     let num_s = s.len();
     let num_axes = axes.len();
@@ -141,11 +138,11 @@ pub fn irfft_device(
     #[optional] axis: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let n = n.into();
     let axis = axis.into();
     let modify_n = n.is_none();
-    let (mut n, axis) = resolve_size_and_axis_unchecked(&a, n, axis);
+    let (mut n, axis) = resolve_size_and_axis_unchecked(a, n, axis);
     if modify_n {
         n = (n - 1) * 2;
     }
@@ -176,12 +173,12 @@ pub fn irfft2_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let s = s.into_option();
     let axes = axes.into_option().unwrap_or(&[-2, -1]);
     let modify_last_axis = s.is_none();
 
-    let (mut s, axes) = resolve_sizes_and_axes_unchecked(&a, s, Some(axes));
+    let (mut s, axes) = resolve_sizes_and_axes_unchecked(a, s, Some(axes));
     if modify_last_axis {
         let end = s.len() - 1;
         s[end] = (s[end] - 1) * 2;
@@ -228,12 +225,12 @@ pub fn irfftn_device<'a>(
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let a = as_complex64(a.as_ref())?;
+    let a = a.as_ref();
     let s = s.into_option();
     let axes = axes.into_option();
     let modify_last_axis = s.is_none();
 
-    let (mut s, axes) = resolve_sizes_and_axes_unchecked(&a, s, axes);
+    let (mut s, axes) = resolve_sizes_and_axes_unchecked(a, s, axes);
     if modify_last_axis {
         let end = s.len() - 1;
         s[end] = (s[end] - 1) * 2;

--- a/mlx-rs/src/lib.rs
+++ b/mlx-rs/src/lib.rs
@@ -270,6 +270,12 @@
 //! Please refer to the transforms module ([`transforms`]) for more details.
 //!
 //! # Compilation
+//!
+//! See also [MLX python
+//! documentation](https://ml-explore.github.io/mlx/build/html/usage/compile.html)
+//!
+//! Please refer to the compilation module ([`transforms::compile`]) for more
+//! details.
 
 #![deny(unused_unsafe, missing_debug_implementations, missing_docs)]
 #![cfg_attr(test, allow(clippy::approx_constant))]

--- a/mlx-rs/src/linalg.rs
+++ b/mlx-rs/src/linalg.rs
@@ -3,7 +3,7 @@
 use crate::error::{Exception, Result};
 use crate::utils::guard::Guarded;
 use crate::utils::{IntoOption, VectorArray};
-use crate::{Array, Stream, StreamOrDevice};
+use crate::{Array, Stream};
 use mlx_internal_macros::{default_device, generate_macro};
 use smallvec::SmallVec;
 use std::f64;
@@ -63,7 +63,7 @@ impl<'a> IntoOption<Ord<'a>> for f64 {
 /// Compute p-norm of an [`Array`]
 #[generate_macro(customize(root = "$crate::linalg"))]
 #[default_device]
-pub fn norm_p_device<'a>(
+pub fn norm_device<'a>(
     array: impl AsRef<Array>,
     ord: f64,
     #[optional] axes: impl IntoOption<&'a [i32]>,
@@ -74,7 +74,7 @@ pub fn norm_p_device<'a>(
 
     match axes.into_option() {
         Some(axes) => Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_linalg_norm_p(
+            mlx_sys::mlx_linalg_norm(
                 res,
                 array.as_ref().as_ptr(),
                 ord,
@@ -85,7 +85,7 @@ pub fn norm_p_device<'a>(
             )
         }),
         None => Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_linalg_norm_p(
+            mlx_sys::mlx_linalg_norm(
                 res,
                 array.as_ref().as_ptr(),
                 ord,
@@ -101,7 +101,7 @@ pub fn norm_p_device<'a>(
 /// Matrix or vector norm.
 #[generate_macro(customize(root = "$crate::linalg"))]
 #[default_device]
-pub fn norm_ord_device<'a>(
+pub fn norm_matrix_device<'a>(
     array: impl AsRef<Array>,
     ord: &'a str,
     #[optional] axes: impl IntoOption<&'a [i32]>,
@@ -113,7 +113,7 @@ pub fn norm_ord_device<'a>(
 
     match axes.into_option() {
         Some(axes) => Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_linalg_norm_ord(
+            mlx_sys::mlx_linalg_norm_matrix(
                 res,
                 array.as_ref().as_ptr(),
                 ord.as_ptr(),
@@ -124,7 +124,7 @@ pub fn norm_ord_device<'a>(
             )
         }),
         None => Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_linalg_norm_ord(
+            mlx_sys::mlx_linalg_norm_matrix(
                 res,
                 array.as_ref().as_ptr(),
                 ord.as_ptr(),
@@ -137,95 +137,131 @@ pub fn norm_ord_device<'a>(
     }
 }
 
-/// Matrix or vector norm.
-///
-/// For values of `ord < 1`, the result is, strictly speaking, not a
-/// mathematical norm, but it may still be useful for various numerical
-/// purposes.
-///
-/// The following norms can be calculated:
-///
-/// ord   | norm for matrices            | norm for vectors
-/// ----- | ---------------------------- | --------------------------
-/// None  | Frobenius norm               | 2-norm
-/// 'fro' | Frobenius norm               | --
-/// inf   | max(sum(abs(x), axis-1))     | max(abs(x))
-/// -inf  | min(sum(abs(x), axis-1))     | min(abs(x))
-/// 0     | --                           | sum(x !- 0)
-/// 1     | max(sum(abs(x), axis-0))     | as below
-/// -1    | min(sum(abs(x), axis-0))     | as below
-/// 2     | 2-norm (largest sing. value) | as below
-/// -2    | smallest singular value      | as below
-/// other | --                           | sum(abs(x)**ord)**(1./ord)
-///
-/// > Nuclear norm and norms based on singular values are not yet implemented.
-///
-/// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
-///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
-///
-/// The nuclear norm is the sum of the singular values.
-///
-/// Both the Frobenius and nuclear norm orders are only defined for
-/// matrices and produce a fatal error when `array.ndim != 2`
-///
-/// # Params
-///
-/// - `array`: input array
-/// - `ord`: order of the norm, see table
-/// - `axes`: axes that hold 2d matrices
-/// - `keep_dims`: if `true` the axes which are normed over are left in the result as dimensions
-///   with size one
+/// Compute the L2 norm of an [`Array`]
 #[generate_macro(customize(root = "$crate::linalg"))]
 #[default_device]
-pub fn norm_device<'a>(
+pub fn norm_l2_device<'a>(
     array: impl AsRef<Array>,
-    #[optional] ord: impl IntoOption<Ord<'a>>,
     #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let ord = ord.into_option();
-    let axes = axes.into_option();
     let keep_dims = keep_dims.into().unwrap_or(false);
 
-    match (ord, axes) {
-        // If axis and ord are both unspecified, computes the 2-norm of flatten(x).
-        (None, None) => {
-            let axes_ptr = std::ptr::null(); // mlx-c already handles the case where axes is null
-            Array::try_from_op(|res| unsafe {
-                mlx_sys::mlx_linalg_norm(
-                    res,
-                    array.as_ref().as_ptr(),
-                    axes_ptr,
-                    0,
-                    keep_dims,
-                    stream.as_ref().as_ptr(),
-                )
-            })
-        }
-        // If axis is not provided but ord is, then x must be either 1D or 2D.
-        //
-        // Frobenius norm is only supported for matrices
-        (Some(Ord::Str(ord)), None) => norm_ord_device(array, ord, axes, keep_dims, stream),
-        (Some(Ord::P(p)), None) => norm_p_device(array, p, axes, keep_dims, stream),
-        // If axis is provided, but ord is not, then the 2-norm (or Frobenius norm for matrices) is
-        // computed along the given axes. At most 2 axes can be specified.
-        (None, Some(axes)) => Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_linalg_norm(
+    match axes.into_option() {
+        Some(axis) => Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_linalg_norm_l2(
                 res,
                 array.as_ref().as_ptr(),
-                axes.as_ptr(),
-                axes.len(),
+                axis.as_ptr(),
+                axis.len(),
                 keep_dims,
                 stream.as_ref().as_ptr(),
             )
         }),
-        // If both axis and ord are provided, then the corresponding matrix or vector
-        // norm is computed. At most 2 axes can be specified.
-        (Some(Ord::Str(ord)), Some(axes)) => norm_ord_device(array, ord, axes, keep_dims, stream),
-        (Some(Ord::P(p)), Some(axes)) => norm_p_device(array, p, axes, keep_dims, stream),
+        None => Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_linalg_norm_l2(
+                res,
+                array.as_ref().as_ptr(),
+                std::ptr::null(),
+                0,
+                keep_dims,
+                stream.as_ref().as_ptr(),
+            )
+        }),
     }
 }
+
+// TODO: Change the original `norm` function to use builder pattern
+// /// Matrix or vector norm.
+// ///
+// /// For values of `ord < 1`, the result is, strictly speaking, not a
+// /// mathematical norm, but it may still be useful for various numerical
+// /// purposes.
+// ///
+// /// The following norms can be calculated:
+// ///
+// /// ord   | norm for matrices            | norm for vectors
+// /// ----- | ---------------------------- | --------------------------
+// /// None  | Frobenius norm               | 2-norm
+// /// 'fro' | Frobenius norm               | --
+// /// inf   | max(sum(abs(x), axis-1))     | max(abs(x))
+// /// -inf  | min(sum(abs(x), axis-1))     | min(abs(x))
+// /// 0     | --                           | sum(x !- 0)
+// /// 1     | max(sum(abs(x), axis-0))     | as below
+// /// -1    | min(sum(abs(x), axis-0))     | as below
+// /// 2     | 2-norm (largest sing. value) | as below
+// /// -2    | smallest singular value      | as below
+// /// other | --                           | sum(abs(x)**ord)**(1./ord)
+// ///
+// /// > Nuclear norm and norms based on singular values are not yet implemented.
+// ///
+// /// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
+// ///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
+// ///
+// /// The nuclear norm is the sum of the singular values.
+// ///
+// /// Both the Frobenius and nuclear norm orders are only defined for
+// /// matrices and produce a fatal error when `array.ndim != 2`
+// ///
+// /// # Params
+// ///
+// /// - `array`: input array
+// /// - `ord`: order of the norm, see table
+// /// - `axes`: axes that hold 2d matrices
+// /// - `keep_dims`: if `true` the axes which are normed over are left in the result as dimensions
+// ///   with size one
+// #[generate_macro(customize(root = "$crate::linalg"))]
+// #[default_device]
+// pub fn norm_device<'a>(
+//     array: impl AsRef<Array>,
+//     #[optional] ord: impl IntoOption<Ord<'a>>,
+//     #[optional] axes: impl IntoOption<&'a [i32]>,
+//     #[optional] keep_dims: impl Into<Option<bool>>,
+//     #[optional] stream: impl AsRef<Stream>,
+// ) -> Result<Array> {
+//     let ord = ord.into_option();
+//     let axes = axes.into_option();
+//     let keep_dims = keep_dims.into().unwrap_or(false);
+
+//     match (ord, axes) {
+//         // If axis and ord are both unspecified, computes the 2-norm of flatten(x).
+//         (None, None) => {
+//             let axes_ptr = std::ptr::null(); // mlx-c already handles the case where axes is null
+//             Array::try_from_op(|res| unsafe {
+//                 mlx_sys::mlx_linalg_norm(
+//                     res,
+//                     array.as_ref().as_ptr(),
+//                     axes_ptr,
+//                     0,
+//                     keep_dims,
+//                     stream.as_ref().as_ptr(),
+//                 )
+//             })
+//         }
+//         // If axis is not provided but ord is, then x must be either 1D or 2D.
+//         //
+//         // Frobenius norm is only supported for matrices
+//         (Some(Ord::Str(ord)), None) => norm_ord_device(array, ord, axes, keep_dims, stream),
+//         (Some(Ord::P(p)), None) => norm_p_device(array, p, axes, keep_dims, stream),
+//         // If axis is provided, but ord is not, then the 2-norm (or Frobenius norm for matrices) is
+//         // computed along the given axes. At most 2 axes can be specified.
+//         (None, Some(axes)) => Array::try_from_op(|res| unsafe {
+//             mlx_sys::mlx_linalg_norm(
+//                 res,
+//                 array.as_ref().as_ptr(),
+//                 axes.as_ptr(),
+//                 axes.len(),
+//                 keep_dims,
+//                 stream.as_ref().as_ptr(),
+//             )
+//         }),
+//         // If both axis and ord are provided, then the corresponding matrix or vector
+//         // norm is computed. At most 2 axes can be specified.
+//         (Some(Ord::Str(ord)), Some(axes)) => norm_ord_device(array, ord, axes, keep_dims, stream),
+//         (Some(Ord::P(p)), Some(axes)) => norm_p_device(array, p, axes, keep_dims, stream),
+//     }
+// }
 
 /// The QR factorization of the input matrix. Returns an error if the input is not valid.
 ///
@@ -298,7 +334,7 @@ pub fn svd_device(
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<(Array, Array, Array)> {
     let v = VectorArray::try_from_op(|res| unsafe {
-        mlx_sys::mlx_linalg_svd(res, array.as_ref().as_ptr(), stream.as_ref().as_ptr())
+        mlx_sys::mlx_linalg_svd(res, array.as_ref().as_ptr(), true, stream.as_ref().as_ptr())
     })?;
 
     let vals: SmallVec<[Array; 3]> = v.try_into_values()?;
@@ -609,6 +645,7 @@ mod tests {
     use crate::{
         array,
         ops::{eye, indexing::IndexOp, tril, triu},
+        StreamOrDevice,
     };
 
     use super::*;
@@ -623,18 +660,18 @@ mod tests {
         let b = a.reshape(&[3, 3]).unwrap();
 
         assert_float_eq!(
-            norm(&a, None, None, None).unwrap().item::<f32>(),
+            norm_l2(&a, None, None).unwrap().item::<f32>(),
             7.74597,
             abs <= 0.001
         );
         assert_float_eq!(
-            norm(&b, None, None, None).unwrap().item::<f32>(),
+            norm_l2(&b, None, None).unwrap().item::<f32>(),
             7.74597,
             abs <= 0.001
         );
 
         assert_float_eq!(
-            norm(&b, "fro", None, None).unwrap().item::<f32>(),
+            norm_matrix(&b, "fro", None, None).unwrap().item::<f32>(),
             7.74597,
             abs <= 0.001
         );
@@ -692,7 +729,7 @@ mod tests {
     fn test_norm_axis() {
         let c = Array::from_slice(&[1, 2, 3, -1, 1, 4], &[2, 3]);
 
-        let result = norm(&c, None, &[0][..], None).unwrap();
+        let result = norm_l2(&c, &[0], None).unwrap();
         let expected = Array::from_slice(&[1.41421, 2.23607, 5.0], &[3]);
         assert!(result
             .all_close(&expected, None, None, None)
@@ -704,7 +741,7 @@ mod tests {
     fn test_norm_axes() {
         let m = Array::from_iter(0..8, &[2, 2, 2]);
 
-        let result = norm(&m, None, &[1, 2][..], None).unwrap();
+        let result = norm_l2(&m, &[1, 2][..], None).unwrap();
         let expected = Array::from_slice(&[3.74166, 11.225], &[2]);
         assert!(result
             .all_close(&expected, None, None, None)

--- a/mlx-rs/src/linalg.rs
+++ b/mlx-rs/src/linalg.rs
@@ -30,8 +30,8 @@ impl Default for Ord<'_> {
 impl std::fmt::Display for Ord<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Ord::Str(s) => write!(f, "{}", s),
-            Ord::P(p) => write!(f, "{}", p),
+            Ord::Str(s) => write!(f, "{s}"),
+            Ord::P(p) => write!(f, "{p}"),
         }
     }
 }
@@ -108,7 +108,7 @@ pub fn norm_matrix_device<'a>(
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let ord = CString::new(ord).map_err(|e| Exception::custom(format!("{}", e)))?;
+    let ord = CString::new(ord).map_err(|e| Exception::custom(format!("{e}")))?;
     let keep_dims = keep_dims.into().unwrap_or(false);
 
     match axes.into_option() {
@@ -454,8 +454,7 @@ pub fn eigh_device(
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<(Array, Array)> {
     let a = a.as_ref();
-    let uplo =
-        CString::new(uplo.unwrap_or("L")).map_err(|e| Exception::custom(format!("{}", e)))?;
+    let uplo = CString::new(uplo.unwrap_or("L")).map_err(|e| Exception::custom(format!("{e}")))?;
 
     <(Array, Array) as Guarded>::try_from_op(|(res_0, res_1)| unsafe {
         mlx_sys::mlx_linalg_eigh(
@@ -480,8 +479,7 @@ pub fn eigvalsh_device(
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     let a = a.as_ref();
-    let uplo =
-        CString::new(uplo.unwrap_or("L")).map_err(|e| Exception::custom(format!("{}", e)))?;
+    let uplo = CString::new(uplo.unwrap_or("L")).map_err(|e| Exception::custom(format!("{e}")))?;
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_linalg_eigvalsh(res, a.as_ptr(), uplo.as_ptr(), stream.as_ref().as_ptr())
     })

--- a/mlx-rs/src/losses.rs
+++ b/mlx-rs/src/losses.rs
@@ -4,8 +4,8 @@ use crate::{
     array,
     error::{CrossEntropyBuildError, Exception},
     ops::{
-        abs, clip, exp, indexing::take_along_axis, log, log_add_exp, log_sum_exp, maximum, minimum,
-        multiply, power, r#where, sqrt, square, sum,
+        abs, clip, exp, indexing::take_along_axis, log, logaddexp, logsumexp_axes, maximum,
+        minimum, multiply, power, r#where, sqrt, square, sum_axes, sum_axis,
     },
     Array,
 };
@@ -46,8 +46,8 @@ impl LossReduction {
     pub fn reduce(&self, loss: Array) -> Result<Array, Exception> {
         match self {
             LossReduction::None => Ok(loss),
-            LossReduction::Sum => Ok(loss.sum(None, None)?),
-            LossReduction::Mean => Ok(loss.mean(None, None)?),
+            LossReduction::Sum => Ok(loss.sum(None)?),
+            LossReduction::Mean => Ok(loss.mean(None)?),
         }
     }
 }
@@ -133,18 +133,19 @@ impl<'a> CrossEntropy<'a> {
         let target_as_probs = targets.ndim() == logits.ndim();
 
         let score = if target_as_probs {
-            sum(&logits.multiply(targets)?, &[self.axis], None)?
+            sum_axes(&logits.multiply(targets)?, &[self.axis], None)?
         } else {
-            take_along_axis(logits, &targets.expand_dims(&[-1])?, self.axis)?.squeeze(&[-1])?
+            take_along_axis(logits, &targets.expand_dims_axes(&[-1])?, self.axis)?
+                .squeeze_axes(&[-1])?
         };
-        let log_sum_exp_logits = log_sum_exp(logits, &[self.axis], None)?;
+        let log_sum_exp_logits = logsumexp_axes(logits, &[self.axis], None)?;
 
         let mut loss = if self.label_smoothing > 0.0 {
             // adjust the true class score with label smoothing
             let adjusted_score = multiply(array!(1.0 - self.label_smoothing), score)?;
 
             // calculate the mean logit across the classes for smoothed loss
-            let mean_logits = logits.mean(&[self.axis], None)?;
+            let mean_logits = logits.mean_axis(self.axis, None)?;
             let smoothed_loss = -multiply(mean_logits, array!(self.label_smoothing))?;
 
             // combine the adjusted score and smoothed loss with the logsumexp logits
@@ -218,7 +219,7 @@ impl<'a> BinaryCrossEntropy<'a> {
         let reduction = self.reduction;
 
         let mut loss = if inputs_are_logits {
-            log_add_exp(array!(0.0), logits)?.subtract(targets.multiply(logits)?)?
+            logaddexp(array!(0.0), logits)?.subtract(targets.multiply(logits)?)?
         } else {
             let log_inputs_clip = clip(log(logits)?, (-100.0, ()))?;
             let log_inputs_inverse_clip = clip(log(&array!(1.0).subtract(logits)?)?, (-100.0, ()))?;
@@ -351,7 +352,8 @@ impl NllLoss {
         let axis = self.axis;
         let reduction = self.reduction;
 
-        let loss = -take_along_axis(inputs, &targets.expand_dims(&[-1])?, axis)?.squeeze(&[-1])?;
+        let loss = -take_along_axis(inputs, &targets.expand_dims_axes(&[-1])?, axis)?
+            .squeeze_axes(&[-1])?;
         reduction.reduce(loss)
     }
 }
@@ -469,9 +471,9 @@ impl KlDivLoss {
         let axis = self.axis;
         let reduction = self.reduction;
 
-        let loss = sum(
+        let loss = sum_axis(
             &exp(targets)?.multiply(targets.subtract(inputs)?)?,
-            &[axis],
+            axis,
             None,
         )?;
         reduction.reduce(loss)
@@ -608,12 +610,12 @@ impl TripletLoss {
 
         let pos = sqrt(
             &power(&anchors.subtract(positives)?, &p)?
-                .sum(&[axis], None)?
+                .sum_axis(axis, None)?
                 .add(&eps)?,
         )?;
         let neg = sqrt(
             &power(&anchors.subtract(negatives)?, &p)?
-                .sum(&[axis], None)?
+                .sum_axis(axis, None)?
                 .add(&eps)?,
         )?;
         let loss = maximum(pos.subtract(neg)?.add(margin)?, array!(0.0))?;
@@ -747,7 +749,7 @@ impl LogCoshLoss {
 
         let errors = inputs.subtract(targets)?;
         let neg_errors = errors.negative()?;
-        let loss = log_add_exp(errors, neg_errors)?.subtract(log(&array!(2.0))?)?;
+        let loss = logaddexp(errors, neg_errors)?.subtract(log(&array!(2.0))?)?;
         reduction.reduce(loss)
     }
 }
@@ -798,16 +800,16 @@ impl CosineSimilarityLoss {
 
         fn l2_loss(a: &Array, axis: i32) -> Result<Array, Exception> {
             if a.dtype().is_complex() {
-                Ok(sqrt(&sum(&abs(a)?.square()?, &[axis], None)?)?)
+                Ok(sqrt(&sum_axis(&abs(a)?.square()?, axis, None)?)?)
             } else {
-                Ok(sqrt(&sum(&a.square()?, &[axis], None)?)?)
+                Ok(sqrt(&sum_axis(&a.square()?, axis, None)?)?)
             }
         }
 
         let x1_norm = l2_loss(x1, axis)?;
         let x2_norm = l2_loss(x2, axis)?;
 
-        let num = sum(&x1.multiply(x2)?, &[axis], None)?;
+        let num = sum_axis(&x1.multiply(x2)?, axis, None)?;
         let den = maximum(x1_norm.multiply(x2_norm)?, array!(eps))?;
         let loss = num.divide(&den)?;
 
@@ -900,11 +902,7 @@ mod tests {
             .build()
             .unwrap();
         let loss = cross_entropy.apply(logits, probs).unwrap();
-        assert!(is_nan(&loss)
-            .unwrap()
-            .all(None, None)
-            .unwrap()
-            .item::<bool>());
+        assert!(is_nan(&loss).unwrap().all(None).unwrap().item::<bool>());
 
         // With weights, no label smoothing
         let logits = array!([[2.0, -1.0], [-1.0, 2.0]]);
@@ -994,7 +992,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_mean = binary_cross_entropy.apply(&logits, &targets).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
         assert_array_eq!(loss_mean, expected_mean);
 
         // Test with reduction 'sum'
@@ -1003,7 +1001,7 @@ mod tests {
             .build()
             .unwrap();
         let loss = binary_cross_entropy.apply(&logits, &targets).unwrap();
-        let expected = expected_none.sum(None, None).unwrap();
+        let expected = expected_none.sum(None).unwrap();
         assert_array_eq!(loss, expected);
 
         // With weights, no label smoothing
@@ -1040,7 +1038,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_mean = binary_cross_entropy.apply(&probs, &targets).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
         assert_array_eq!(loss_mean, expected_mean);
 
         // Test with reduction 'sum'
@@ -1050,7 +1048,7 @@ mod tests {
             .build()
             .unwrap();
         let loss = binary_cross_entropy.apply(&probs, &targets).unwrap();
-        let expected = expected_none.sum(None, None).unwrap();
+        let expected = expected_none.sum(None).unwrap();
         assert_array_eq!(loss, expected);
     }
 
@@ -1077,7 +1075,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_mean = binary_cross_entropy.apply(&probs, &targets).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
         assert_array_eq!(loss_mean, expected_mean);
 
         // Test with reduction 'sum'
@@ -1087,7 +1085,7 @@ mod tests {
             .build()
             .unwrap();
         let loss = binary_cross_entropy.apply(&probs, &targets).unwrap();
-        let expected = expected_none.sum(None, None).unwrap();
+        let expected = expected_none.sum(None).unwrap();
         assert_array_eq!(loss, expected);
     }
 
@@ -1097,8 +1095,8 @@ mod tests {
         let targets = array!([0.5, 0.2, 0.9, 0.0]);
 
         let expected_none = array!([0.0, 0.0, 0.0, 0.0]);
-        let expected_sum = expected_none.sum(None, None).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
 
         let l1_loss = L1LossBuilder::new()
             .reduction(LossReduction::None)
@@ -1128,8 +1126,8 @@ mod tests {
         let targets = array!([0.7, 0.1, 0.8, 0.2]);
 
         let expected_none = array!([0.04, 0.01, 0.01, 0.04]);
-        let expected_mean = expected_none.mean(None, None).unwrap();
-        let expected_sum = expected_none.sum(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
 
         let mse_loss = MseLossBuilder::new()
             .reduction(LossReduction::None)
@@ -1160,8 +1158,8 @@ mod tests {
         let beta = 1.0;
 
         let expected_none = array!([0.125, 0.125, 0.0, 0.5]);
-        let expected_sum = expected_none.sum(None, None).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
 
         let smooth_l1_loss = SmoothL1LossBuilder::new()
             .beta(beta)
@@ -1206,8 +1204,8 @@ mod tests {
         let targets = array!([0, 1]);
 
         let expected_none = array!([0.0, 0.0]);
-        let expected_sum = expected_none.sum(None, None).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
 
         let nll_loss = NllLossBuilder::new()
             .reduction(LossReduction::None)
@@ -1254,7 +1252,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_mean = gaussian_nll_loss.apply(&inputs, &targets, &vars).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
         assert_array_eq!(loss_mean, expected_mean);
 
         // Test with reduction 'sum', full=False
@@ -1264,7 +1262,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_sum = gaussian_nll_loss.apply(&inputs, &targets, &vars).unwrap();
-        let expected_sum = expected_none.sum(None, None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
         assert_array_eq!(loss_sum, expected_sum);
 
         // Test with reduction='none', full=True
@@ -1284,7 +1282,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_mean_full = gaussian_nll_loss.apply(&inputs, &targets, &vars).unwrap();
-        let expected_mean_full = expected_none_full.mean(None, None).unwrap();
+        let expected_mean_full = expected_none_full.mean(None).unwrap();
         assert_array_eq!(loss_mean_full, expected_mean_full);
 
         // Test with reduction='sum', full=True
@@ -1294,7 +1292,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_sum_full = gaussian_nll_loss.apply(&inputs, &targets, &vars).unwrap();
-        let expected_sum_full = expected_none_full.sum(None, None).unwrap();
+        let expected_sum_full = expected_none_full.sum(None).unwrap();
         assert_array_eq!(loss_sum_full, expected_sum_full);
     }
 
@@ -1318,7 +1316,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_mean = kl_div_loss.apply(&p_logits, &q_logits).unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
         assert_array_eq!(loss_mean, expected_mean);
 
         // Test with reduction 'sum'
@@ -1327,7 +1325,7 @@ mod tests {
             .build()
             .unwrap();
         let loss_sum = kl_div_loss.apply(&p_logits, &q_logits).unwrap();
-        let expected_sum = expected_none.sum(None, None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
         assert_array_eq!(loss_sum, expected_sum);
     }
 
@@ -1356,7 +1354,7 @@ mod tests {
         let loss_mean = triplet_loss
             .apply(&anchors, &positives, &negatives)
             .unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
         assert_array_eq!(loss_mean, expected_mean);
 
         // Test with reduction 'sum'
@@ -1367,7 +1365,7 @@ mod tests {
         let loss_sum = triplet_loss
             .apply(&anchors, &positives, &negatives)
             .unwrap();
-        let expected_sum = expected_none.sum(None, None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
         assert_array_eq!(loss_sum, expected_sum);
     }
 
@@ -1431,7 +1429,7 @@ mod tests {
         let loss_mean = cosine_similarity_loss
             .apply(&embeddings1, &embeddings2)
             .unwrap();
-        let expected_mean = expected_none.mean(None, None).unwrap();
+        let expected_mean = expected_none.mean(None).unwrap();
         assert_array_eq!(loss_mean, expected_mean);
 
         // Test with reduction 'sum'
@@ -1442,7 +1440,7 @@ mod tests {
         let loss_sum = cosine_similarity_loss
             .apply(&embeddings1, &embeddings2)
             .unwrap();
-        let expected_sum = expected_none.sum(None, None).unwrap();
+        let expected_sum = expected_none.sum(None).unwrap();
         assert_array_eq!(loss_sum, expected_sum);
     }
 

--- a/mlx-rs/src/module/module.rs
+++ b/mlx-rs/src/module/module.rs
@@ -53,6 +53,12 @@ impl<T> UnaryModule for T where T: for<'a> Module<&'a Array, Output = Array> {}
 
 /// Trait for accessing and updating module parameters.
 pub trait ModuleParameters {
+    /// Get the total number of parameters in the module.
+    ///
+    /// Returns the total number of parameters in the module without counting
+    /// the parameters iterator. `module.parameters().flatten().len()`
+    fn num_parameters(&self) -> usize;
+
     /// Get references to the module parameters.
     fn parameters(&self) -> ModuleParamRef<'_>;
 
@@ -107,6 +113,10 @@ impl<T> ModuleParameters for &'_ mut T
 where
     T: ModuleParameters + ?Sized,
 {
+    fn num_parameters(&self) -> usize {
+        (**self).num_parameters()
+    }
+
     fn parameters(&self) -> ModuleParamRef<'_> {
         (**self).parameters()
     }
@@ -140,6 +150,10 @@ impl<T> ModuleParameters for Box<T>
 where
     T: ModuleParameters + ?Sized,
 {
+    fn num_parameters(&self) -> usize {
+        self.as_ref().num_parameters()
+    }
+
     fn parameters(&self) -> ModuleParamRef<'_> {
         self.as_ref().parameters()
     }
@@ -173,6 +187,10 @@ impl<T> ModuleParameters for Vec<T>
 where
     T: ModuleParameters,
 {
+    fn num_parameters(&self) -> usize {
+        self.iter().map(|module| module.num_parameters()).sum()
+    }
+
     fn parameters(&self) -> ModuleParamRef<'_> {
         let mut parameters = NestedHashMap::new();
         self.iter().enumerate().for_each(|(i, module)| {

--- a/mlx-rs/src/module/param.rs
+++ b/mlx-rs/src/module/param.rs
@@ -10,6 +10,9 @@ use super::ModuleParameters;
 
 /// Trait for a module parameter.
 pub trait Parameter {
+    /// Total number of parameters in this module/parameter.
+    fn count(&self) -> usize;
+
     /// Freeze the parameter.
     fn freeze(&mut self, recursive: bool);
 
@@ -85,6 +88,10 @@ impl<T> AsMut<T> for Param<T> {
 }
 
 impl Parameter for Param<Array> {
+    fn count(&self) -> usize {
+        1
+    }
+
     fn freeze(&mut self, _recursive: bool) {
         self.is_frozen = true;
     }
@@ -114,6 +121,10 @@ impl Parameter for Param<Array> {
 }
 
 impl Parameter for Param<Option<Array>> {
+    fn count(&self) -> usize {
+        self.value.as_ref().map_or(0, |_| 1)
+    }
+
     fn freeze(&mut self, _recursive: bool) {
         self.is_frozen = true;
     }
@@ -154,6 +165,10 @@ impl<T> Parameter for T
 where
     T: ModuleParameters,
 {
+    fn count(&self) -> usize {
+        self.num_parameters()
+    }
+
     fn freeze(&mut self, recursive: bool) {
         self.freeze_parameters(recursive);
     }

--- a/mlx-rs/src/nested.rs
+++ b/mlx-rs/src/nested.rs
@@ -28,7 +28,7 @@ impl<K, V> NestedValue<K, V> {
             }
             NestedValue::Map(entries) => entries
                 .into_iter()
-                .flat_map(|(key, value)| value.flatten(&format!("{}{}{}", prefix, DELIMITER, key)))
+                .flat_map(|(key, value)| value.flatten(&format!("{prefix}{DELIMITER}{key}")))
                 .collect(),
         }
     }

--- a/mlx-rs/src/nn/activation.rs
+++ b/mlx-rs/src/nn/activation.rs
@@ -1,10 +1,11 @@
 use std::f32::consts::PI;
 
 use crate::module::{Module, Param};
+use crate::ops::logsumexp_axis;
 use crate::{
     array,
     error::{Exception, Result},
-    ops::{abs, exp, log_sum_exp, maximum, minimum, multiply, which},
+    ops::{abs, exp, maximum, minimum, multiply, which},
     transforms::compile::compile,
     Array,
 };
@@ -57,12 +58,12 @@ pub fn leaky_relu(x: impl AsRef<Array>, neg_slope: impl Into<Option<f32>>) -> Re
 /// This is:
 ///
 /// ```rust, ignore
-/// x - log_sum_exp(x, axis, true)
+/// x - logsumexp_axis(x, axis, true)
 /// ```
 pub fn log_softmax(x: impl AsRef<Array>, axis: impl Into<Option<i32>>) -> Result<Array> {
     let x = x.as_ref();
     let axis = axis.into().unwrap_or(-1);
-    x.subtract(log_sum_exp(x, &[axis], true)?)
+    x.subtract(logsumexp_axis(x, axis, true)?)
 }
 
 /// Applies the Exponential Linear Unit.
@@ -100,10 +101,10 @@ pub fn relu6(x: impl AsRef<Array>) -> Result<Array> {
 /// This is:
 ///
 /// ```rust, ignore
-/// log_add_exp(x, 0)
+/// logaddexp(x, 0)
 /// ```
 pub fn softplus(x: impl AsRef<Array>) -> Result<Array> {
-    crate::ops::log_add_exp(x.as_ref(), &array!(0))
+    crate::ops::logaddexp(x.as_ref(), &array!(0))
 }
 
 /// Applies the Softsign function.
@@ -191,7 +192,7 @@ pub fn gelu_fast_approximate(x: impl AsRef<Array>) -> Result<Array> {
 /// This function splits the `axis` dimension of the input into two halves
 /// (`a` and `b`) and applies `a * sigmoid(b)`.
 pub fn glu(x: impl AsRef<Array>, axis: impl Into<Option<i32>>) -> Result<Array> {
-    let split = x.as_ref().split_equal(2, axis)?;
+    let split = x.as_ref().split(2, axis)?;
     let (a, b) = (&split[0], &split[1]);
     Ok(a * sigmoid(b)?)
 }
@@ -450,7 +451,7 @@ impl Module<&Array> for Softmax {
     type Output = Array;
 
     fn forward(&mut self, x: &Array) -> Result<Array> {
-        crate::ops::softmax(x, &[self.axis], None)
+        crate::ops::softmax_axis(x, self.axis, None)
     }
 
     fn training_mode(&mut self, _: bool) {}
@@ -461,7 +462,7 @@ impl Module<&Array> for Softmax {
 /// This is:
 ///
 /// ```rust, ignore
-/// log_add_exp(x, 0)
+/// logaddexp(x, 0)
 /// ```
 #[derive(Debug, Clone, ModuleParameters)]
 #[module(root = crate)]
@@ -564,7 +565,7 @@ generate_builder! {
     /// This is:
     ///
     /// ```rust, ignore
-    /// x - log_sum_exp(x, axis, true)
+    /// x - logsumexp(x, axis, true)
     /// ```
     #[derive(Debug, Clone, ModuleParameters, Buildable)]
     #[module(root = crate)]
@@ -972,12 +973,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.547_252_66,
             abs <= 0.010_945_053
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             140.096_68,
             abs <= 2.801_933_5
         );
@@ -985,12 +986,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 8]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.333_276_75,
             abs <= 0.006_665_535
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             42.659_424,
             abs <= 0.853_188_46
         );
@@ -1003,12 +1004,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.529_697_9,
             abs <= 0.010_593_958
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             135.602_66,
             abs <= 2.712_053_3
         );
@@ -1016,12 +1017,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.627_014,
             abs <= 0.012_540_28
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             160.515_58,
             abs <= 3.210_311_7
         );
@@ -1034,12 +1035,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.501_719_8,
             abs <= 0.010_034_395
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             128.440_26,
             abs <= 2.568_805_2
         );
@@ -1047,12 +1048,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.395_375_73,
             abs <= 0.007_907_514
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             101.216_19,
             abs <= 2.024_323_7
         );
@@ -1065,12 +1066,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.478_322_74,
             abs <= 0.009_566_455
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             122.450_62,
             abs <= 2.449_012_5
         );
@@ -1078,12 +1079,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.478_322_74,
             abs <= 0.009_566_455
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             122.450_62,
             abs <= 2.449_012_5
         );
@@ -1096,12 +1097,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.499_930_68,
             abs <= 0.009_998_614
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             127.982_254,
             abs <= 2.559_645_2
         );
@@ -1109,12 +1110,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.499_930_68,
             abs <= 0.009_998_614
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             127.982_254,
             abs <= 2.559_645_2
         );
@@ -1127,12 +1128,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.493_258_66,
             abs <= 0.009_865_173
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             126.274_216,
             abs <= 2.525_484_3
         );
@@ -1140,12 +1141,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.493_258_66,
             abs <= 0.009_865_173
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             126.274_216,
             abs <= 2.525_484_3
         );
@@ -1158,12 +1159,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.514_396_3,
             abs <= 0.010_287_926_5
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             131.685_46,
             abs <= 2.633_709_2
         );
@@ -1171,12 +1172,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.062_499_996,
             abs <= 0.001_25
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             15.999_999,
             abs <= 0.32
         );
@@ -1189,12 +1190,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.498_981_42,
             abs <= 0.009_979_628
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             127.739_24,
             abs <= 2.554_784_8
         );
@@ -1202,12 +1203,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.982_857_76,
             abs <= 0.019_657_155
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             251.611_59,
             abs <= 5.032_232
         );
@@ -1220,12 +1221,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.506_551_27,
             abs <= 0.010_131_026
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             129.677_12,
             abs <= 2.593_542_6
         );
@@ -1233,12 +1234,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.314_089_83,
             abs <= 0.006_281_797
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             80.407,
             abs <= 1.608_14
         );
@@ -1259,7 +1260,7 @@ mod tests {
             .unwrap()
             .lt(&epsilon)
             .unwrap()
-            .all(None, None)
+            .all(None)
             .unwrap()
             .item::<bool>());
         assert_eq!(y.shape(), &[3]);
@@ -1279,7 +1280,7 @@ mod tests {
             .unwrap()
             .lt(&epsilon)
             .unwrap()
-            .all(None, None)
+            .all(None)
             .unwrap()
             .item::<bool>());
         assert_eq!(y.shape(), &[3]);
@@ -1293,12 +1294,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.502_970_6,
             abs <= 0.010_059_412
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             128.760_47,
             abs <= 2.575_209_4
         );
@@ -1306,12 +1307,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.331_970_93,
             abs <= 0.006_639_418_7
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             84.984_56,
             abs <= 1.699_691_2
         );
@@ -1324,12 +1325,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.527_843_7,
             abs <= 0.010_556_874
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             135.127_99,
             abs <= 2.702_559_7
         );
@@ -1337,12 +1338,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             -2.810_954_6,
             abs <= 0.056_219_09
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             -719.604_4,
             abs <= 14.392_087
         );
@@ -1355,12 +1356,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.510_977_7,
             abs <= 0.010_219_553_5
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             130.810_29,
             abs <= 2.616_205_7
         );
@@ -1368,12 +1369,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             -0.479_598_55,
             abs <= 0.009_591_971
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             -122.777_23,
             abs <= 2.455_544_5
         );
@@ -1386,12 +1387,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.496_651_44,
             abs <= 0.009_933_028
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             127.142_77,
             abs <= 2.542_855_3
         );
@@ -1399,12 +1400,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.496_651_44,
             abs <= 0.009_933_028
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             127.142_77,
             abs <= 2.542_855_3
         );
@@ -1417,12 +1418,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.492_950_32,
             abs <= 0.009_859_007
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             126.195_28,
             abs <= 2.523_905_8
         );
@@ -1430,12 +1431,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.365_638_38,
             abs <= 0.007_312_767_7
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             93.603_424,
             abs <= 1.872_068_5
         );
@@ -1448,12 +1449,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.474_122_7,
             abs <= 0.009_482_454_5
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             121.375_41,
             abs <= 2.427_508_4
         );
@@ -1461,12 +1462,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.413_079_68,
             abs <= 0.008_261_594
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             105.748_4,
             abs <= 2.114_968
         );
@@ -1479,12 +1480,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.491_892_46,
             abs <= 0.009_837_849
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             125.924_47,
             abs <= 2.518_489_4
         );
@@ -1492,12 +1493,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.299_602_24,
             abs <= 0.005_992_044_7
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             76.698_17,
             abs <= 1.533_963_4
         );
@@ -1510,28 +1511,20 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.479_360_64,
             abs <= 0.009_587_212_5
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             122.716_324,
             abs <= 2.454_326_4
         );
         let result = Step::new().forward(&a).unwrap();
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Int32);
-        assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
-            1.0,
-            abs <= 0.02
-        );
-        assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
-            256.0,
-            abs <= 5.12
-        );
+        assert_float_eq!(result.mean(None).unwrap().item::<f32>(), 1.0, abs <= 0.02);
+        assert_float_eq!(result.sum(None).unwrap().item::<f32>(), 256.0, abs <= 5.12);
     }
 
     #[test]
@@ -1541,12 +1534,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.493_026_8,
             abs <= 0.009_860_536
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             126.214_86,
             abs <= 2.524_297_2
         );
@@ -1554,12 +1547,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.518_023_2,
             abs <= 0.010_360_463_5
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             132.613_94,
             abs <= 2.652_278_7
         );

--- a/mlx-rs/src/nn/container.rs
+++ b/mlx-rs/src/nn/container.rs
@@ -116,7 +116,7 @@ mod tests {
             params["layers.0.weight"]
                 .abs()
                 .unwrap()
-                .sum(None, None)
+                .sum(None)
                 .unwrap()
                 .item::<f32>()
                 - 0.0
@@ -133,7 +133,7 @@ mod tests {
         let first_layer = &model.layers[0];
         let linear_params = first_layer.parameters().flatten();
         let weight = linear_params["weight"];
-        assert!(weight.abs().unwrap().sum(None, None).unwrap().item::<f32>() - 0.0 < 1e-6);
+        assert!(weight.abs().unwrap().sum(None).unwrap().item::<f32>() - 0.0 < 1e-6);
     }
 
     #[test]

--- a/mlx-rs/src/nn/container.rs
+++ b/mlx-rs/src/nn/container.rs
@@ -106,7 +106,7 @@ mod tests {
             .flatten()
             .iter()
             .for_each(|(key, value)| {
-                println!("{}: {:?}", key, value);
+                println!("{key}: {value:?}");
             });
 
         let mut params = model.parameters_mut().flatten();
@@ -184,8 +184,7 @@ mod tests {
         // Check that it converges
         assert!(
             losses[0] > losses[losses.len() - 1],
-            "Not converging loss: {:?}",
-            losses
+            "Not converging loss: {losses:?}"
         );
     }
 }

--- a/mlx-rs/src/nn/convolution.rs
+++ b/mlx-rs/src/nn/convolution.rs
@@ -464,12 +464,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.512_987_5,
             abs <= 0.010_259_75
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             131.324_8,
             abs <= 2.626_496
         );
@@ -477,12 +477,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 1, 2]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.264_865_2,
             abs <= 0.005_297_303_7
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             1.059_460_8,
             abs <= 0.021_189_215
         );
@@ -495,12 +495,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 8, 4]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.522_504_27,
             abs <= 0.010_450_086
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             267.522_2,
             abs <= 5.350_444
         );
@@ -511,12 +511,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 1, 1, 2]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             -0.279_321_5,
             abs <= 0.005_586_43
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             -1.117_286,
             abs <= 0.022_345_72
         );

--- a/mlx-rs/src/nn/convolution_transpose.rs
+++ b/mlx-rs/src/nn/convolution_transpose.rs
@@ -36,6 +36,10 @@ pub struct ConvTranspose1dBuilder {
     #[builder(optional, default = ConvTranspose1d::DEFAULT_PADDING)]
     pub padding: i32,
 
+    /// Output padding. Default to [`ConvTranspose1d::DEFAULT_OUTPUT_PADDING`] if not specified.
+    #[builder(optional, default = ConvTranspose1d::DEFAULT_OUTPUT_PADDING)]
+    pub output_padding: i32,
+
     /// Stride. Default to [`ConvTranspose1d::DEFAULT_STRIDE`] if not specified.
     #[builder(optional, default = ConvTranspose1d::DEFAULT_STRIDE)]
     pub stride: i32,
@@ -48,6 +52,7 @@ fn build_conv_transpose_1d(builder: ConvTranspose1dBuilder) -> Result<ConvTransp
 
     let bias = builder.bias;
     let padding = builder.padding;
+    let output_padding = builder.output_padding;
     let stride = builder.stride;
 
     let scale = f32::sqrt(1.0f32 / (input_channels * kernel_size) as f32);
@@ -67,6 +72,7 @@ fn build_conv_transpose_1d(builder: ConvTranspose1dBuilder) -> Result<ConvTransp
         weight: Param::new(weight),
         bias: Param::new(bias),
         padding,
+        output_padding,
         stride,
     })
 }
@@ -93,6 +99,9 @@ pub struct ConvTranspose1d {
     /// Padding. Default to 0 if not specified.
     pub padding: i32,
 
+    /// Output padding. Default to 0 if not specified.
+    pub output_padding: i32,
+
     /// Stride. Default to 1 if not specified.
     pub stride: i32,
 }
@@ -103,6 +112,9 @@ impl ConvTranspose1d {
 
     /// Default value for `padding` if not specified.
     pub const DEFAULT_PADDING: i32 = 0;
+
+    /// Default value for `output_padding` if not specified.
+    pub const DEFAULT_OUTPUT_PADDING: i32 = 0;
 
     /// Default value for `stride` if not specified.
     pub const DEFAULT_STRIDE: i32 = 1;
@@ -119,6 +131,7 @@ impl Module<&Array> for ConvTranspose1d {
             self.stride,
             self.padding,
             None,
+            self.output_padding,
             None,
         )?;
         if let Some(bias) = &self.bias.value {
@@ -156,6 +169,10 @@ pub struct ConvTranspose2dBuilder {
     #[builder(optional, default = ConvTranspose2d::DEFAULT_PADDING)]
     padding: SingleOrPair<i32>,
 
+    /// Output padding. Default to [`ConvTranspose2d::DEFAULT_OUTPUT_PADDING`] if not specified.
+    #[builder(optional, default = ConvTranspose2d::DEFAULT_OUTPUT_PADDING)]
+    output_padding: SingleOrPair<i32>,
+
     /// Stride. Default to [`ConvTranspose2d::DEFAULT_STRIDE`] if not specified.
     #[builder(optional, default = ConvTranspose2d::DEFAULT_STRIDE)]
     stride: SingleOrPair<i32>,
@@ -168,6 +185,7 @@ fn build_conv_transpose_2d(builder: ConvTranspose2dBuilder) -> Result<ConvTransp
 
     let bias = builder.bias;
     let padding = builder.padding.into();
+    let output_padding = builder.output_padding.into();
     let stride = builder.stride.into();
 
     let scale = f32::sqrt(1.0 / (input_channels * kernel_size.0 * kernel_size.1) as f32);
@@ -192,6 +210,7 @@ fn build_conv_transpose_2d(builder: ConvTranspose2dBuilder) -> Result<ConvTransp
         weight: Param::new(weight),
         bias: Param::new(bias),
         padding,
+        output_padding,
         stride,
     })
 }
@@ -219,6 +238,9 @@ pub struct ConvTranspose2d {
     /// Padding. Default to `(0, 0)` if not specified.
     pub padding: (i32, i32),
 
+    /// Output padding. Default to `(0, 0)` if not specified.
+    pub output_padding: (i32, i32),
+
     /// Stride. Default to `(1, 1)` if not specified.
     pub stride: (i32, i32),
 }
@@ -229,6 +251,9 @@ impl ConvTranspose2d {
 
     /// Default value for `padding` if not specified.
     pub const DEFAULT_PADDING: SingleOrPair<i32> = SingleOrPair::Pair(0, 0);
+
+    /// Default value for `output_padding` if not specified.
+    pub const DEFAULT_OUTPUT_PADDING: SingleOrPair<i32> = SingleOrPair::Pair(0, 0);
 
     /// Default value for `stride` if not specified.
     pub const DEFAULT_STRIDE: SingleOrPair<i32> = SingleOrPair::Pair(1, 1);
@@ -245,6 +270,7 @@ impl Module<&Array> for ConvTranspose2d {
             self.stride,
             self.padding,
             None,
+            self.output_padding,
             None,
         )?;
         if let Some(bias) = &self.bias.value {
@@ -282,6 +308,10 @@ pub struct ConvTranspose3dBuilder {
     #[builder(optional, default = ConvTranspose3d::DEFAULT_PADDING)]
     pub padding: SingleOrTriple<i32>,
 
+    /// Output padding. Default to [`ConvTranspose3d::DEFAULT_OUTPUT_PADDING`] if not specified.
+    #[builder(optional, default = ConvTranspose3d::DEFAULT_OUTPUT_PADDING)]
+    pub output_padding: SingleOrTriple<i32>,
+
     /// Stride. Default to [`ConvTranspose3d::DEFAULT_STRIDE`] if not specified.
     #[builder(optional, default = ConvTranspose3d::DEFAULT_STRIDE)]
     pub stride: SingleOrTriple<i32>,
@@ -294,6 +324,7 @@ fn build_conv_transpose_3d(builder: ConvTranspose3dBuilder) -> Result<ConvTransp
 
     let bias = builder.bias;
     let padding = builder.padding.into();
+    let output_padding = builder.output_padding.into();
     let stride = builder.stride.into();
 
     let scale =
@@ -320,6 +351,7 @@ fn build_conv_transpose_3d(builder: ConvTranspose3dBuilder) -> Result<ConvTransp
         weight: Param::new(weight),
         bias: Param::new(bias),
         padding,
+        output_padding,
         stride,
     })
 }
@@ -347,6 +379,9 @@ pub struct ConvTranspose3d {
     /// Padding. Default to `(0, 0, 0)` if not specified.
     pub padding: (i32, i32, i32),
 
+    /// Output padding. Default to `(0, 0, 0)` if not specified.
+    pub output_padding: (i32, i32, i32),
+
     /// Stride. Default to `(1, 1, 1)` if not specified.
     pub stride: (i32, i32, i32),
 }
@@ -357,6 +392,9 @@ impl ConvTranspose3d {
 
     /// Default value for `padding` if not specified.
     pub const DEFAULT_PADDING: SingleOrTriple<i32> = SingleOrTriple::Triple(0, 0, 0);
+
+    /// Default value for `output_padding` if not specified.
+    pub const DEFAULT_OUTPUT_PADDING: SingleOrTriple<i32> = SingleOrTriple::Triple(0, 0, 0);
 
     /// Default value for `stride` if not specified.
     pub const DEFAULT_STRIDE: SingleOrTriple<i32> = SingleOrTriple::Triple(1, 1, 1);
@@ -373,6 +411,7 @@ impl Module<&Array> for ConvTranspose3d {
             self.stride,
             self.padding,
             None,
+            self.output_padding,
             None,
         )?;
         if let Some(bias) = &self.bias.value {

--- a/mlx-rs/src/nn/dropout.rs
+++ b/mlx-rs/src/nn/dropout.rs
@@ -291,12 +291,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.511_429_2,
             abs <= 0.010_228_584
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             130.925_87,
             abs <= 2.618_517_4
         );
@@ -304,12 +304,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.477_913_62,
             abs <= 0.009_558_273
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             122.345_89,
             abs <= 2.446_917_8
         );
@@ -322,12 +322,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.457_839_9,
             abs <= 0.009_156_798
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             117.207_016,
             abs <= 2.344_140_3
         );
@@ -335,12 +335,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.368_284_34,
             abs <= 0.007_365_687
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             94.280_79,
             abs <= 1.885_615_8
         );
@@ -353,12 +353,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 8, 4]);
         assert_eq!(a.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.500_606_2,
             abs <= 0.010_012_124
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             256.310_36,
             abs <= 5.126_207_4
         );
@@ -366,12 +366,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 8, 4]);
         assert_eq!(result.dtype(), crate::Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.237_284_15,
             abs <= 0.004_745_683
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             121.489_49,
             abs <= 2.429_789_8
         );

--- a/mlx-rs/src/nn/embedding.rs
+++ b/mlx-rs/src/nn/embedding.rs
@@ -85,26 +85,22 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 8, 4]);
         assert_eq!(a.dtype(), crate::Dtype::Int32);
         float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             4.605_468_8,
             abs <= 0.092_109_375
         );
-        float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
-            2358.0,
-            abs <= 47.16
-        );
+        float_eq!(a.sum(None).unwrap().item::<f32>(), 2358.0, abs <= 47.16);
 
         let result = Embedding::new(10, 8).unwrap().forward(&a).unwrap();
         assert_eq!(result.shape(), &[2, 8, 8, 4, 8]);
         assert_eq!(result.dtype(), crate::Dtype::Float32);
         float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             -0.001_197_346_3,
             abs <= 2.394_692_5e-5
         );
         float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             -4.904_330_3,
             abs <= 0.098_086_6
         );

--- a/mlx-rs/src/nn/linear.rs
+++ b/mlx-rs/src/nn/linear.rs
@@ -195,7 +195,7 @@ impl Module<&Array> for Bilinear {
         let mut y = crate::ops::matmul(&x1, w.t())?;
         y = y.reshape(&[-1, out, in2])?.swap_axes(-2, -1)?;
         y = crate::ops::matmul(&x2, &y)?;
-        y = y.squeeze(&[1])?;
+        y = y.squeeze_axes(&[1])?;
 
         // reset the shape
         let new_shape = x_shape.iter().cloned().chain(once(out)).collect::<Vec<_>>();
@@ -227,12 +227,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.508_688_57,
             abs <= 0.010_173_771_5
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             130.224_27,
             abs <= 2.604_485_5
         );
@@ -240,12 +240,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 5]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.104_193_09,
             abs <= 0.002_083_861_7
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             8.335_447,
             abs <= 0.166_708_95
         );

--- a/mlx-rs/src/nn/normalization.rs
+++ b/mlx-rs/src/nn/normalization.rs
@@ -12,8 +12,8 @@ use mlx_macros::ModuleParameters;
 
 fn instance_norm(x: &Array, axes: &[i32], eps: &Array) -> Result<Array, Exception> {
     // Compute stats
-    let mean = x.mean(axes, true)?;
-    let variance = x.variance(axes, true, None)?;
+    let mean = x.mean_axes(axes, true)?;
+    let variance = x.var_axes(axes, true, None)?;
 
     // Normalize
     let x = x.subtract(&mean)?.multiply(rsqrt(&variance.add(eps)?)?)?;
@@ -375,7 +375,7 @@ impl GroupNorm {
         // Split into groups
         let x = x.reshape(&[batch, -1, self.group_count, group_size])?;
         let x = x
-            .transpose(&[0, 2, 1, 3])?
+            .transpose_axes(&[0, 2, 1, 3])?
             .reshape(&[batch, self.group_count, -1])?;
 
         // Normalize
@@ -388,7 +388,7 @@ impl GroupNorm {
             .chain(rest.iter().copied())
             .chain([dims])
             .collect();
-        x.transpose(&[0, 2, 1, 3])?.reshape(&new_shape[..])
+        x.transpose_axes(&[0, 2, 1, 3])?.reshape(&new_shape[..])
     }
 
     fn group_norm(&self, x: &Array) -> Result<Array, Exception> {
@@ -557,8 +557,8 @@ impl BatchNorm {
     fn stats(x: &Array) -> Result<(Array, Array), Exception> {
         let reduction_axes = (0..x.ndim() as i32 - 1).collect::<Vec<_>>();
 
-        let mean = x.mean(&reduction_axes, None)?;
-        let variance = x.variance(&reduction_axes, None, None)?;
+        let mean = x.mean_axes(&reduction_axes, None)?;
+        let variance = x.var_axes(&reduction_axes, None, None)?;
 
         Ok((mean, variance))
     }
@@ -633,12 +633,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.500_064_6,
             abs <= 0.010_001_292
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             128.016_54,
             abs <= 2.560_330_9
         );
@@ -651,12 +651,12 @@ mod tests {
         assert_eq!(result.shape(), &[16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.106_454_11,
             abs <= 0.002_129_082_3
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             1.703_265_8,
             abs <= 0.034_065_317
         );
@@ -669,12 +669,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.492_690_32,
             abs <= 0.009_853_806
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             126.128_72,
             abs <= 2.522_574_4
         );
@@ -687,12 +687,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.290_990_38,
             abs <= 0.005_819_807_8
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             4.655_846,
             abs <= 0.093_116_924
         );
@@ -705,12 +705,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.505_476_36,
             abs <= 0.010_109_527
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             129.401_95,
             abs <= 2.588_039
         );
@@ -719,12 +719,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.872_938_75,
             abs <= 0.017_458_774
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             223.472_32,
             abs <= 4.469_446
         );
@@ -737,12 +737,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.486_665_87,
             abs <= 0.009_733_317
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             124.586_464,
             abs <= 2.491_729_3
         );
@@ -755,12 +755,12 @@ mod tests {
         assert_eq!(result.shape(), &[16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             -0.054_606_52,
             abs <= 0.001_092_130_4
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             -0.873_704_3,
             abs <= 0.017_474_087
         );
@@ -773,12 +773,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.505_814_7,
             abs <= 0.010_116_293
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             129.488_56,
             abs <= 2.589_771
         );
@@ -791,12 +791,12 @@ mod tests {
         assert_eq!(result.shape(), &[16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.439_785_24,
             abs <= 0.008_795_705
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             7.036_564,
             abs <= 0.140_731_28
         );

--- a/mlx-rs/src/nn/pooling.rs
+++ b/mlx-rs/src/nn/pooling.rs
@@ -165,7 +165,7 @@ impl MaxPool1d {
     /// - `kernel_size`: The size of the pooling window.
     /// - `stride`: The stride of the pooling window.
     pub fn new(kernel_size: i32, stride: i64) -> Self {
-        let op = |x: &Array, axes: &[i32]| x.max(axes, None);
+        let op = |x: &Array, axes: &[i32]| x.max_axes(axes, None);
         let inner = Pool::new(vec![kernel_size], vec![stride], op);
         Self { inner }
     }
@@ -204,7 +204,7 @@ impl MaxPool2d {
         let stride = stride.into();
         let stride = vec![stride.first(), stride.second()];
 
-        let op = |x: &Array, axes: &[i32]| x.max(axes, None);
+        let op = |x: &Array, axes: &[i32]| x.max_axes(axes, None);
         let inner = Pool::new(kernel_size, stride, op);
         Self { inner }
     }
@@ -235,7 +235,7 @@ impl AvgPool1d {
     /// - `kernel_size`: The size of the pooling window.
     /// - `stride`: The stride of the pooling window.
     pub fn new(kernel_size: i32, stride: i64) -> Self {
-        let op = |x: &Array, axes: &[i32]| x.mean(axes, None);
+        let op = |x: &Array, axes: &[i32]| x.mean_axes(axes, None);
         let inner = Pool::new(vec![kernel_size], vec![stride], op);
         Self { inner }
     }
@@ -274,7 +274,7 @@ impl AvgPool2d {
         let stride = stride.into();
         let stride = vec![stride.first(), stride.second()];
 
-        let op = |x: &Array, axes: &[i32]| x.mean(axes, None);
+        let op = |x: &Array, axes: &[i32]| x.mean_axes(axes, None);
         let inner = Pool::new(kernel_size, stride, op);
         Self { inner }
     }

--- a/mlx-rs/src/nn/positional_encoding.rs
+++ b/mlx-rs/src/nn/positional_encoding.rs
@@ -4,8 +4,11 @@ use crate::{
     array,
     error::Exception,
     module::{Module, Param},
-    ops::indexing::NewAxis,
-    ops::{arange, concatenate, exp, indexing::TryIndexOp, log},
+    ops::{
+        arange, concatenate_axis, exp,
+        indexing::{NewAxis, TryIndexOp},
+        log,
+    },
     Array, Dtype,
 };
 use mlx_internal_macros::{generate_builder, Buildable, Builder};
@@ -235,16 +238,16 @@ impl Module<&Array> for Sinpe {
 
     fn forward(&mut self, x: &Array) -> Result<Self::Output, Self::Error> {
         let mut y = x
-            .expand_dims(&[-1])
+            .expand_dims_axes(&[-1])
             .and_then(|x| x.multiply(&self.sigmas))?;
 
         let cosy = y.cos()?;
         let siny = y.sin()?;
 
         if self.cosine_first {
-            y = concatenate(&[cosy, siny], -1)?;
+            y = concatenate_axis(&[cosy, siny], -1)?;
         } else {
-            y = concatenate(&[siny, cosy], -1)?;
+            y = concatenate_axis(&[siny, cosy], -1)?;
         }
 
         if self.scale != 1.0 {
@@ -281,7 +284,7 @@ impl Alibi {
         let x = 2.0_f32.powi(8).powf(1.0 / num_heads as f32);
         array!(x)
             .power(&arange::<_, f32>(1, num_heads + 1, None)?)?
-            .expand_dims(&[-1, -2])
+            .expand_dims_axes(&[-1, -2])
     }
 
     fn matrix(key: AlibiKey) -> Result<Array, Exception> {
@@ -294,7 +297,7 @@ impl Alibi {
         let distance_matrix = x1
             .try_index((.., NewAxis))?
             .subtract(x2.try_index((NewAxis, ..))?)?
-            .expand_dims(&[0, 1])?
+            .expand_dims_axes(&[0, 1])?
             .abs()?
             .negative()?;
 
@@ -433,12 +436,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.5082664489746094,
             abs <= 0.010165328979492188
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             130.1162109375,
             abs <= 2.60232421875
         );
@@ -448,12 +451,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.4562537670135498,
             abs <= 0.009125075340270997
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             116.80096435546875,
             abs <= 2.3360192871093752
         );
@@ -468,12 +471,12 @@ mod tests {
         assert_eq!(a.shape(), &[2, 8, 16]);
         assert_eq!(a.dtype(), Dtype::Float32);
         assert_float_eq!(
-            a.mean(None, None).unwrap().item::<f32>(),
+            a.mean(None).unwrap().item::<f32>(),
             0.5026599168777466,
             abs <= 0.010053198337554931
         );
         assert_float_eq!(
-            a.sum(None, None).unwrap().item::<f32>(),
+            a.sum(None).unwrap().item::<f32>(),
             128.68093872070312,
             abs <= 2.5736187744140624
         );
@@ -483,12 +486,12 @@ mod tests {
         assert_eq!(result.shape(), &[2, 8, 16, 8]);
         assert_eq!(result.dtype(), Dtype::Float32);
         assert_float_eq!(
-            result.mean(None, None).unwrap().item::<f32>(),
+            result.mean(None).unwrap().item::<f32>(),
             0.2705308198928833,
             abs <= 0.005410616397857666
         );
         assert_float_eq!(
-            result.sum(None, None).unwrap().item::<f32>(),
+            result.sum(None).unwrap().item::<f32>(),
             554.047119140625,
             abs <= 11.0809423828125
         );

--- a/mlx-rs/src/nn/recurrent.rs
+++ b/mlx-rs/src/nn/recurrent.rs
@@ -4,8 +4,11 @@ use crate::{
     array,
     error::Exception,
     module::{Module, Param},
-    ops::indexing::{Ellipsis, IndexOp},
-    ops::{addmm, matmul, sigmoid, split_equal, stack, tanh, tanh_device},
+    ops::{
+        addmm,
+        indexing::{Ellipsis, IndexOp},
+        matmul, sigmoid, split, stack_axis, tanh, tanh_device,
+    },
     random::uniform,
     Array, Stream,
 };
@@ -144,7 +147,7 @@ impl Rnn {
             all_hidden.push(hidden);
         }
 
-        stack(&all_hidden[..], -2)
+        stack_axis(&all_hidden[..], -2)
     }
 }
 
@@ -326,7 +329,7 @@ impl Gru {
 
             rz = sigmoid(&rz)?;
 
-            let parts = split_equal(&rz, 2, -1)?;
+            let parts = split(&rz, 2, -1)?;
             let r = &parts[0];
             let z = &parts[1];
 
@@ -348,7 +351,7 @@ impl Gru {
             all_hidden.push(hidden);
         }
 
-        stack(&all_hidden[..], -2)
+        stack_axis(&all_hidden[..], -2)
     }
 }
 
@@ -534,7 +537,7 @@ impl Lstm {
                 ifgo = addmm(&ifgo, hidden, self.wh.t(), None, None)?;
             }
 
-            let pieces = split_equal(&ifgo, 4, -1)?;
+            let pieces = split(&ifgo, 4, -1)?;
 
             let i = sigmoid(&pieces[0])?;
             let f = sigmoid(&pieces[1])?;
@@ -552,7 +555,10 @@ impl Lstm {
             all_cell.push(cell);
         }
 
-        Ok((stack(&all_hidden[..], -2)?, stack(&all_cell[..], -2)?))
+        Ok((
+            stack_axis(&all_hidden[..], -2)?,
+            stack_axis(&all_cell[..], -2)?,
+        ))
     }
 }
 

--- a/mlx-rs/src/nn/transformer.rs
+++ b/mlx-rs/src/nn/transformer.rs
@@ -5,7 +5,7 @@ use crate::{
     builder::Builder,
     error::Exception,
     module::{Module, UnaryModule},
-    ops::{arange, expand_dims, matmul, softmax},
+    ops::{arange, expand_dims, matmul, softmax_axis},
     quantization::MaybeQuantized,
     Array, ArrayElement, FromScalar,
 };
@@ -145,8 +145,8 @@ impl MultiHeadAttention {
         Array: FromScalar<T>,
     {
         let indices = arange::<_, T>(0, n, 1)?;
-        let left = expand_dims(&indices, &[1])?;
-        let right = expand_dims(&indices, &[0])?;
+        let left = expand_dims(&indices, 1)?;
+        let right = expand_dims(&indices, 0)?;
         let mask = left.lt(right)?;
         let mask = mask.as_type::<T>()?.multiply(array!(T::min_value()))?; // TODO: replace with f32::MIN?
         Ok(mask)
@@ -231,13 +231,13 @@ where
 
         let queries = queries
             .reshape(&[B, L, self.num_heads, -1])?
-            .transpose(&[0, 2, 1, 3])?;
+            .transpose_axes(&[0, 2, 1, 3])?;
         let keys = keys
             .reshape(&[B, S, self.num_heads, -1])?
-            .transpose(&[0, 2, 3, 1])?;
+            .transpose_axes(&[0, 2, 3, 1])?;
         let values = values
             .reshape(&[B, S, self.num_heads, -1])?
-            .transpose(&[0, 2, 1, 3])?;
+            .transpose_axes(&[0, 2, 1, 3])?;
 
         // Dimensions are [batch x num_heads x sequence x hidden_dim]
         let scale = f32::sqrt(1.0 / queries.dim(-1) as f32);
@@ -245,9 +245,9 @@ where
         if let Some(mask) = input.mask {
             scores = scores.add(mask.as_dtype(scores.dtype())?)?;
         }
-        scores = softmax(&scores, &[-1], None)?;
+        scores = softmax_axis(&scores, -1, None)?;
         let value_hat = matmul(&scores, &values)?
-            .transpose(&[0, 2, 1, 3])?
+            .transpose_axes(&[0, 2, 1, 3])?
             .reshape(&[B, L, -1])?;
 
         self.output_proj.forward(&value_hat)

--- a/mlx-rs/src/nn/upsample.rs
+++ b/mlx-rs/src/nn/upsample.rs
@@ -4,7 +4,7 @@ use crate::{
     macros::ModuleParameters,
     module::Module,
     ops::{
-        abs, broadcast_to, ceil, clip, expand_dims, floor,
+        abs, broadcast_to, ceil, clip, expand_dims_axes, floor,
         indexing::{ArrayIndex, ArrayIndexOp, Ellipsis, IndexOp, NewAxis, TryIndexOp},
     },
     transforms::compile::compile,
@@ -245,7 +245,7 @@ fn linear_indices(
     indices = clip(&indices, (0, dimension - 1))?;
     let indices_left = floor(&indices)?;
     let indices_right = ceil(&indices)?;
-    let weight = expand_dims(&indices.subtract(&indices_left)?, &[-1])?;
+    let weight = expand_dims_axes(&indices.subtract(&indices_left)?, &[-1])?;
 
     let indices_left = indices_left.as_type::<i32>()?;
     let indices_right = indices_right.as_type::<i32>()?;
@@ -356,7 +356,7 @@ mod tests {
         let input = array!([1, 2, 3, 4], shape = [1, 2, 2, 1]);
 
         let mut up = Upsample::new(2.0, UpsampleMode::Nearest);
-        let result = up.forward(&input).and_then(|r| r.squeeze(None)).unwrap();
+        let result = up.forward(&input).and_then(|r| r.squeeze()).unwrap();
 
         assert_eq!(result.shape(), &[4, 4]);
 
@@ -385,7 +385,7 @@ mod tests {
                 align_corners: false,
             },
         );
-        let result = up.forward(&input).and_then(|r| r.squeeze(None)).unwrap();
+        let result = up.forward(&input).and_then(|r| r.squeeze()).unwrap();
 
         assert_eq!(result.shape(), &[4, 4]);
 
@@ -417,7 +417,7 @@ mod tests {
                 align_corners: false,
             },
         );
-        let result = up.forward(&input).and_then(|r| r.squeeze(None)).unwrap();
+        let result = up.forward(&input).and_then(|r| r.squeeze()).unwrap();
 
         assert_eq!(result.shape(), &[4, 4]);
 

--- a/mlx-rs/src/nn/value_and_grad.rs
+++ b/mlx-rs/src/nn/value_and_grad.rs
@@ -160,15 +160,15 @@ mod tests {
         let x = crate::random::uniform::<_, f32>(1.0, 2.0, &[2, 2], None).unwrap();
 
         let loss = |model: &mut Linear, x: &Array| -> Vec<Array> {
-            vec![model.forward(x).unwrap().sum(None, None).unwrap()]
+            vec![model.forward(x).unwrap().sum(None).unwrap()]
         };
 
         let mut vg = nn::value_and_grad(loss);
         let (v, g) = vg(&mut model, &x).unwrap();
 
-        assert_ne!(v[0].sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["weight"].sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["bias"].sum(None, None).unwrap(), array!(0.0));
+        assert_ne!(v[0].sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["weight"].sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["bias"].sum(None).unwrap(), array!(0.0));
     }
 
     #[test]
@@ -177,15 +177,15 @@ mod tests {
         let x = crate::random::uniform::<_, f32>(1.0, 2.0, &[2, 2], None).unwrap();
 
         let loss = |model: &mut Linear, x: &Array| -> Array {
-            model.forward(x).unwrap().sum(None, None).unwrap()
+            model.forward(x).unwrap().sum(None).unwrap()
         };
 
         let mut vg = nn::value_and_grad(loss);
         let (v, g) = vg(&mut model, &x).unwrap();
 
-        assert_ne!(v.sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["weight"].sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["bias"].sum(None, None).unwrap(), array!(0.0));
+        assert_ne!(v.sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["weight"].sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["bias"].sum(None).unwrap(), array!(0.0));
     }
 
     #[test]
@@ -194,15 +194,15 @@ mod tests {
         let x = crate::random::uniform::<_, f32>(1.0, 2.0, &[2, 2], None).unwrap();
 
         let loss = |model: &mut Linear, x: &Array| -> Result<Vec<Array>, Exception> {
-            Ok(vec![model.forward(x)?.sum(None, None)?])
+            Ok(vec![model.forward(x)?.sum(None)?])
         };
 
         let mut vg = nn::value_and_grad(loss);
         let (v, g) = vg(&mut model, &x).unwrap();
 
-        assert_ne!(v[0].sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["weight"].sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["bias"].sum(None, None).unwrap(), array!(0.0));
+        assert_ne!(v[0].sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["weight"].sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["bias"].sum(None).unwrap(), array!(0.0));
     }
 
     #[test]
@@ -217,16 +217,16 @@ mod tests {
                     .forward(x)?
                     .subtract(y)?
                     .square()?
-                    .sum(None, None)
+                    .sum(None)
                     .map(|v| vec![v])
             };
 
         let mut vg = nn::value_and_grad(loss);
         let (v, g) = vg(&mut model, (&x, &y)).unwrap();
 
-        assert_ne!(v[0].sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["weight"].sum(None, None).unwrap(), array!(0.0));
-        assert_ne!(g["bias"].sum(None, None).unwrap(), array!(0.0));
+        assert_ne!(v[0].sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["weight"].sum(None).unwrap(), array!(0.0));
+        assert_ne!(g["bias"].sum(None).unwrap(), array!(0.0));
     }
 
     #[test]
@@ -236,7 +236,7 @@ mod tests {
         let x = crate::random::uniform::<_, f32>(1.0, 2.0, &[3, 3], None).unwrap();
 
         let loss = |model: &mut Linear, x: &Array| -> Result<Vec<Array>, Exception> {
-            Ok(vec![model.forward(x)?.sum(None, None)?])
+            Ok(vec![model.forward(x)?.sum(None)?])
         };
 
         let mut vg = nn::value_and_grad(loss);

--- a/mlx-rs/src/ops/arithmetic.rs
+++ b/mlx-rs/src/ops/arithmetic.rs
@@ -652,6 +652,22 @@ impl Array {
             mlx_sys::mlx_square(res, self.as_ptr(), stream.as_ref().as_ptr())
         })
     }
+
+    /// Element-wise real part from a complex array.
+    #[default_device]
+    pub fn real_device(&self, stream: impl AsRef<Stream>) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_real(res, self.as_ptr(), stream.as_ref().as_ptr())
+        })
+    }
+
+    /// Element-wise imag part from a complex array.
+    #[default_device]
+    pub fn imag_device(&self, stream: impl AsRef<Stream>) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_imag(res, self.as_ptr(), stream.as_ref().as_ptr())
+        })
+    }
 }
 
 /// Element-wise absolute value.
@@ -1303,6 +1319,24 @@ pub fn tan_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>) 
 pub fn tanh_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
         mlx_sys::mlx_tanh(res, a.as_ref().as_ptr(), stream.as_ref().as_ptr())
+    })
+}
+
+/// Element-wise real part from a complex array.
+#[generate_macro]
+#[default_device]
+pub fn real_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>) -> Result<Array> {
+    Array::try_from_op(|res| unsafe {
+        mlx_sys::mlx_real(res, a.as_ref().as_ptr(), stream.as_ref().as_ptr())
+    })
+}
+
+/// Element-wise imaginary part from a complex array.
+#[generate_macro]
+#[default_device]
+pub fn imag_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>) -> Result<Array> {
+    Array::try_from_op(|res| unsafe {
+        mlx_sys::mlx_imag(res, a.as_ref().as_ptr(), stream.as_ref().as_ptr())
     })
 }
 

--- a/mlx-rs/src/ops/arithmetic.rs
+++ b/mlx-rs/src/ops/arithmetic.rs
@@ -1709,12 +1709,12 @@ mod tests {
         let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
         let b = a.cos().unwrap();
 
-        let b_data: &[f32] = b.as_slice();
-        assert_eq!(b_data, &[1.0, 0.54030234, -0.41614687]);
+        let b_expected = array!([1.0, 0.54030234, -0.41614687]);
+        assert_array_all_close!(b, b_expected);
 
         // check a is not modified
-        let a_data: &[f32] = a.as_slice();
-        assert_eq!(a_data, &[0.0, 1.0, 2.0]);
+        let a_expected = array!([0.0, 1.0, 2.0]);
+        assert_array_all_close!(a, a_expected);
     }
 
     #[test]
@@ -1722,12 +1722,12 @@ mod tests {
         let a = Array::from_slice(&[0.0, 1.0, 2.0], &[3]);
         let b = a.exp().unwrap();
 
-        let b_data: &[f32] = b.as_slice();
-        assert_eq!(b_data, &[1.0, 2.7182817, 7.389056]);
+        let b_expected = array!([1.0, 2.7182817, 7.389056]);
+        assert_array_all_close!(b, b_expected);
 
         // check a is not modified
-        let a_data: &[f32] = a.as_slice();
-        assert_eq!(a_data, &[0.0, 1.0, 2.0]);
+        let a_expected = array!([0.0, 1.0, 2.0]);
+        assert_array_all_close!(a, a_expected);
     }
 
     #[test]

--- a/mlx-rs/src/ops/arithmetic.rs
+++ b/mlx-rs/src/ops/arithmetic.rs
@@ -1,7 +1,6 @@
 use crate::array::Array;
 use crate::error::Result;
 use crate::sealed::Sealed;
-use crate::stream::StreamOrDevice;
 
 use crate::utils::guard::Guarded;
 use crate::utils::{IntoOption, ScalarOrArray, VectorArray};
@@ -1016,7 +1015,7 @@ pub fn log2_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>)
 /// The computation is is a numerically stable version of `log(exp(a) + exp(b))`.
 #[generate_macro]
 #[default_device]
-pub fn log_add_exp_device(
+pub fn logaddexp_device(
     a: impl AsRef<Array>,
     b: impl AsRef<Array>,
     #[optional] stream: impl AsRef<Stream>,
@@ -1209,7 +1208,7 @@ pub fn sinh_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>)
 /// for more information.
 #[generate_macro]
 #[default_device]
-pub fn softmax_device(
+pub fn softmax_axes_device(
     a: impl AsRef<Array>,
     axes: &[i32],
     precise: impl Into<Option<bool>>,
@@ -1219,7 +1218,7 @@ pub fn softmax_device(
     let s = stream.as_ref().as_ptr();
 
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_softmax(
+        mlx_sys::mlx_softmax_axes(
             res,
             a.as_ref().as_ptr(),
             axes.as_ptr(),
@@ -1230,20 +1229,35 @@ pub fn softmax_device(
     })
 }
 
-/// Perform the softmax along all axes.
+/// Similar to [`softmax_axes`] but with a single axis.
 #[generate_macro]
 #[default_device]
-pub fn softmax_all_device(
+pub fn softmax_axis_device(
     a: impl AsRef<Array>,
-    #[optional] precise: impl Into<Option<bool>>,
+    axis: i32,
+    precise: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     let precise = precise.into().unwrap_or(false);
     let s = stream.as_ref().as_ptr();
 
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_softmax_all(res, a.as_ref().as_ptr(), precise, s)
+        mlx_sys::mlx_softmax_axis(res, a.as_ref().as_ptr(), axis, precise, s)
     })
+}
+
+/// Similar to [`softmax_axes`] but with no axis specified.
+#[generate_macro]
+#[default_device]
+pub fn softmax_device(
+    a: impl AsRef<Array>,
+    precise: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    let precise = precise.into().unwrap_or(false);
+    let s = stream.as_ref().as_ptr();
+
+    Array::try_from_op(|res| unsafe { mlx_sys::mlx_softmax(res, a.as_ref().as_ptr(), precise, s) })
 }
 
 /// See [`Array::sqrt`].
@@ -1412,76 +1426,46 @@ pub fn outer_device(
     })
 }
 
-/// The number of dimensions to sum over
-#[derive(Debug)]
-pub enum TensorDotDims<'a> {
-    /// Sum over the last axes dimensions of a and the first axes dimensions of b.
-    Int(i32),
-
-    /// Sum over the corresponding dimensions of a and b.
-    List((&'a [i32], &'a [i32])),
-}
-
-impl From<i32> for TensorDotDims<'_> {
-    fn from(i: i32) -> Self {
-        TensorDotDims::Int(i)
-    }
-}
-
-impl<'a> From<(&'a [i32], &'a [i32])> for TensorDotDims<'a> {
-    fn from((lhs, rhs): (&'a [i32], &'a [i32])) -> Self {
-        TensorDotDims::List((lhs, rhs))
-    }
-}
-
-impl<'a, const M: usize, const N: usize> From<(&'a [i32; M], &'a [i32; N])> for TensorDotDims<'a> {
-    fn from((lhs, rhs): (&'a [i32; M], &'a [i32; N])) -> Self {
-        TensorDotDims::List((lhs, rhs))
-    }
-}
-
 /// Compute the tensor dot product along the specified axes.
-///
-/// # Params
-///
-/// - `a`: input array,
-/// - `b`: input array,
-/// - `axes`: The number of dimensions to sum over. If an integer is provided, then sum over
-///   the last axes dimensions of a and the first axes dimensions of b. If a tuple of lists is
-///   provided, then sum over the corresponding dimensions of a and b. (default: 2)
 #[generate_macro]
 #[default_device]
-pub fn tensordot_device<'a>(
+pub fn tensordot_axes_device(
     a: impl AsRef<Array>,
     b: impl AsRef<Array>,
-    #[optional] axes: impl Into<TensorDotDims<'a>>,
+    axes_a: &[i32],
+    axes_b: &[i32],
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     let a = a.as_ref();
     let b = b.as_ref();
-    match axes.into() {
-        TensorDotDims::Int(dim) => Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_tensordot_along_axis(
-                res,
-                a.as_ptr(),
-                b.as_ptr(),
-                dim,
-                stream.as_ref().as_ptr(),
-            )
-        }),
-        TensorDotDims::List((lhs, rhs)) => Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_tensordot(
-                res,
-                a.as_ptr(),
-                b.as_ptr(),
-                lhs.as_ptr(),
-                lhs.len(),
-                rhs.as_ptr(),
-                rhs.len(),
-                stream.as_ref().as_ptr(),
-            )
-        }),
-    }
+    Array::try_from_op(|res| unsafe {
+        mlx_sys::mlx_tensordot(
+            res,
+            a.as_ptr(),
+            b.as_ptr(),
+            axes_a.as_ptr(),
+            axes_a.len(),
+            axes_b.as_ptr(),
+            axes_b.len(),
+            stream.as_ref().as_ptr(),
+        )
+    })
+}
+
+/// Similar to [`tensordot_axes`] but with a single axis.
+#[generate_macro]
+#[default_device]
+pub fn tensordot_axis_device(
+    a: impl AsRef<Array>,
+    b: impl AsRef<Array>,
+    axis: i32,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    let a = a.as_ref();
+    let b = b.as_ref();
+    Array::try_from_op(|res| unsafe {
+        mlx_sys::mlx_tensordot_axis(res, a.as_ptr(), b.as_ptr(), axis, stream.as_ref().as_ptr())
+    })
 }
 
 #[cfg(test)]
@@ -1491,9 +1475,9 @@ mod tests {
     use super::*;
     use crate::{
         array, complex64,
-        ops::{all_close, arange, broadcast_to, eye, full, linspace, ones, reshape, split_equal},
+        ops::{all_close, arange, broadcast_to, eye, full, linspace, ones, reshape, split},
         transforms::eval,
-        Dtype,
+        Dtype, StreamOrDevice,
     };
     use float_eq::assert_float_eq;
     use pretty_assertions::assert_eq;
@@ -2143,7 +2127,7 @@ mod tests {
             .item::<bool>());
 
         let data = Array::from_slice(&[0.0, 1.0, 2.0, 3.0], &[2, 2]);
-        let x = split_equal(&data, 2, 1).unwrap();
+        let x = split(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0f32.exp(), 2.0f32.exp()], &[2, 1]);
         assert!(all_close(exp(&x[0]).unwrap(), &expected, None, None, None)
             .unwrap()
@@ -2208,7 +2192,7 @@ mod tests {
             .item::<bool>());
 
         let data = Array::from_slice(&[0.0, 1.0, 2.0, 3.0], &[2, 2]);
-        let x = split_equal(&data, 2, 1).unwrap();
+        let x = split(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0f32.sin(), 2.0f32.sin()], &[2, 1]);
         assert!(all_close(sin(&x[0]).unwrap(), &expected, None, None, None)
             .unwrap()
@@ -2251,7 +2235,7 @@ mod tests {
             .item::<bool>());
 
         let data = Array::from_slice(&[0.0, 1.0, 2.0, 3.0], &[2, 2]);
-        let x = split_equal(&data, 2, 1).unwrap();
+        let x = split(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0f32.cos(), 2.0f32.cos()], &[2, 1]);
         assert!(all_close(cos(&x[0]).unwrap(), &expected, None, None, None)
             .unwrap()
@@ -2282,7 +2266,7 @@ mod tests {
             .item::<bool>());
 
         let angles = Array::from_slice(&[0.0, PI / 2.0, PI, 1.5 * PI], &[2, 2]);
-        let x = split_equal(&angles, 2, 1).unwrap();
+        let x = split(&angles, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0, 180.0], &[2, 1]);
         assert!(
             all_close(degrees(&x[0]).unwrap(), &expected, None, None, None)
@@ -2321,7 +2305,7 @@ mod tests {
             .item::<bool>());
 
         let angles = Array::from_slice(&[0.0, 90.0, 180.0, 270.0], &[2, 2]);
-        let x = split_equal(&angles, 2, 1).unwrap();
+        let x = split(&angles, 2, 1).unwrap();
         let expected = Array::from_slice(&[0.0, PI], &[2, 1]);
         assert!(
             all_close(radians(&x[0]).unwrap(), &expected, None, None, None)
@@ -2352,7 +2336,7 @@ mod tests {
             .item::<bool>());
 
         let data = Array::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
-        let x = split_equal(&data, 2, 1).unwrap();
+        let x = split(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[1.0f32.ln(), 3.0f32.ln()], &[2, 1]);
         assert!(all_close(log(&x[0]).unwrap(), &expected, None, None, None)
             .unwrap()
@@ -2417,7 +2401,7 @@ mod tests {
             .item::<bool>());
 
         let data = Array::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
-        let x = split_equal(&data, 2, 1).unwrap();
+        let x = split(&data, 2, 1).unwrap();
         let expected = Array::from_slice(&[1.0f32.ln_1p(), 3.0f32.ln_1p()], &[2, 1]);
         assert!(
             all_close(log1p(&x[0]).unwrap(), &expected, None, None, None)
@@ -2650,37 +2634,34 @@ mod tests {
         let x = array![0.0];
         let y = array![0.0];
         assert_float_eq! {
-            log_add_exp(&x, &y).unwrap().item::<f32>(),
+            logaddexp(&x, &y).unwrap().item::<f32>(),
             2.0f32.ln(),
             abs <= 1e-5
         };
 
         let x = array!([0u32]);
         let y = array!([10000u32]);
-        assert_eq!(log_add_exp(&x, &y).unwrap().item::<f32>(), 10000.0);
+        assert_eq!(logaddexp(&x, &y).unwrap().item::<f32>(), 10000.0);
 
         let x = array![f32::INFINITY];
         let y = array![3.0];
-        assert_eq!(log_add_exp(&x, &y).unwrap().item::<f32>(), f32::INFINITY);
+        assert_eq!(logaddexp(&x, &y).unwrap().item::<f32>(), f32::INFINITY);
 
         let x = array![f32::NEG_INFINITY];
         let y = array![3.0];
-        assert_eq!(log_add_exp(&x, &y).unwrap().item::<f32>(), 3.0);
+        assert_eq!(logaddexp(&x, &y).unwrap().item::<f32>(), 3.0);
 
         let x = array![f32::NEG_INFINITY];
         let y = array![f32::NEG_INFINITY];
-        assert_eq!(
-            log_add_exp(&x, &y).unwrap().item::<f32>(),
-            f32::NEG_INFINITY
-        );
+        assert_eq!(logaddexp(&x, &y).unwrap().item::<f32>(), f32::NEG_INFINITY);
 
         let x = array![f32::INFINITY];
         let y = array![f32::INFINITY];
-        assert_eq!(log_add_exp(&x, &y).unwrap().item::<f32>(), f32::INFINITY);
+        assert_eq!(logaddexp(&x, &y).unwrap().item::<f32>(), f32::INFINITY);
 
         let x = array![f32::NEG_INFINITY];
         let y = array![f32::INFINITY];
-        assert_eq!(log_add_exp(&x, &y).unwrap().item::<f32>(), f32::INFINITY);
+        assert_eq!(logaddexp(&x, &y).unwrap().item::<f32>(), f32::INFINITY);
     }
 
     #[test]
@@ -2723,7 +2704,7 @@ mod tests {
     fn test_tensordot() {
         let x = reshape(arange::<_, f32>(None, 60.0, None).unwrap(), &[3, 4, 5]).unwrap();
         let y = reshape(arange::<_, f32>(None, 24.0, None).unwrap(), &[4, 3, 2]).unwrap();
-        let z = tensordot(&x, &y, (&[1i32, 0], &[0i32, 1])).unwrap();
+        let z = tensordot_axes(&x, &y, &[1i32, 0], &[0i32, 1]).unwrap();
         let expected = Array::from_slice(
             &[4400, 4730, 4532, 4874, 4664, 5018, 4796, 5162, 4928, 5306],
             &[5, 2],
@@ -2732,12 +2713,12 @@ mod tests {
 
         let x = reshape(arange::<_, f32>(None, 360.0, None).unwrap(), &[3, 4, 5, 6]).unwrap();
         let y = reshape(arange::<_, f32>(None, 360.0, None).unwrap(), &[6, 4, 5, 3]).unwrap();
-        assert!(tensordot(&x, &y, (&[2, 1, 3], &[1, 2, 0])).is_err());
+        assert!(tensordot_axes(&x, &y, &[2, 1, 3], &[1, 2, 0]).is_err());
 
         let x = reshape(arange::<_, f32>(None, 60.0, None).unwrap(), &[3, 4, 5]).unwrap();
         let y = reshape(arange::<_, f32>(None, 120.0, None).unwrap(), &[4, 5, 6]).unwrap();
 
-        let z = tensordot(&x, &y, 2).unwrap();
+        let z = tensordot_axis(&x, &y, 2).unwrap();
         let expected = Array::from_slice(
             &[
                 14820.0, 15010.0, 15200.0, 15390.0, 15580.0, 15770.0, 37620.0, 38210.0, 38800.0,

--- a/mlx-rs/src/ops/conversion.rs
+++ b/mlx-rs/src/ops/conversion.rs
@@ -1,8 +1,6 @@
 use mlx_internal_macros::default_device;
 
-use crate::{
-    error::Result, utils::guard::Guarded, Array, ArrayElement, Dtype, Stream, StreamOrDevice,
-};
+use crate::{error::Result, utils::guard::Guarded, Array, ArrayElement, Dtype, Stream};
 
 impl Array {
     /// Create a new array with the contents converted to the given [ArrayElement] type.

--- a/mlx-rs/src/ops/convolution.rs
+++ b/mlx-rs/src/ops/convolution.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::utils::guard::Guarded;
 use crate::utils::IntoOption;
-use crate::{Array, Stream, StreamOrDevice};
+use crate::{Array, Stream};
 use mlx_internal_macros::{default_device, generate_macro};
 
 /// General convolution over an input with several channels returning an error if the inputs are invalid.
@@ -203,6 +203,7 @@ pub fn conv3d_device(
 /// - dilation: kernel dilation. Default to 1 if not specified.
 /// - groups: input feature groups. Default to 1 if not specified.
 /// - stream: stream or device to evaluate on.
+#[allow(clippy::too_many_arguments)]
 #[generate_macro]
 #[default_device]
 pub fn conv_transpose1d_device(
@@ -211,12 +212,14 @@ pub fn conv_transpose1d_device(
     #[optional] stride: impl Into<Option<i32>>,
     #[optional] padding: impl Into<Option<i32>>,
     #[optional] dilation: impl Into<Option<i32>>,
+    #[optional] output_padding: impl Into<Option<i32>>,
     #[optional] groups: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     let stride = stride.into().unwrap_or(1);
     let padding = padding.into().unwrap_or(0);
     let dilation = dilation.into().unwrap_or(1);
+    let output_padding = output_padding.into().unwrap_or(0);
     let groups = groups.into().unwrap_or(1);
 
     Array::try_from_op(|res| unsafe {
@@ -227,6 +230,7 @@ pub fn conv_transpose1d_device(
             stride,
             padding,
             dilation,
+            output_padding,
             groups,
             stream.as_ref().as_ptr(),
         )
@@ -247,6 +251,7 @@ pub fn conv_transpose1d_device(
 /// - dilation: kernel dilation. Default to (1, 1) if not specified.
 /// - groups: input feature groups. Default to 1 if not specified.
 /// - stream: stream or device to evaluate on.
+#[allow(clippy::too_many_arguments)]
 #[generate_macro]
 #[default_device]
 pub fn conv_transpose2d_device(
@@ -255,12 +260,14 @@ pub fn conv_transpose2d_device(
     #[optional] stride: impl Into<Option<(i32, i32)>>,
     #[optional] padding: impl Into<Option<(i32, i32)>>,
     #[optional] dilation: impl Into<Option<(i32, i32)>>,
+    #[optional] output_padding: impl Into<Option<(i32, i32)>>,
     #[optional] groups: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     let stride = stride.into().unwrap_or((1, 1));
     let padding = padding.into().unwrap_or((0, 0));
     let dilation = dilation.into().unwrap_or((1, 1));
+    let output_padding = output_padding.into().unwrap_or((0, 0));
     let groups = groups.into().unwrap_or(1);
 
     Array::try_from_op(|res| unsafe {
@@ -274,6 +281,8 @@ pub fn conv_transpose2d_device(
             padding.1,
             dilation.0,
             dilation.1,
+            output_padding.0,
+            output_padding.1,
             groups,
             stream.as_ref().as_ptr(),
         )
@@ -294,6 +303,7 @@ pub fn conv_transpose2d_device(
 /// - dilation: kernel dilation. Default to (1, 1, 1) if not specified.
 /// - groups: input feature groups. Default to 1 if not specified.
 /// - stream: stream or device to evaluate on.
+#[allow(clippy::too_many_arguments)]
 #[generate_macro]
 #[default_device]
 pub fn conv_transpose3d_device(
@@ -302,12 +312,14 @@ pub fn conv_transpose3d_device(
     #[optional] stride: impl Into<Option<(i32, i32, i32)>>,
     #[optional] padding: impl Into<Option<(i32, i32, i32)>>,
     #[optional] dilation: impl Into<Option<(i32, i32, i32)>>,
+    #[optional] output_padding: impl Into<Option<(i32, i32, i32)>>,
     #[optional] groups: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     let stride = stride.into().unwrap_or((1, 1, 1));
     let padding = padding.into().unwrap_or((0, 0, 0));
     let dilation = dilation.into().unwrap_or((1, 1, 1));
+    let output_padding = output_padding.into().unwrap_or((0, 0, 0));
     let groups = groups.into().unwrap_or(1);
 
     Array::try_from_op(|res| unsafe {
@@ -324,6 +336,9 @@ pub fn conv_transpose3d_device(
             dilation.0,
             dilation.1,
             dilation.2,
+            output_padding.0,
+            output_padding.1,
+            output_padding.2,
             groups,
             stream.as_ref().as_ptr(),
         )
@@ -373,6 +388,7 @@ mod tests {
             Some(1), // stride
             Some(0), // padding
             Some(1), // dilation
+            None,    // output padding
             Some(1), // groups
         )
         .unwrap();
@@ -423,6 +439,7 @@ mod tests {
             Some((1, 1)), // stride
             Some((0, 0)), // padding
             Some((1, 1)), // dilation
+            None,         // output padding
             Some(1),      // groups
         )
         .unwrap();
@@ -481,6 +498,7 @@ mod tests {
             Some((1, 1, 1)), // stride
             Some((0, 0, 0)), // padding
             Some((1, 1, 1)), // dilation
+            None,            // output padding
             Some(1),         // groups
         )
         .unwrap();

--- a/mlx-rs/src/ops/cumulative.rs
+++ b/mlx-rs/src/ops/cumulative.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::utils::guard::Guarded;
-use crate::{Array, Stream, StreamOrDevice};
+use crate::{Array, Stream};
 use mlx_internal_macros::{default_device, generate_macro};
 
 impl Array {

--- a/mlx-rs/src/ops/factory.rs
+++ b/mlx-rs/src/ops/factory.rs
@@ -1,7 +1,7 @@
+use crate::array::Array;
 use crate::array::ArrayElement;
 use crate::error::Result;
 use crate::utils::guard::Guarded;
-use crate::{array::Array, stream::StreamOrDevice};
 use crate::{Dtype, Stream};
 use mlx_internal_macros::{default_device, generate_macro};
 use num_traits::NumCast;
@@ -239,17 +239,17 @@ impl Array {
     /// use mlx_rs::{Array, StreamOrDevice};
     /// // repeat a [2, 2] array 4 times along axis 1
     /// let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-    /// let r = Array::repeat_device::<i32>(source, 4, 1, StreamOrDevice::default()).unwrap();
+    /// let r = Array::repeat_axis::<i32>(source, 4, 1).unwrap();
     /// ```
     #[default_device]
-    pub fn repeat_device<T: ArrayElement>(
+    pub fn repeat_axis_device<T: ArrayElement>(
         array: Array,
         count: i32,
         axis: i32,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_repeat(res, array.as_ptr(), count, axis, stream.as_ref().as_ptr())
+            mlx_sys::mlx_repeat_axis(res, array.as_ptr(), count, axis, stream.as_ref().as_ptr())
         })
     }
 
@@ -266,16 +266,16 @@ impl Array {
     /// use mlx_rs::{Array, StreamOrDevice};
     /// // repeat a 4 element array 4 times along axis 0
     /// let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-    /// let r = Array::repeat_all_device::<i32>(source, 4, StreamOrDevice::default()).unwrap();
+    /// let r = Array::repeat::<i32>(source, 4).unwrap();
     /// ```
     #[default_device]
-    pub fn repeat_all_device<T: ArrayElement>(
+    pub fn repeat_device<T: ArrayElement>(
         array: Array,
         count: i32,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_repeat_all(res, array.as_ptr(), count, stream.as_ref().as_ptr())
+            mlx_sys::mlx_repeat(res, array.as_ptr(), count, stream.as_ref().as_ptr())
         })
     }
 
@@ -466,24 +466,24 @@ where
 /// See [`Array::repeat`]
 #[generate_macro]
 #[default_device]
-pub fn repeat_device<T: ArrayElement>(
+pub fn repeat_axis_device<T: ArrayElement>(
     array: Array,
     count: i32,
     axis: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    Array::repeat_device::<T>(array, count, axis, stream)
+    Array::repeat_axis_device::<T>(array, count, axis, stream)
 }
 
-/// See [`Array::repeat_all`]
+/// See [`Array::repeat`]
 #[generate_macro]
 #[default_device]
-pub fn repeat_all_device<T: ArrayElement>(
+pub fn repeat_device<T: ArrayElement>(
     array: Array,
     count: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    Array::repeat_all_device::<T>(array, count, stream)
+    Array::repeat_device::<T>(array, count, stream)
 }
 
 /// See [`Array::tri`]
@@ -542,7 +542,7 @@ pub fn triu_device(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{array, dtype::Dtype};
+    use crate::{array, dtype::Dtype, StreamOrDevice};
     use half::f16;
 
     #[test]
@@ -672,9 +672,10 @@ mod tests {
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        let data: &[f32] = array.as_slice();
-        let expected: Vec<f32> = (0..50).map(|x| x as f32 * (50.0 / 49.0)).collect();
-        assert_eq!(data, expected.as_slice());
+        let expected_data: Vec<f32> = (0..50).map(|x| x as f32 * (50.0 / 49.0)).collect();
+        let expected = Array::from_slice(&expected_data, &[50]);
+        assert_eq!(array.shape(), expected.shape());
+        assert_array_all_close!(array, expected);
     }
 
     #[test]
@@ -683,9 +684,10 @@ mod tests {
         assert_eq!(array.shape(), &[50]);
         assert_eq!(array.dtype(), Dtype::Float32);
 
-        let data: &[f32] = array.as_slice();
-        let expected: Vec<f32> = (0..50).map(|x| x as f32 * (50.0 / 49.0)).collect();
-        assert_eq!(data, expected.as_slice());
+        let expected_data: Vec<f32> = (0..50).map(|x| x as f32 * (50.0 / 49.0)).collect();
+        let expected = Array::from_slice(&expected_data, &[50]);
+        assert_eq!(array.shape(), expected.shape());
+        assert_array_all_close!(array, expected);
     }
 
     #[test]
@@ -700,7 +702,7 @@ mod tests {
     #[test]
     fn test_repeat() {
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let array = Array::repeat::<i32>(source, 4, 1).unwrap();
+        let array = Array::repeat_axis::<i32>(source, 4, 1).unwrap();
         assert_eq!(array.shape(), &[2, 8]);
         assert_eq!(array.dtype(), Dtype::Int32);
 
@@ -711,18 +713,18 @@ mod tests {
     #[test]
     fn test_repeat_try() {
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let array = Array::repeat::<i32>(source, 4, 1);
+        let array = Array::repeat_axis::<i32>(source, 4, 1);
         assert!(array.is_ok());
 
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let array = Array::repeat::<i32>(source, -1, 1);
+        let array = Array::repeat_axis::<i32>(source, -1, 1);
         assert!(array.is_err());
     }
 
     #[test]
     fn test_repeat_all() {
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let array = Array::repeat_all::<i32>(source, 4).unwrap();
+        let array = Array::repeat::<i32>(source, 4).unwrap();
         assert_eq!(array.shape(), &[16]);
         assert_eq!(array.dtype(), Dtype::Int32);
 
@@ -733,11 +735,11 @@ mod tests {
     #[test]
     fn test_repeat_all_try() {
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let array = Array::repeat_all::<i32>(source, 4);
+        let array = Array::repeat::<i32>(source, 4);
         assert!(array.is_ok());
 
         let source = Array::from_slice(&[0, 1, 2, 3], &[2, 2]);
-        let array = Array::repeat_all::<i32>(source, -1);
+        let array = Array::repeat::<i32>(source, -1);
         assert!(array.is_err());
     }
 

--- a/mlx-rs/src/ops/indexing/index_impl.rs
+++ b/mlx-rs/src/ops/indexing/index_impl.rs
@@ -896,7 +896,7 @@ fn gather_nd<'a>(
 #[inline]
 fn get_item_index(src: &Array, index: i32, axis: i32, stream: impl AsRef<Stream>) -> Result<Array> {
     let index = resolve_index_unchecked(index, src.dim(axis) as usize) as i32;
-    src.take_device(array!(index), axis, stream)
+    src.take_axis_device(array!(index), axis, stream)
 }
 
 #[inline]
@@ -906,7 +906,7 @@ fn get_item_array(
     axis: i32,
     stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    src.take_device(indices, axis, stream)
+    src.take_axis_device(indices, axis, stream)
 }
 
 #[inline]
@@ -939,7 +939,7 @@ fn get_item<'a>(
         TakeArray { indices } => get_item_array(src, &indices, 0, stream),
         TakeArrayRef { indices } => get_item_array(src, indices, 0, stream),
         Slice(range) => get_item_slice(src, range, stream),
-        ExpandDims => src.expand_dims_device(&[0], stream),
+        ExpandDims => src.expand_dims_device(0, stream),
     }
 }
 
@@ -1381,7 +1381,7 @@ mod tests {
         let result = result.as_ref();
         assert_eq!(result.shape(), shape);
 
-        let sum = result.sum(None, None).unwrap();
+        let sum = result.sum(None).unwrap();
 
         assert_eq!(sum.item::<i32>(), expected_sum);
     }

--- a/mlx-rs/src/ops/indexing/indexmut_impl.rs
+++ b/mlx-rs/src/ops/indexing/indexmut_impl.rs
@@ -127,7 +127,7 @@ fn update_slice(
     }
 
     if !update_expand_dims.is_empty() {
-        update = Cow::Owned(update.expand_dims_device(&update_expand_dims, &stream)?);
+        update = Cow::Owned(update.expand_dims_axes_device(&update_expand_dims, &stream)?);
     }
 
     Ok(Some(src.slice_update_device(
@@ -1350,7 +1350,7 @@ mod tests {
             let mut a = Array::from_iter(0..60, &[3, 4, 5]);
 
             a.index_mut(index, Array::from_int(1));
-            let sum = a.sum(None, None).unwrap().item::<i32>();
+            let sum = a.sum(None).unwrap().item::<i32>();
             assert_eq!(sum, expected_sum);
         }
 
@@ -1381,7 +1381,7 @@ mod tests {
                     let mut a = Array::from_iter(0..360, &[2, 3, 4, 5, 3]);
 
                     a.index_mut(($($i),*), Array::from_int(1));
-                    let sum = a.sum(None, None).unwrap().item::<i32>();
+                    let sum = a.sum(None).unwrap().item::<i32>();
                     assert_eq!(sum, $sum);
                 }
             };
@@ -1429,7 +1429,7 @@ mod tests {
                     let mut a = Array::from_iter(0..540, &[3, 3, 4, 5, 3]);
 
                     a.index_mut(($($i),*), Array::from_int(1));
-                    let sum = a.sum(None, None).unwrap().item::<i32>();
+                    let sum = a.sum(None).unwrap().item::<i32>();
                     assert_eq!(sum, $sum);
                 }
             };

--- a/mlx-rs/src/ops/indexing/mod.rs
+++ b/mlx-rs/src/ops/indexing/mod.rs
@@ -383,14 +383,14 @@ impl Array {
     /// - `indices`: The indices to take from the array.
     /// - `axis`: The axis along which to take the elements.
     #[default_device]
-    pub fn take_device(
+    pub fn take_axis_device(
         &self,
         indices: impl AsRef<Array>,
         axis: i32,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_take(
+            mlx_sys::mlx_take_axis(
                 res,
                 self.as_ptr(),
                 indices.as_ref().as_ptr(),
@@ -406,13 +406,13 @@ impl Array {
     ///
     /// - `indices`: The indices to take from the array.
     #[default_device]
-    pub fn take_all_device(
+    pub fn take_device(
         &self,
         indices: impl AsRef<Array>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_take_all(
+            mlx_sys::mlx_take(
                 res,
                 self.as_ptr(),
                 indices.as_ref().as_ptr(),
@@ -510,7 +510,7 @@ impl Array {
 /// - `keep_dims`: Keep reduced axes as singleton dimensions, defaults to False.
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn argmax_device(
+pub fn argmax_axis_device(
     a: impl AsRef<Array>,
     axis: i32,
     #[optional] keep_dims: impl Into<Option<bool>>,
@@ -519,7 +519,7 @@ pub fn argmax_device(
     let keep_dims = keep_dims.into().unwrap_or(false);
 
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argmax(
+        mlx_sys::mlx_argmax_axis(
             res,
             a.as_ref().as_ptr(),
             axis,
@@ -537,7 +537,7 @@ pub fn argmax_device(
 /// - `keep_dims`: Keep reduced axes as singleton dimensions, defaults to False.
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn argmax_all_device(
+pub fn argmax_device(
     a: impl AsRef<Array>,
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
@@ -545,7 +545,7 @@ pub fn argmax_all_device(
     let keep_dims = keep_dims.into().unwrap_or(false);
 
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argmax_all(
+        mlx_sys::mlx_argmax(
             res,
             a.as_ref().as_ptr(),
             keep_dims,
@@ -565,7 +565,7 @@ pub fn argmax_all_device(
 /// - `keep_dims`: Keep reduced axes as singleton dimensions, defaults to False.
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn argmin_device(
+pub fn argmin_axis_device(
     a: impl AsRef<Array>,
     axis: i32,
     #[optional] keep_dims: impl Into<Option<bool>>,
@@ -574,7 +574,7 @@ pub fn argmin_device(
     let keep_dims = keep_dims.into().unwrap_or(false);
 
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argmin(
+        mlx_sys::mlx_argmin_axis(
             res,
             a.as_ref().as_ptr(),
             axis,
@@ -592,7 +592,7 @@ pub fn argmin_device(
 /// - `keep_dims`: Keep reduced axes as singleton dimensions, defaults to False.
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn argmin_all_device(
+pub fn argmin_device(
     a: impl AsRef<Array>,
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
@@ -600,7 +600,7 @@ pub fn argmin_all_device(
     let keep_dims = keep_dims.into().unwrap_or(false);
 
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argmin_all(
+        mlx_sys::mlx_argmin(
             res,
             a.as_ref().as_ptr(),
             keep_dims,
@@ -638,24 +638,24 @@ pub fn put_along_axis_device(
 /// See [`Array::take`]
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn take_device(
+pub fn take_axis_device(
     a: impl AsRef<Array>,
     indices: impl AsRef<Array>,
     axis: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    a.as_ref().take_device(indices, axis, stream)
+    a.as_ref().take_axis_device(indices, axis, stream)
 }
 
 /// See [`Array::take_all`]
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn take_all_device(
+pub fn take_device(
     a: impl AsRef<Array>,
     indices: impl AsRef<Array>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    a.as_ref().take_all_device(indices, stream)
+    a.as_ref().take_device(indices, stream)
 }
 
 /// Returns the `k` largest elements from the input along a given axis.
@@ -671,29 +671,27 @@ pub fn take_all_device(
 /// - `axis`: Axis to sort over. Default to `-1` if not specified.
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn topk_device(
+pub fn topk_axis_device(
     a: impl AsRef<Array>,
     k: i32,
-    #[optional] axis: impl Into<Option<i32>>,
+    axis: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    let axis = axis.into().unwrap_or(-1);
-
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_topk(res, a.as_ref().as_ptr(), k, axis, stream.as_ref().as_ptr())
+        mlx_sys::mlx_topk_axis(res, a.as_ref().as_ptr(), k, axis, stream.as_ref().as_ptr())
     })
 }
 
 /// Returns the `k` largest elements from the flattened input array.
 #[generate_macro(customize(root = "$crate::ops::indexing"))]
 #[default_device]
-pub fn topk_all_device(
+pub fn topk_device(
     a: impl AsRef<Array>,
     k: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_topk_all(res, a.as_ref().as_ptr(), k, stream.as_ref().as_ptr())
+        mlx_sys::mlx_topk(res, a.as_ref().as_ptr(), k, stream.as_ref().as_ptr())
     })
 }
 

--- a/mlx-rs/src/ops/logical.rs
+++ b/mlx-rs/src/ops/logical.rs
@@ -1,8 +1,6 @@
 use crate::array::Array;
 use crate::error::Result;
-use crate::stream::StreamOrDevice;
 use crate::utils::guard::Guarded;
-use crate::utils::{axes_or_default_to_all, IntoOption};
 use crate::Stream;
 use mlx_internal_macros::{default_device, generate_macro};
 
@@ -423,26 +421,60 @@ impl Array {
     /// let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
     ///
     /// // will produce a scalar Array with true -- some of the values are non-zero
-    /// let all = array.any(None, None).unwrap();
+    /// let all = array.any(None).unwrap();
     ///
     /// // produces an Array([true, true, true, true]) -- all rows have non-zeros
-    /// let all_rows = array.any(&[0], None).unwrap();
+    /// let all_rows = array.any_axes(&[0], None).unwrap();
     /// ```
     #[default_device]
-    pub fn any_device<'a>(
+    pub fn any_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
-
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_any(
+            mlx_sys::mlx_any_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`any_axes`] but defaults to all axes.
+    #[default_device]
+    pub fn any_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_any_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`any_axes`] but defaults to all axes.
+    #[default_device]
+    pub fn any_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_any(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 stream.as_ref().as_ptr(),
             )
@@ -453,13 +485,36 @@ impl Array {
 /// See [`Array::any`]
 #[generate_macro]
 #[default_device]
-pub fn any_device<'a>(
+pub fn any_axes_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
+    axes: &[i32],
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().any_device(axes, keep_dims, stream)
+    array.as_ref().any_axes_device(axes, keep_dims, stream)
+}
+
+/// See [`Array::any`]
+#[generate_macro]
+#[default_device]
+pub fn any_axis_device(
+    array: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().any_axis_device(axis, keep_dims, stream)
+}
+
+/// See [`Array::any`]
+#[generate_macro]
+#[default_device]
+pub fn any_device(
+    array: impl AsRef<Array>,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().any_device(keep_dims, stream)
 }
 
 /// See [`Array::logical_and`]
@@ -960,7 +1015,7 @@ mod tests {
     #[test]
     fn test_any() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-        let all = array.any(&[0][..], None).unwrap();
+        let all = array.any_axes(&[0][..], None).unwrap();
 
         let results: &[bool] = all.as_slice();
         assert_eq!(results, &[true, true, true, true]);
@@ -969,7 +1024,7 @@ mod tests {
     #[test]
     fn test_any_empty_axes() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-        let all = array.any(&[][..], None).unwrap();
+        let all = array.any_axes(&[][..], None).unwrap();
 
         let results: &[bool] = all.as_slice();
         assert_eq!(
@@ -981,14 +1036,14 @@ mod tests {
     #[test]
     fn test_any_out_of_bounds() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[12]);
-        let result = array.any(&[1][..], None);
+        let result = array.any_axes(&[1][..], None);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_any_duplicate_axes() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-        let result = array.any(&[0, 0][..], None);
+        let result = array.any_axes(&[0, 0][..], None);
         assert!(result.is_err());
     }
 

--- a/mlx-rs/src/ops/other.rs
+++ b/mlx-rs/src/ops/other.rs
@@ -6,7 +6,7 @@ use crate::utils::guard::Guarded;
 use crate::utils::VectorArray;
 use crate::{
     error::{Exception, Result},
-    Array, Stream, StreamOrDevice,
+    Array, Stream,
 };
 
 impl Array {

--- a/mlx-rs/src/ops/quantization.rs
+++ b/mlx-rs/src/ops/quantization.rs
@@ -1,6 +1,6 @@
 use mlx_internal_macros::{default_device, generate_macro};
 
-use crate::{error::Result, utils::guard::Guarded, Array, Stream, StreamOrDevice};
+use crate::{error::Result, utils::guard::Guarded, Array, Stream};
 
 /// Quantize the matrix `w` using `bits` bits per element.
 ///
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn test_quantize_dequantize() {
         let x1 = Array::ones::<f32>(&[128, 1]).unwrap();
-        let x2 = expand_dims(Array::arange::<_, f32>(0, 512, None).unwrap(), &[0]).unwrap();
+        let x2 = expand_dims(Array::arange::<_, f32>(0, 512, None).unwrap(), 0).unwrap();
         let x = x1 * x2;
 
         for i in [2, 4, 8].iter() {
@@ -130,7 +130,7 @@ mod tests {
             assert_eq!(biases.shape(), [128, 4]);
 
             let x_hat = dequantize(&x_q, &scales, &biases, 128, *i).unwrap();
-            let max_diff = ((&x - &x_hat).abs().unwrap().max(None, None).unwrap()).item::<f32>();
+            let max_diff = ((&x - &x_hat).abs().unwrap().max(None).unwrap()).item::<f32>();
             assert!(max_diff <= 127.0 / (1 << i) as f32);
         }
     }

--- a/mlx-rs/src/ops/reduction.rs
+++ b/mlx-rs/src/ops/reduction.rs
@@ -1,8 +1,7 @@
 use crate::array::Array;
 use crate::error::Result;
-use crate::stream::StreamOrDevice;
+use crate::utils::axes_or_default_to_all;
 use crate::utils::guard::Guarded;
-use crate::utils::{axes_or_default_to_all, IntoOption};
 use crate::Stream;
 use mlx_internal_macros::{default_device, generate_macro};
 
@@ -19,25 +18,60 @@ impl Array {
     /// ```rust
     /// use mlx_rs::Array;
     /// let a = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-    /// let mut b = a.all(&[0], None).unwrap();
+    /// let mut b = a.all_axes(&[0], None).unwrap();
     ///
     /// let results: &[bool] = b.as_slice();
     /// // results == [false, true, true, true]
     /// ```
     #[default_device]
-    pub fn all_device<'a>(
+    pub fn all_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
             mlx_sys::mlx_all_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::all_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn all_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_all_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::all_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn all_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_all(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 stream.as_ref().as_ptr(),
             )
@@ -58,22 +92,57 @@ impl Array {
     /// let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
     ///
     /// // result is [20, 72]
-    /// let result = array.prod(&[0], None).unwrap();
+    /// let result = array.prod_axes(&[0], None).unwrap();
     /// ```
     #[default_device]
-    pub fn prod_device<'a>(
+    pub fn prod_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_prod(
+            mlx_sys::mlx_prod_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::prod_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn prod_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_prod_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::prod_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn prod_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_prod(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 stream.as_ref().as_ptr(),
             )
@@ -94,22 +163,57 @@ impl Array {
     /// let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
     ///
     /// // result is [5, 9]
-    /// let result = array.max(&[0], None).unwrap();
+    /// let result = array.max_axes(&[0], None).unwrap();
     /// ```
     #[default_device]
-    pub fn max_device<'a>(
+    pub fn max_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_max(
+            mlx_sys::mlx_max_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::max_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn max_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_max_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::max_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn max_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_max(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 stream.as_ref().as_ptr(),
             )
@@ -130,22 +234,57 @@ impl Array {
     /// let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
     ///
     /// // result is [9, 17]
-    /// let result = array.sum(&[0], None).unwrap();
+    /// let result = array.sum_axes(&[0], None).unwrap();
     /// ```
     #[default_device]
-    pub fn sum_device<'a>(
+    pub fn sum_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_sum(
+            mlx_sys::mlx_sum_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::sum_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn sum_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_sum_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::sum_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn sum_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_sum(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 stream.as_ref().as_ptr(),
             )
@@ -166,22 +305,58 @@ impl Array {
     /// let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
     ///
     /// // result is [4.5, 8.5]
-    /// let result = array.mean(&[0], None).unwrap();
+    /// let result = array.mean_axes(&[0], None).unwrap();
     /// ```
     #[default_device]
-    pub fn mean_device<'a>(
+    pub fn mean_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
         let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_mean(
+            mlx_sys::mlx_mean_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::mean_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn mean_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_mean_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::mean_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn mean_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_mean(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 stream.as_ref().as_ptr(),
             )
@@ -202,22 +377,57 @@ impl Array {
     /// let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
     ///
     /// // result is [4, 8]
-    /// let result = array.min(&[0], None).unwrap();
+    /// let result = array.min_axes(&[0], None).unwrap();
     /// ```
     #[default_device]
-    pub fn min_device<'a>(
+    pub fn min_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_min(
+            mlx_sys::mlx_min_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::min_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn min_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_min_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::min_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn min_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_min(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 stream.as_ref().as_ptr(),
             )
@@ -232,20 +442,59 @@ impl Array {
     /// - keep_dims: if `true`, keep the reduces axes as singleton dimensions
     /// - ddof: the divisor to compute the variance is `N - ddof`
     #[default_device]
-    pub fn variance_device<'a>(
+    pub fn var_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         ddof: impl Into<Option<i32>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_var(
+            mlx_sys::mlx_var_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
                 axes.len(),
+                keep_dims.into().unwrap_or(false),
+                ddof.into().unwrap_or(0),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::var_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn var_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        ddof: impl Into<Option<i32>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_var_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                ddof.into().unwrap_or(0),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::var_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn var_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        ddof: impl Into<Option<i32>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_var(
+                res,
+                self.as_ptr(),
                 keep_dims.into().unwrap_or(false),
                 ddof.into().unwrap_or(0),
                 stream.as_ref().as_ptr(),
@@ -262,15 +511,14 @@ impl Array {
     /// - axes: axes to reduce over
     /// - keep_dims: Whether to keep the reduced dimensions -- defaults to false if not provided
     #[default_device]
-    pub fn log_sum_exp_device<'a>(
+    pub fn logsumexp_axes_device(
         &self,
-        axes: impl IntoOption<&'a [i32]>,
+        axes: &[i32],
         keep_dims: impl Into<Option<bool>>,
         stream: impl AsRef<Stream>,
     ) -> Result<Array> {
-        let axes = axes_or_default_to_all(axes, self.ndim() as i32);
         Array::try_from_op(|res| unsafe {
-            mlx_sys::mlx_logsumexp(
+            mlx_sys::mlx_logsumexp_axes(
                 res,
                 self.as_ptr(),
                 axes.as_ptr(),
@@ -280,42 +528,147 @@ impl Array {
             )
         })
     }
+
+    /// Similar to [`Array::logsumexp_axes`] but only reduces over a single axis.
+    #[default_device]
+    pub fn logsumexp_axis_device(
+        &self,
+        axis: i32,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_logsumexp_axis(
+                res,
+                self.as_ptr(),
+                axis,
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+
+    /// Similar to [`Array::logsumexp_axes`] but reduces over all axes.
+    #[default_device]
+    pub fn logsumexp_device(
+        &self,
+        keep_dims: impl Into<Option<bool>>,
+        stream: impl AsRef<Stream>,
+    ) -> Result<Array> {
+        Array::try_from_op(|res| unsafe {
+            mlx_sys::mlx_logsumexp(
+                res,
+                self.as_ptr(),
+                keep_dims.into().unwrap_or(false),
+                stream.as_ref().as_ptr(),
+            )
+        })
+    }
+}
+
+/// See [`Array::all_axes`]
+#[generate_macro]
+#[default_device]
+pub fn all_axes_device(
+    array: impl AsRef<Array>,
+    axes: &[i32],
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().all_axes_device(axes, keep_dims, stream)
+}
+
+/// See [`Array::all_axis`]
+#[generate_macro]
+#[default_device]
+pub fn all_axis_device(
+    array: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().all_axis_device(axis, keep_dims, stream)
 }
 
 /// See [`Array::all`]
 #[generate_macro]
 #[default_device]
-pub fn all_device<'a>(
+pub fn all_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().all_device(axes, keep_dims, stream)
+    array.as_ref().all_device(keep_dims, stream)
+}
+
+/// See [`Array::prod_axes`]
+#[generate_macro]
+#[default_device]
+pub fn prod_axes_device(
+    array: impl AsRef<Array>,
+    axes: &[i32],
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().prod_axes_device(axes, keep_dims, stream)
+}
+
+/// See [`Array::prod_axis`]
+#[generate_macro]
+#[default_device]
+pub fn prod_axis_device(
+    array: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().prod_axis_device(axis, keep_dims, stream)
 }
 
 /// See [`Array::prod`]
 #[generate_macro]
 #[default_device]
-pub fn prod_device<'a>(
+pub fn prod_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().prod_device(axes, keep_dims, stream)
+    array.as_ref().prod_device(keep_dims, stream)
+}
+
+/// See [`Array::max_axes`]
+#[generate_macro]
+#[default_device]
+pub fn max_axes_device(
+    array: impl AsRef<Array>,
+    axes: &[i32],
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().max_axes_device(axes, keep_dims, stream)
+}
+
+/// See [`Array::max_axis`]
+#[generate_macro]
+#[default_device]
+pub fn max_axis_device(
+    array: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().max_axis_device(axis, keep_dims, stream)
 }
 
 /// See [`Array::max`]
 #[generate_macro]
 #[default_device]
-pub fn max_device<'a>(
+pub fn max_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().max_device(axes, keep_dims, stream)
+    array.as_ref().max_device(keep_dims, stream)
 }
 
 /// Compute the standard deviation(s) over the given axes.
@@ -329,19 +682,18 @@ pub fn max_device<'a>(
 /// - `ddof`: The divisor to compute the variance is `N - ddof`, defaults to `0`.
 #[generate_macro]
 #[default_device]
-pub fn std_device<'a>(
+pub fn std_axes_device(
     a: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
+    axes: &[i32],
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] ddof: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     let a = a.as_ref();
-    let axes = axes_or_default_to_all(axes, a.ndim() as i32);
     let keep_dims = keep_dims.into().unwrap_or(false);
     let ddof = ddof.into().unwrap_or(0);
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_std(
+        mlx_sys::mlx_std_axes(
             res,
             a.as_ptr(),
             axes.as_ptr(),
@@ -353,67 +705,232 @@ pub fn std_device<'a>(
     })
 }
 
-/// See [`Array::sum`]
+/// Similar to [`std_axes`] but only reduces over a single axis.
 #[generate_macro]
 #[default_device]
-pub fn sum_device<'a>(
+pub fn std_axis_device(
+    a: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] ddof: impl Into<Option<i32>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    let a = a.as_ref();
+    let keep_dims = keep_dims.into().unwrap_or(false);
+    let ddof = ddof.into().unwrap_or(0);
+    Array::try_from_op(|res| unsafe {
+        mlx_sys::mlx_std_axis(
+            res,
+            a.as_ptr(),
+            axis,
+            keep_dims,
+            ddof,
+            stream.as_ref().as_ptr(),
+        )
+    })
+}
+
+/// Similar to [`std_axes`] but reduces over all axes.
+#[generate_macro]
+#[default_device]
+pub fn std_device(
+    a: impl AsRef<Array>,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] ddof: impl Into<Option<i32>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    let a = a.as_ref();
+    let keep_dims = keep_dims.into().unwrap_or(false);
+    let ddof = ddof.into().unwrap_or(0);
+    Array::try_from_op(|res| unsafe {
+        mlx_sys::mlx_std(res, a.as_ptr(), keep_dims, ddof, stream.as_ref().as_ptr())
+    })
+}
+
+/// See [`Array::sum_axes`]
+#[generate_macro]
+#[default_device]
+pub fn sum_axes_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
+    axes: &[i32],
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().sum_device(axes, keep_dims, stream)
+    array.as_ref().sum_axes_device(axes, keep_dims, stream)
+}
+
+/// See [`Array::sum_axis`]
+#[generate_macro]
+#[default_device]
+pub fn sum_axis_device(
+    array: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().sum_axis_device(axis, keep_dims, stream)
+}
+
+/// See [`Array::sum`]
+#[generate_macro]
+#[default_device]
+pub fn sum_device(
+    array: impl AsRef<Array>,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().sum_device(keep_dims, stream)
+}
+
+/// See [`Array::mean_axes`]
+#[generate_macro]
+#[default_device]
+pub fn mean_axes_device(
+    array: impl AsRef<Array>,
+    axes: &[i32],
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().mean_axes_device(axes, keep_dims, stream)
+}
+
+/// See [`Array::mean_axis`]
+#[generate_macro]
+#[default_device]
+pub fn mean_axis_device(
+    array: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().mean_axis_device(axis, keep_dims, stream)
 }
 
 /// See [`Array::mean`]
 #[generate_macro]
 #[default_device]
-pub fn mean_device<'a>(
+pub fn mean_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().mean_device(axes, keep_dims, stream)
+    array.as_ref().mean_device(keep_dims, stream)
 }
 
 /// See [`Array::min`]
 #[generate_macro]
 #[default_device]
-pub fn min_device<'a>(
+pub fn min_axes_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
+    axes: &[i32],
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().min_device(axes, keep_dims, stream)
+    array.as_ref().min_axes_device(axes, keep_dims, stream)
 }
 
-/// See [`Array::variance`]
+/// See [`Array::min_axis`]
 #[generate_macro]
 #[default_device]
-pub fn variance_device<'a>(
+pub fn min_axis_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().min_axis_device(axis, keep_dims, stream)
+}
+
+/// See [`Array::min`]
+#[generate_macro]
+#[default_device]
+pub fn min_device(
+    array: impl AsRef<Array>,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().min_device(keep_dims, stream)
+}
+
+/// See [`Array::var_axes`]
+#[generate_macro]
+#[default_device]
+pub fn var_axes_device(
+    array: impl AsRef<Array>,
+    axes: &[i32],
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] ddof: impl Into<Option<i32>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     array
         .as_ref()
-        .variance_device(axes, keep_dims, ddof, stream)
+        .var_axes_device(axes, keep_dims, ddof, stream)
 }
 
-/// See [`Array::log_sum_exp`]
+/// See [`Array::var_axis`]
 #[generate_macro]
 #[default_device]
-pub fn log_sum_exp_device<'a>(
+pub fn var_axis_device(
     array: impl AsRef<Array>,
-    #[optional] axes: impl IntoOption<&'a [i32]>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] ddof: impl Into<Option<i32>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array
+        .as_ref()
+        .var_axis_device(axis, keep_dims, ddof, stream)
+}
+
+/// See [`Array::var`]
+#[generate_macro]
+#[default_device]
+pub fn var_device(
+    array: impl AsRef<Array>,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] ddof: impl Into<Option<i32>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().var_device(keep_dims, ddof, stream)
+}
+
+/// See [`Array::logsumexp_axes`]
+#[generate_macro]
+#[default_device]
+pub fn logsumexp_axes_device(
+    array: impl AsRef<Array>,
+    axes: &[i32],
     #[optional] keep_dims: impl Into<Option<bool>>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
-    array.as_ref().log_sum_exp_device(axes, keep_dims, stream)
+    array
+        .as_ref()
+        .logsumexp_axes_device(axes, keep_dims, stream)
+}
+
+/// See [`Array::logsumexp_axis`]
+#[generate_macro]
+#[default_device]
+pub fn logsumexp_axis_device(
+    array: impl AsRef<Array>,
+    axis: i32,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array
+        .as_ref()
+        .logsumexp_axis_device(axis, keep_dims, stream)
+}
+
+/// See [`Array::logsumexp`]
+#[generate_macro]
+#[default_device]
+pub fn logsumexp_device(
+    array: impl AsRef<Array>,
+    #[optional] keep_dims: impl Into<Option<bool>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    array.as_ref().logsumexp_device(keep_dims, stream)
 }
 
 #[cfg(test)]
@@ -425,21 +942,21 @@ mod tests {
     fn test_all() {
         let array = Array::from_slice(&[true, false, true, false], &[2, 2]);
 
-        assert_eq!(array.all(None, None).unwrap().item::<bool>(), false);
-        assert_eq!(array.all(None, true).unwrap().shape(), &[1, 1]);
-        assert_eq!(array.all(&[0, 1][..], None).unwrap().item::<bool>(), false);
+        assert_eq!(array.all(None).unwrap().item::<bool>(), false);
+        assert_eq!(array.all(true).unwrap().shape(), &[1, 1]);
+        assert_eq!(array.all_axes(&[0, 1], None).unwrap().item::<bool>(), false);
 
-        let result = array.all(&[0][..], None).unwrap();
+        let result = array.all_axis(0, None).unwrap();
         assert_eq!(result.as_slice::<bool>(), &[true, false]);
 
-        let result = array.all(&[1][..], None).unwrap();
+        let result = array.all_axis(1, None).unwrap();
         assert_eq!(result.as_slice::<bool>(), &[false, false]);
     }
 
     #[test]
     fn test_all_empty_axes() {
         let array = Array::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], &[3, 4]);
-        let all = array.all(&[][..], None).unwrap();
+        let all = array.all_axes(&[], None).unwrap();
 
         let results: &[bool] = all.as_slice();
         assert_eq!(
@@ -451,23 +968,23 @@ mod tests {
     #[test]
     fn test_prod() {
         let x = Array::from_slice(&[1, 2, 3, 3], &[2, 2]);
-        assert_eq!(x.prod(None, None).unwrap().item::<i32>(), 18);
+        assert_eq!(x.prod(None).unwrap().item::<i32>(), 18);
 
-        let y = x.prod(None, true).unwrap();
+        let y = x.prod(true).unwrap();
         assert_eq!(y.item::<i32>(), 18);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let result = x.prod(&[0][..], None).unwrap();
+        let result = x.prod_axis(0, None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[3, 6]);
 
-        let result = x.prod(&[1][..], None).unwrap();
+        let result = x.prod_axis(1, None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[2, 9])
     }
 
     #[test]
     fn test_prod_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.prod(&[][..], None).unwrap();
+        let result = array.prod_axes(&[], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -476,22 +993,22 @@ mod tests {
     #[test]
     fn test_max() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
-        assert_eq!(x.max(None, None).unwrap().item::<i32>(), 4);
-        let y = x.max(None, true).unwrap();
+        assert_eq!(x.max(None).unwrap().item::<i32>(), 4);
+        let y = x.max(true).unwrap();
         assert_eq!(y.item::<i32>(), 4);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let result = x.max(&[0][..], None).unwrap();
+        let result = x.max_axis(0, None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[3, 4]);
 
-        let result = x.max(&[1][..], None).unwrap();
+        let result = x.max_axis(1, None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[2, 4]);
     }
 
     #[test]
     fn test_max_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.max(&[][..], None).unwrap();
+        let result = array.max_axes(&[], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -500,7 +1017,7 @@ mod tests {
     #[test]
     fn test_sum() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.sum(&[0][..], None).unwrap();
+        let result = array.sum_axis(0, None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[9, 17]);
@@ -509,7 +1026,7 @@ mod tests {
     #[test]
     fn test_sum_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.sum(&[][..], None).unwrap();
+        let result = array.sum_axes(&[], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -518,22 +1035,22 @@ mod tests {
     #[test]
     fn test_mean() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
-        assert_eq!(x.mean(None, None).unwrap().item::<f32>(), 2.5);
-        let y = x.mean(None, true).unwrap();
+        assert_eq!(x.mean(None).unwrap().item::<f32>(), 2.5);
+        let y = x.mean(true).unwrap();
         assert_eq!(y.item::<f32>(), 2.5);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let result = x.mean(&[0][..], None).unwrap();
+        let result = x.mean_axis(0, None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[2.0, 3.0]);
 
-        let result = x.mean(&[1][..], None).unwrap();
+        let result = x.mean_axis(1, None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[1.5, 3.5]);
     }
 
     #[test]
     fn test_mean_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.mean(&[][..], None).unwrap();
+        let result = array.mean_axes(&[], None).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.0, 8.0, 4.0, 9.0]);
@@ -542,29 +1059,29 @@ mod tests {
     #[test]
     fn test_mean_out_of_bounds() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.mean(&[2][..], None);
+        let result = array.mean_axis(2, None);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_min() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
-        assert_eq!(x.min(None, None).unwrap().item::<i32>(), 1);
-        let y = x.min(None, true).unwrap();
+        assert_eq!(x.min(None).unwrap().item::<i32>(), 1);
+        let y = x.min(true).unwrap();
         assert_eq!(y.item::<i32>(), 1);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let result = x.min(&[0][..], None).unwrap();
+        let result = x.min_axis(0, None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[1, 2]);
 
-        let result = x.min(&[1][..], None).unwrap();
+        let result = x.min_axis(1, None).unwrap();
         assert_eq!(result.as_slice::<i32>(), &[1, 3]);
     }
 
     #[test]
     fn test_min_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.min(&[][..], None).unwrap();
+        let result = array.min_axes(&[], None).unwrap();
 
         let results: &[i32] = result.as_slice();
         assert_eq!(results, &[5, 8, 4, 9]);
@@ -573,26 +1090,26 @@ mod tests {
     #[test]
     fn test_var() {
         let x = Array::from_slice(&[1, 2, 3, 4], &[2, 2]);
-        assert_eq!(x.variance(None, None, None).unwrap().item::<f32>(), 1.25);
-        let y = x.variance(None, true, None).unwrap();
+        assert_eq!(x.var(None, None).unwrap().item::<f32>(), 1.25);
+        let y = x.var(true, None).unwrap();
         assert_eq!(y.item::<f32>(), 1.25);
         assert_eq!(y.shape(), &[1, 1]);
 
-        let result = x.variance(&[0][..], None, None).unwrap();
+        let result = x.var_axis(0, None, None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[1.0, 1.0]);
 
-        let result = x.variance(&[1][..], None, None).unwrap();
+        let result = x.var_axis(1, None, None).unwrap();
         assert_eq!(result.as_slice::<f32>(), &[0.25, 0.25]);
 
         let x = Array::from_slice(&[1.0, 2.0], &[2]);
-        let out = x.variance(None, None, Some(3)).unwrap();
+        let out = x.var(None, Some(3)).unwrap();
         assert_eq!(out.item::<f32>(), f32::INFINITY);
     }
 
     #[test]
     fn test_var_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.variance(&[][..], None, 0).unwrap();
+        let result = array.var_axes(&[], None, 0).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[0.0, 0.0, 0.0, 0.0]);
@@ -601,7 +1118,7 @@ mod tests {
     #[test]
     fn test_log_sum_exp() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.log_sum_exp(&[0][..], None).unwrap();
+        let result = array.logsumexp_axis(0, None).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.3132615, 9.313262]);
@@ -610,7 +1127,7 @@ mod tests {
     #[test]
     fn test_log_sum_exp_empty_axes() {
         let array = Array::from_slice(&[5, 8, 4, 9], &[2, 2]);
-        let result = array.log_sum_exp(&[][..], None).unwrap();
+        let result = array.logsumexp_axes(&[], None).unwrap();
 
         let results: &[f32] = result.as_slice();
         assert_eq!(results, &[5.0, 8.0, 4.0, 9.0]);

--- a/mlx-rs/src/ops/sort.rs
+++ b/mlx-rs/src/ops/sort.rs
@@ -2,7 +2,7 @@
 
 use mlx_internal_macros::{default_device, generate_macro};
 
-use crate::{error::Result, utils::guard::Guarded, Array, Stream, StreamOrDevice};
+use crate::{error::Result, utils::guard::Guarded, Array, Stream};
 
 /// Returns a sorted copy of the array. Returns an error if the arguments are invalid.
 ///
@@ -18,17 +18,17 @@ use crate::{error::Result, utils::guard::Guarded, Array, Stream, StreamOrDevice}
 ///
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
 /// let axis = 0;
-/// let result = sort(&a, axis);
+/// let result = sort_axis(&a, axis);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn sort_device(
+pub fn sort_axis_device(
     a: impl AsRef<Array>,
     axis: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_sort(res, a.as_ref().as_ptr(), axis, stream.as_ref().as_ptr())
+        mlx_sys::mlx_sort_axis(res, a.as_ref().as_ptr(), axis, stream.as_ref().as_ptr())
     })
 }
 
@@ -44,16 +44,13 @@ pub fn sort_device(
 /// use mlx_rs::{Array, ops::*};
 ///
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
-/// let result = sort_all(&a);
+/// let result = sort(&a);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn sort_all_device(
-    a: impl AsRef<Array>,
-    #[optional] stream: impl AsRef<Stream>,
-) -> Result<Array> {
+pub fn sort_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_sort_all(res, a.as_ref().as_ptr(), stream.as_ref().as_ptr())
+        mlx_sys::mlx_sort(res, a.as_ref().as_ptr(), stream.as_ref().as_ptr())
     })
 }
 
@@ -71,17 +68,17 @@ pub fn sort_all_device(
 ///
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
 /// let axis = 0;
-/// let result = argsort(&a, axis);
+/// let result = argsort_axis(&a, axis);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn argsort_device(
+pub fn argsort_axis_device(
     a: impl AsRef<Array>,
     axis: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argsort(res, a.as_ref().as_ptr(), axis, stream.as_ref().as_ptr())
+        mlx_sys::mlx_argsort_axis(res, a.as_ref().as_ptr(), axis, stream.as_ref().as_ptr())
     })
 }
 
@@ -98,16 +95,16 @@ pub fn argsort_device(
 /// use mlx_rs::{Array, ops::*};
 ///
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
-/// let result = argsort_all(&a);
+/// let result = argsort(&a);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn argsort_all_device(
+pub fn argsort_device(
     a: impl AsRef<Array>,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argsort_all(res, a.as_ref().as_ptr(), stream.as_ref().as_ptr())
+        mlx_sys::mlx_argsort(res, a.as_ref().as_ptr(), stream.as_ref().as_ptr())
     })
 }
 
@@ -132,18 +129,18 @@ pub fn argsort_all_device(
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
 /// let kth = 1;
 /// let axis = 0;
-/// let result = partition(&a, kth, axis);
+/// let result = partition_axis(&a, kth, axis);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn partition_device(
+pub fn partition_axis_device(
     a: impl AsRef<Array>,
     kth: i32,
     axis: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_partition(
+        mlx_sys::mlx_partition_axis(
             res,
             a.as_ref().as_ptr(),
             kth,
@@ -172,17 +169,17 @@ pub fn partition_device(
 ///
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
 /// let kth = 1;
-/// let result = partition_all(&a, kth);
+/// let result = partition(&a, kth);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn partition_all_device(
+pub fn partition_device(
     a: impl AsRef<Array>,
     kth: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_partition_all(res, a.as_ref().as_ptr(), kth, stream.as_ref().as_ptr())
+        mlx_sys::mlx_partition(res, a.as_ref().as_ptr(), kth, stream.as_ref().as_ptr())
     })
 }
 
@@ -207,18 +204,18 @@ pub fn partition_all_device(
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
 /// let kth = 1;
 /// let axis = 0;
-/// let result = argpartition(&a, kth, axis);
+/// let result = argpartition_axis(&a, kth, axis);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn argpartition_device(
+pub fn argpartition_axis_device(
     a: impl AsRef<Array>,
     kth: i32,
     axis: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argpartition(
+        mlx_sys::mlx_argpartition_axis(
             res,
             a.as_ref().as_ptr(),
             kth,
@@ -248,17 +245,17 @@ pub fn argpartition_device(
 ///
 /// let a = Array::from_slice(&[3, 2, 1], &[3]);
 /// let kth = 1;
-/// let result = argpartition_all(&a, kth);
+/// let result = argpartition(&a, kth);
 /// ```
 #[generate_macro]
 #[default_device]
-pub fn argpartition_all_device(
+pub fn argpartition_device(
     a: impl AsRef<Array>,
     kth: i32,
     #[optional] stream: impl AsRef<Stream>,
 ) -> Result<Array> {
     Array::try_from_op(|res| unsafe {
-        mlx_sys::mlx_argpartition_all(res, a.as_ref().as_ptr(), kth, stream.as_ref().as_ptr())
+        mlx_sys::mlx_argpartition(res, a.as_ref().as_ptr(), kth, stream.as_ref().as_ptr())
     })
 }
 
@@ -270,7 +267,7 @@ mod tests {
     fn test_sort_with_invalid_axis() {
         let a = Array::from_slice(&[1, 2, 3, 4, 5], &[5]);
         let axis = 1;
-        let result = super::sort(&a, axis);
+        let result = super::sort_axis(&a, axis);
         assert!(result.is_err());
     }
 
@@ -279,7 +276,7 @@ mod tests {
         let a = Array::from_slice(&[1, 2, 3, 4, 5], &[5]);
         let kth = 2;
         let axis = 1;
-        let result = super::partition(&a, kth, axis);
+        let result = super::partition_axis(&a, kth, axis);
         assert!(result.is_err());
     }
 
@@ -288,7 +285,7 @@ mod tests {
         let a = Array::from_slice(&[1, 2, 3, 4, 5], &[5]);
         let kth = 5;
         let axis = 0;
-        let result = super::partition(&a, kth, axis);
+        let result = super::partition_axis(&a, kth, axis);
         assert!(result.is_err());
     }
 
@@ -296,7 +293,7 @@ mod tests {
     fn test_partition_all_with_invalid_kth() {
         let a = Array::from_slice(&[1, 2, 3, 4, 5], &[5]);
         let kth = 5;
-        let result = super::partition_all(&a, kth);
+        let result = super::partition(&a, kth);
         assert!(result.is_err());
     }
 }

--- a/mlx-rs/src/optimizers/adadelta.rs
+++ b/mlx-rs/src/optimizers/adadelta.rs
@@ -118,13 +118,17 @@ impl Optimizer for AdaDelta {
 }
 
 impl Updatable for AdaDelta {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len() * 2
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 
         self.state
             .iter()
             .sorted_by(|a, b| a.0.cmp(b.0))
-            .flat_map(|(_, (v, u))| vec![v, u])
+            .flat_map(|(_, (v, u))| [v, u])
     }
 
     fn updatable_states_mut(&mut self) -> impl IntoIterator<Item = &mut Array> {
@@ -133,7 +137,7 @@ impl Updatable for AdaDelta {
         self.state
             .iter_mut()
             .sorted_by(|a, b| a.0.cmp(b.0))
-            .flat_map(|(_, (v, u))| vec![v, u])
+            .flat_map(|(_, (v, u))| [v, u])
     }
 }
 

--- a/mlx-rs/src/optimizers/adafactor.rs
+++ b/mlx-rs/src/optimizers/adafactor.rs
@@ -442,6 +442,10 @@ impl Optimizer for Adafactor {
 }
 
 impl Updatable for Adafactor {
+    fn updatable_states_len(&self) -> usize {
+        self.updatable_states().into_iter().count()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/optimizers/adafactor.rs
+++ b/mlx-rs/src/optimizers/adafactor.rs
@@ -45,22 +45,22 @@ impl OptimizerState for State<AdafactorState> {
 
     fn flatten(&self) -> impl Iterator<Item = (Rc<str>, &Array)> {
         self.iter().flat_map(|(k, v)| {
-            let mut iter = vec![(Rc::from(format!("{}.step", k)), &v.step)];
+            let mut iter = vec![(Rc::from(format!("{k}.step")), &v.step)];
 
             if let Some(exp_avg_sq_row) = &v.exp_avg_sq_row {
-                iter.push((Rc::from(format!("{}.exp_avg_sq_row", k)), exp_avg_sq_row));
+                iter.push((Rc::from(format!("{k}.exp_avg_sq_row")), exp_avg_sq_row));
             }
 
             if let Some(exp_avg_sq_col) = &v.exp_avg_sq_col {
-                iter.push((Rc::from(format!("{}.exp_avg_sq_col", k)), exp_avg_sq_col));
+                iter.push((Rc::from(format!("{k}.exp_avg_sq_col")), exp_avg_sq_col));
             }
 
             if let Some(exp_avg_sq) = &v.exp_avg_sq {
-                iter.push((Rc::from(format!("{}.exp_avg_sq", k)), exp_avg_sq));
+                iter.push((Rc::from(format!("{k}.exp_avg_sq")), exp_avg_sq));
             }
 
             if let Some(exp_avg) = &v.exp_avg {
-                iter.push((Rc::from(format!("{}.exp_avg", k)), exp_avg));
+                iter.push((Rc::from(format!("{k}.exp_avg")), exp_avg));
             }
 
             iter
@@ -69,22 +69,22 @@ impl OptimizerState for State<AdafactorState> {
 
     fn flatten_mut(&mut self) -> impl Iterator<Item = (Rc<str>, &mut Array)> {
         self.iter_mut().flat_map(|(k, v)| {
-            let mut iter = vec![(Rc::from(format!("{}.step", k)), &mut v.step)];
+            let mut iter = vec![(Rc::from(format!("{k}.step")), &mut v.step)];
 
             if let Some(exp_avg_sq_row) = &mut v.exp_avg_sq_row {
-                iter.push((Rc::from(format!("{}.exp_avg_sq_row", k)), exp_avg_sq_row));
+                iter.push((Rc::from(format!("{k}.exp_avg_sq_row")), exp_avg_sq_row));
             }
 
             if let Some(exp_avg_sq_col) = &mut v.exp_avg_sq_col {
-                iter.push((Rc::from(format!("{}.exp_avg_sq_col", k)), exp_avg_sq_col));
+                iter.push((Rc::from(format!("{k}.exp_avg_sq_col")), exp_avg_sq_col));
             }
 
             if let Some(exp_avg_sq) = &mut v.exp_avg_sq {
-                iter.push((Rc::from(format!("{}.exp_avg_sq", k)), exp_avg_sq));
+                iter.push((Rc::from(format!("{k}.exp_avg_sq")), exp_avg_sq));
             }
 
             if let Some(exp_avg) = &mut v.exp_avg {
-                iter.push((Rc::from(format!("{}.exp_avg", k)), exp_avg));
+                iter.push((Rc::from(format!("{k}.exp_avg")), exp_avg));
             }
 
             iter

--- a/mlx-rs/src/optimizers/adafactor.rs
+++ b/mlx-rs/src/optimizers/adafactor.rs
@@ -5,7 +5,9 @@ use mlx_internal_macros::{generate_builder, Buildable};
 use crate::{
     array,
     error::AdafactorBuildError,
-    ops::{matmul, maximum, mean, minimum, rsqrt, sqrt, square, zeros_dtype, zeros_like},
+    ops::{
+        matmul, maximum, mean, mean_axes, minimum, rsqrt, sqrt, square, zeros_dtype, zeros_like,
+    },
     utils::Updatable,
     Array,
 };
@@ -13,16 +15,16 @@ use crate::{
 use super::*;
 
 fn rms(inputs: &Array) -> crate::error::Result<Array> {
-    sqrt(&mean(&square(inputs)?, None, None)?)
+    sqrt(&mean(&square(inputs)?, None)?)
 }
 
 fn approvate_exp_moving_avg(
     exp_avg_sq_row: &Array,
     exp_avg_sq_col: &Array,
 ) -> crate::error::Result<Array> {
-    let rfactor = rsqrt(&exp_avg_sq_row.divide(&mean(exp_avg_sq_row, &[-1], true)?)?)?;
+    let rfactor = rsqrt(&exp_avg_sq_row.divide(&mean_axes(exp_avg_sq_row, &[-1], true)?)?)?;
     let cfactor = rsqrt(exp_avg_sq_col)?;
-    matmul(&rfactor.expand_dims(&[-1])?, &cfactor.expand_dims(&[0])?)
+    matmul(&rfactor.expand_dims(-1)?, &cfactor.expand_dims(0)?)
 }
 
 /// Type alias for the epsilon values used in Adafactor builder
@@ -393,10 +395,10 @@ impl Optimizer for Adafactor {
 
             *exp_avg_sq_row = beta2
                 .multiply(&*exp_avg_sq_row)?
-                .add(&one_minus_beta2.multiply(&update.mean(&[-1], None)?)?)?;
+                .add(&one_minus_beta2.multiply(&update.mean_axes(&[-1], None)?)?)?;
             *exp_avg_sq_col = beta2
                 .multiply(&*exp_avg_sq_col)?
-                .add(&one_minus_beta2.multiply(&update.mean(&[-2], None)?)?)?;
+                .add(&one_minus_beta2.multiply(&update.mean_axes(&[-2], None)?)?)?;
 
             update = Cow::Owned(approvate_exp_moving_avg(
                 &*exp_avg_sq_row,

--- a/mlx-rs/src/optimizers/adagrad.rs
+++ b/mlx-rs/src/optimizers/adagrad.rs
@@ -85,6 +85,10 @@ impl Optimizer for AdaGrad {
 }
 
 impl Updatable for AdaGrad {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/optimizers/adam.rs
+++ b/mlx-rs/src/optimizers/adam.rs
@@ -124,6 +124,10 @@ pub(super) fn adam_apply_single(
 }
 
 impl Updatable for Adam {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len() * 2
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/optimizers/adamax.rs
+++ b/mlx-rs/src/optimizers/adamax.rs
@@ -100,6 +100,10 @@ impl Optimizer for Adamax {
 }
 
 impl Updatable for Adamax {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len() * 2
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/optimizers/adamw.rs
+++ b/mlx-rs/src/optimizers/adamw.rs
@@ -121,6 +121,10 @@ impl Optimizer for AdamW {
 }
 
 impl Updatable for AdamW {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len() * 2
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/optimizers/lion.rs
+++ b/mlx-rs/src/optimizers/lion.rs
@@ -105,6 +105,10 @@ impl Optimizer for Lion {
 }
 
 impl Updatable for Lion {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/optimizers/mod.rs
+++ b/mlx-rs/src/optimizers/mod.rs
@@ -229,9 +229,7 @@ pub fn clip_grad_norm(
 ) -> crate::error::Result<(MaybeClippedGrads, f32)> {
     let total_norm: f32 = gradients
         .values()
-        .try_fold(array!(0.0), |acc, grad| {
-            acc.add(&grad.square()?.sum(None, None)?)
-        })?
+        .try_fold(array!(0.0), |acc, grad| acc.add(&grad.square()?.sum(None)?))?
         .sqrt()?
         .item();
     let normalizer = array!(max_norm / (total_norm + 1e-6));
@@ -285,7 +283,7 @@ mod tests {
         let clipped_values: Vec<_> = clipped_grads.values().map(|v| v.as_ref()).collect();
         let norm_of_clipped = clipped_values
             .into_iter()
-            .map(|g| g.square().unwrap().sum(None, None).unwrap())
+            .map(|g| g.square().unwrap().sum(None).unwrap())
             .sum::<Array>()
             .sqrt()
             .unwrap();

--- a/mlx-rs/src/optimizers/mod.rs
+++ b/mlx-rs/src/optimizers/mod.rs
@@ -45,6 +45,10 @@ pub use sgd::*;
 macro_rules! impl_updatable_for_mut_optimizer {
     ($optimizer:ty) => {
         impl Updatable for &'_ mut $optimizer {
+            fn updatable_states_len(&self) -> usize {
+                <$optimizer as Updatable>::updatable_states_len(&**self)
+            }
+
             fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
                 <$optimizer as Updatable>::updatable_states(&**self)
             }

--- a/mlx-rs/src/optimizers/mod.rs
+++ b/mlx-rs/src/optimizers/mod.rs
@@ -124,8 +124,8 @@ impl OptimizerState for State<(Array, Array)> {
 
     fn flatten(&self) -> impl Iterator<Item = (Rc<str>, &Array)> {
         self.iter().flat_map(|(k, (first, second))| {
-            let first_k: Rc<str> = Rc::from(format!("{}.0", k));
-            let second_k: Rc<str> = Rc::from(format!("{}.1", k));
+            let first_k: Rc<str> = Rc::from(format!("{k}.0"));
+            let second_k: Rc<str> = Rc::from(format!("{k}.1"));
 
             [(first_k, first), (second_k, second)]
         })
@@ -133,8 +133,8 @@ impl OptimizerState for State<(Array, Array)> {
 
     fn flatten_mut(&mut self) -> impl Iterator<Item = (Rc<str>, &mut Array)> {
         self.iter_mut().flat_map(|(k, (first, second))| {
-            let first_k: Rc<str> = Rc::from(format!("{}.0", k));
-            let second_k: Rc<str> = Rc::from(format!("{}.1", k));
+            let first_k: Rc<str> = Rc::from(format!("{k}.0"));
+            let second_k: Rc<str> = Rc::from(format!("{k}.1"));
 
             [(first_k, first), (second_k, second)]
         })

--- a/mlx-rs/src/optimizers/rmsprop.rs
+++ b/mlx-rs/src/optimizers/rmsprop.rs
@@ -112,6 +112,10 @@ impl Optimizer for RmsProp {
 }
 
 impl Updatable for RmsProp {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/optimizers/sgd.rs
+++ b/mlx-rs/src/optimizers/sgd.rs
@@ -134,6 +134,10 @@ impl Optimizer for Sgd {
 }
 
 impl Updatable for Sgd {
+    fn updatable_states_len(&self) -> usize {
+        self.state.len()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 

--- a/mlx-rs/src/quantization.rs
+++ b/mlx-rs/src/quantization.rs
@@ -131,6 +131,13 @@ where
     M: Quantizable + ModuleParameters,
     M::Quantized: ModuleParameters,
 {
+    fn num_parameters(&self) -> usize {
+        match self {
+            MaybeQuantized::Original(m) => m.num_parameters(),
+            MaybeQuantized::Quantized(q) => q.num_parameters(),
+        }
+    }
+
     fn parameters(&self) -> crate::module::ModuleParamRef<'_> {
         match self {
             MaybeQuantized::Original(m) => m.parameters(),

--- a/mlx-rs/src/random.rs
+++ b/mlx-rs/src/random.rs
@@ -3,7 +3,7 @@
 use crate::ops::indexing::TryIndexOp;
 use crate::utils::guard::Guarded;
 use crate::utils::IntoOption;
-use crate::{error::Result, Array, ArrayElement, Stream, StreamOrDevice};
+use crate::{error::Result, Array, ArrayElement, Stream};
 use mach_sys::mach_time;
 use mlx_internal_macros::{default_device, generate_macro};
 use parking_lot::Mutex;

--- a/mlx-rs/src/transforms/compile/compile_with_state.rs
+++ b/mlx-rs/src/transforms/compile/compile_with_state.rs
@@ -404,16 +404,17 @@ where
     })?;
 
     // number of states may change during the call
-    let mut state_mut = state.borrow_mut();
-    let state_params_mut: Vec<_> = state_mut.updatable_states_mut().into_iter().collect();
-    let state_params_len = state_params_mut.len();
+    let state_params_len = state.borrow().updatable_states_len();
 
     let result_plus_state_output: Vec<Array> = result_vector.try_into_values()?;
 
     // push the stateOutput into the state
     let result_plus_state_output_len = result_plus_state_output.len();
     let suffix_start = result_plus_state_output_len - state_params_len;
-    for (s, new_values) in state_params_mut
+  
+    for (s, new_values) in state
+        .borrow_mut()
+        .updatable_states_mut()
         .into_iter()
         .zip(result_plus_state_output[suffix_start..].iter())
     {

--- a/mlx-rs/src/transforms/compile/compile_with_state.rs
+++ b/mlx-rs/src/transforms/compile/compile_with_state.rs
@@ -411,7 +411,7 @@ where
     // push the stateOutput into the state
     let result_plus_state_output_len = result_plus_state_output.len();
     let suffix_start = result_plus_state_output_len - state_params_len;
-  
+
     for (s, new_values) in state
         .borrow_mut()
         .updatable_states_mut()

--- a/mlx-rs/src/transforms/compile/compile_with_state.rs
+++ b/mlx-rs/src/transforms/compile/compile_with_state.rs
@@ -388,16 +388,13 @@ where
         )
     })?;
 
-    let (state_params_len, inner_inputs_vector) = {
+    let inner_inputs_vector = {
         let borrow = state.borrow();
-        let state_params: Vec<_> = borrow.updatable_states().into_iter().collect();
-        let state_params_len = state_params.len();
-        let inner_inputs_vector = VectorArray::try_from_iter(
+        VectorArray::try_from_iter(
             args.iter()
                 .map(AsRef::as_ref)
-                .chain(state_params.into_iter()),
-        )?;
-        (state_params_len, inner_inputs_vector)
+                .chain(borrow.updatable_states()),
+        )?
     };
 
     // will compile the function (if needed) and evaluate the
@@ -405,16 +402,20 @@ where
     let result_vector = VectorArray::try_from_op(|res| unsafe {
         mlx_sys::mlx_closure_apply(res, compiled.as_ptr(), inner_inputs_vector.as_ptr())
     })?;
+
+    // number of states may change during the call
+    let mut state_mut = state.borrow_mut();
+    let state_params_mut: Vec<_> = state_mut.updatable_states_mut().into_iter().collect();
+    let state_params_len = state_params_mut.len();
+
     let result_plus_state_output: Vec<Array> = result_vector.try_into_values()?;
 
     // push the stateOutput into the state
     let result_plus_state_output_len = result_plus_state_output.len();
-    let suffix_len = result_plus_state_output_len - state_params_len;
-    for (s, new_values) in state
-        .borrow_mut()
-        .updatable_states_mut()
+    let suffix_start = result_plus_state_output_len - state_params_len;
+    for (s, new_values) in state_params_mut
         .into_iter()
-        .zip(result_plus_state_output[suffix_len..].iter())
+        .zip(result_plus_state_output[suffix_start..].iter())
     {
         update_by_replace_with_ref_to_new_array(s, new_values);
     }

--- a/mlx-rs/src/transforms/compile/compile_with_state.rs
+++ b/mlx-rs/src/transforms/compile/compile_with_state.rs
@@ -411,7 +411,6 @@ where
     // push the stateOutput into the state
     let result_plus_state_output_len = result_plus_state_output.len();
     let suffix_start = result_plus_state_output_len - state_params_len;
-
     for (s, new_values) in state
         .borrow_mut()
         .updatable_states_mut()

--- a/mlx-rs/src/transforms/compile/mod.rs
+++ b/mlx-rs/src/transforms/compile/mod.rs
@@ -215,6 +215,7 @@ where
 }
 
 fn update_by_replace_with_ref_to_new_array(src: &mut Array, new_array: &Array) {
+    debug_assert_eq!(src.shape(), new_array.shape());
     unsafe {
         mlx_sys::mlx_array_set(&mut src.as_ptr() as *mut _, new_array.as_ptr());
     }

--- a/mlx-rs/src/utils/io.rs
+++ b/mlx-rs/src/utils/io.rs
@@ -1,40 +1,12 @@
 use crate::error::{Exception, IoError};
 use crate::utils::SUCCESS;
 use crate::{Array, Stream};
-use mlx_sys::FILE;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::path::Path;
-use std::ptr::{null_mut, NonNull};
+use std::ptr::null_mut;
 
 use super::Guarded;
-
-pub(crate) struct FilePtr(NonNull<FILE>);
-
-impl Drop for FilePtr {
-    fn drop(&mut self) {
-        unsafe {
-            mlx_sys::fclose(self.0.as_ptr());
-        }
-    }
-}
-
-impl FilePtr {
-    pub(crate) fn as_ptr(&self) -> *mut FILE {
-        self.0.as_ptr()
-    }
-
-    pub(crate) fn open(path: &Path, mode: &str) -> Result<Self, IoError> {
-        let path = CString::new(path.to_str().ok_or(IoError::InvalidUtf8)?)?;
-        let mode = CString::new(mode)?;
-
-        unsafe {
-            NonNull::new(mlx_sys::fopen(path.as_ptr(), mode.as_ptr()))
-                .map(Self)
-                .ok_or(IoError::UnableToOpenFile)
-        }
-    }
-}
 
 pub(crate) struct SafeTensors {
     pub(crate) c_data: mlx_sys::mlx_map_string_to_array,

--- a/mlx-rs/src/utils/mod.rs
+++ b/mlx-rs/src/utils/mod.rs
@@ -378,6 +378,13 @@ pub(crate) fn get_mut_or_insert_with<'a, T>(
 ///
 /// This is automatically implemented for all types that implement ModuleParameters.
 pub trait Updatable {
+    /// Returns the number of updatable states.
+    ///
+    /// The number should be the same as calling `self.updatable_states().len()` but
+    /// this method should be more efficient in general. The implementation should
+    /// avoid iterating over the states if possible.
+    fn updatable_states_len(&self) -> usize;
+
     /// Returns a list of references to the updatable states.
     ///
     /// The order of the states should be consistent across calls and should be the same as the
@@ -395,6 +402,10 @@ impl<T> Updatable for T
 where
     T: ModuleParameters,
 {
+    fn updatable_states_len(&self) -> usize {
+        self.num_parameters()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         use itertools::Itertools;
 
@@ -422,6 +433,11 @@ where
     T1: Updatable,
     T2: Updatable,
 {
+    fn updatable_states_len(&self) -> usize {
+        let (a, b) = self;
+        a.updatable_states_len() + b.updatable_states_len()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         let (a, b) = self;
         let params = a.updatable_states();
@@ -436,6 +452,10 @@ where
 }
 
 impl Updatable for Vec<Array> {
+    fn updatable_states_len(&self) -> usize {
+        self.len()
+    }
+
     fn updatable_states(&self) -> impl IntoIterator<Item = &Array> {
         self.iter()
     }

--- a/mlx-rs/src/utils/mod.rs
+++ b/mlx-rs/src/utils/mod.rs
@@ -52,6 +52,10 @@ impl VectorArray {
         self.c_vec
     }
 
+    pub(crate) unsafe fn from_ptr(c_vec: mlx_sys::mlx_vector_array) -> Self {
+        Self { c_vec }
+    }
+
     pub(crate) fn try_from_iter(
         iter: impl Iterator<Item = impl AsRef<Array>>,
     ) -> Result<Self, Exception> {

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-sys"
-version = "0.2.0-alpha.2" # mlx-sys version should follow that of mlx-c
+version = "0.2.0" # mlx-sys version should follow that of mlx-c
 authors.workspace = true
 edition.workspace = true
 

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-sys"
-version = "0.1.2-release" # mlx-sys version should follow that of mlx-c
+version = "0.2.0-alpha" # mlx-sys version should follow that of mlx-c
 authors.workspace = true
 edition.workspace = true
 

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-sys"
-version = "0.2.0-alpha" # mlx-sys version should follow that of mlx-c
+version = "0.2.0-alpha.1" # mlx-sys version should follow that of mlx-c
 authors.workspace = true
 edition.workspace = true
 

--- a/mlx-sys/Cargo.toml
+++ b/mlx-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlx-sys"
-version = "0.2.0-alpha.1" # mlx-sys version should follow that of mlx-c
+version = "0.2.0-alpha.2" # mlx-sys version should follow that of mlx-c
 authors.workspace = true
 edition.workspace = true
 

--- a/mlx-sys/examples/is_metal_available.rs
+++ b/mlx-sys/examples/is_metal_available.rs
@@ -2,5 +2,5 @@ fn main() {
     let mut is_available = false;
     let status = unsafe { mlx_sys::mlx_metal_is_available(&mut is_available as *mut bool) };
     assert_eq!(status, 0);
-    println!("{:?}", is_available);
+    println!("{is_available:?}");
 }

--- a/mlx-tests/tests/test_compile_with_state.rs
+++ b/mlx-tests/tests/test_compile_with_state.rs
@@ -43,42 +43,111 @@ fn test_compile_module() {
     assert_eq!(&original, &result);
 }
 
-#[test]
-fn test_compile_module_and_optimizer() {
+fn compile_module_and_optimizer<O: Optimizer>(optimizer: O) -> (Array, Array) {
     let loss = |model: &mut LinearFunctionModel, x: &Array| -> Array {
         let y = model.forward(x).unwrap();
         y.square().unwrap().sum(None).unwrap()
     };
     let model = LinearFunctionModel::new(None).unwrap();
-    // Use a learning rate of 0.0 so that the parameters don't change
-    // and we can check that the compiled function produces the same result
-    let optimizer = Sgd::new(0.0);
 
     let x = ones::<f32>(&[10, 1]).unwrap();
-    let x = vec![x];
 
-    let step =
-        move |(model, optimizer): &mut (LinearFunctionModel, Sgd), x: &[Array]| -> Vec<Array> {
-            let mut lg = nn::value_and_grad(loss);
-            let x = &x[0];
-            let (loss, grad) = lg(model, x).unwrap();
-            optimizer.update(model, grad).unwrap();
-            vec![loss]
-        };
+    let step = move |(model, optimizer): &mut (LinearFunctionModel, O), x: &Array| -> Array {
+        let mut lg = nn::value_and_grad(loss);
+        let (loss, grad) = lg(model, x).unwrap();
+        optimizer.update(model, grad).unwrap();
+        loss
+    };
 
     let mut state = (model, optimizer);
     let mut compiled = compile_with_state(step, None);
 
-    // Check that the original function works
-    let original = step(&mut state, x.as_slice());
+    let original = step(&mut state, &x);
+    let result = compiled(&mut state, &x).unwrap();
 
-    // Make sure the compiled function produces the same result
-    let result = compiled(&mut state, x.as_slice()).unwrap();
-    assert_array_eq!(&original[0], &result[0]);
-    eval_params(state.0.parameters()).unwrap();
-    let result = compiled(&mut state, x.as_slice()).unwrap();
-    assert_array_eq!(&original[0], &result[0]);
-    eval_params(state.0.parameters()).unwrap();
+    (original, result)
+}
+
+/// A simple sanity check for adafactor optimizer
+#[test]
+fn test_compile_module_and_adafactor_works() {
+    let optimizer = mlx_rs::optimizers::Adafactor::new().unwrap();
+    let (original, result) = compile_module_and_optimizer(optimizer);
+
+    assert_eq!(original.shape(), result.shape());
+    assert_eq!(original.dtype(), result.dtype());
+}
+
+#[test]
+fn test_compile_module_and_sgd_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = Sgd::new(0.0);
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
+}
+
+#[test]
+fn test_compile_module_and_adam_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = mlx_rs::optimizers::Adam::new(0.0);
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
+}
+
+#[test]
+fn test_compile_module_and_rmsprop_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = mlx_rs::optimizers::RmsProp::new(0.0).unwrap();
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
+}
+
+#[test]
+fn test_compile_module_and_adagrad_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = mlx_rs::optimizers::AdaGrad::new(0.0);
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
+}
+
+#[test]
+fn test_compile_module_and_adadelta_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = mlx_rs::optimizers::AdaDelta::new(0.0).unwrap();
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
+}
+
+#[test]
+fn test_compile_module_and_adamw_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = mlx_rs::optimizers::AdamW::new(0.0);
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
+}
+
+#[test]
+fn test_compile_module_and_adamax_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = mlx_rs::optimizers::Adamax::new(0.0);
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
+}
+
+#[test]
+fn test_compile_module_and_lion_consistency() {
+    // Use a learning rate of 0.0 so that the parameters don't change
+    // and we can check that the compiled function produces the same result
+    let optimizer = mlx_rs::optimizers::Lion::new(0.0);
+    let (original, result) = compile_module_and_optimizer(optimizer);
+    assert_array_eq!(&original, &result);
 }
 
 #[test]

--- a/mlx-tests/tests/test_compile_with_state.rs
+++ b/mlx-tests/tests/test_compile_with_state.rs
@@ -18,7 +18,7 @@ use mlx_rs::{
 fn test_compile_module() {
     let loss = |model: &mut LinearFunctionModel, x: &Array| -> Array {
         let y = model.forward(x).unwrap();
-        y.square().unwrap().sum(None, None).unwrap()
+        y.square().unwrap().sum(None).unwrap()
     };
     let mut model = LinearFunctionModel::new(None).unwrap();
 
@@ -47,7 +47,7 @@ fn test_compile_module() {
 fn test_compile_module_and_optimizer() {
     let loss = |model: &mut LinearFunctionModel, x: &Array| -> Array {
         let y = model.forward(x).unwrap();
-        y.square().unwrap().sum(None, None).unwrap()
+        y.square().unwrap().sum(None).unwrap()
     };
     let model = LinearFunctionModel::new(None).unwrap();
     // Use a learning rate of 0.0 so that the parameters don't change
@@ -85,7 +85,7 @@ fn test_compile_module_and_optimizer() {
 fn test_compile_module_with_error() {
     let loss = |model: &mut LinearFunctionModel, x: &Array| -> Result<Array, Exception> {
         let y = model.forward(x)?;
-        y.square()?.sum(None, None)
+        y.square()?.sum(None)
     };
     let mut model = LinearFunctionModel::new(&[10]).unwrap();
 
@@ -130,7 +130,7 @@ fn test_compile_module_with_error() {
 fn test_compile_module_and_optimizer_with_error() {
     let loss = |model: &mut LinearFunctionModel, x: &Array| -> Result<Array, Exception> {
         let y = model.forward(x)?;
-        y.square()?.sum(None, None)
+        y.square()?.sum(None)
     };
     let model = LinearFunctionModel::new(&[10]).unwrap();
     // Use a learning rate of 0.0 so that the parameters don't change

--- a/mlx-tests/tests/test_disable_compile.rs
+++ b/mlx-tests/tests/test_disable_compile.rs
@@ -1,0 +1,30 @@
+use mlx_rs::{
+    array,
+    error::Exception,
+    exp, negative,
+    transforms::compile::{compile, disable_compile, enable_compile},
+    Array,
+};
+
+#[test]
+fn test_disable_compile() {
+    disable_compile();
+
+    let f = |x: &Array| -> Result<Array, Exception> {
+        let z = negative!(x)?;
+
+        // this will crash is compile is enabled
+        println!("{:?}", z);
+
+        exp!(z)
+    };
+
+    let x = array!(10.0);
+    let mut compiled = compile(f, None);
+
+    // This will panic if compilation is enabled
+    let _result = compiled(&x).unwrap();
+
+    // Re-enable compilation for other tests
+    enable_compile();
+}

--- a/mlx-tests/tests/test_disable_compile.rs
+++ b/mlx-tests/tests/test_disable_compile.rs
@@ -14,7 +14,7 @@ fn test_disable_compile() {
         let z = negative!(x)?;
 
         // this will crash is compile is enabled
-        println!("{:?}", z);
+        println!("{z:?}");
 
         exp!(z)
     };

--- a/mlx-tests/tests/test_exported_macros.rs
+++ b/mlx-tests/tests/test_exported_macros.rs
@@ -43,8 +43,9 @@ fn test_ops_arithmetic_add() {
 fn test_ops_arithmetic_tensordot() {
     let x = reshape(arange::<_, f32>(None, 60.0, None).unwrap(), &[3, 4, 5]).unwrap();
     let y = reshape(arange::<_, f32>(None, 24.0, None).unwrap(), &[4, 3, 2]).unwrap();
-    let axes = (&[1, 0], &[0, 1]);
-    let z = mlx_rs::tensordot!(&x, &y, axes = axes).unwrap();
+    let axes_x = [1, 0];
+    let axes_y = [0, 1];
+    let z = mlx_rs::tensordot_axes!(&x, &y, &axes_x, &axes_y).unwrap();
     let expected = Array::from_slice(
         &[4400, 4730, 4532, 4874, 4664, 5018, 4796, 5162, 4928, 5306],
         &[5, 2],
@@ -52,7 +53,7 @@ fn test_ops_arithmetic_tensordot() {
     assert_eq!(z, expected);
 
     let stream = StreamOrDevice::cpu();
-    let z = mlx_rs::tensordot!(x, y, axes = axes, stream = stream).unwrap();
+    let z = mlx_rs::tensordot_axes!(&x, &y, &axes_x, &axes_y, stream = stream).unwrap();
     assert_eq!(z, expected);
 }
 
@@ -136,7 +137,7 @@ fn test_fft_fft() {
 #[test]
 fn test_linalg_norm() {
     let a = array!([1.0, 2.0, 3.0, 4.0]).reshape(&[2, 2]).unwrap();
-    let norm = mlx_rs::norm!(&a).unwrap();
+    let norm = mlx_rs::norm_l2!(&a).unwrap();
     assert_eq!(norm.item::<f32>(), 5.477_226);
 }
 

--- a/mlx-tests/tests/test_generate_macro.rs
+++ b/mlx-tests/tests/test_generate_macro.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables)]
 
 use mlx_internal_macros::{default_device, generate_macro};
-use mlx_rs::{Stream, StreamOrDevice};
+use mlx_rs::Stream;
 
 // Test generate_macro for functions with no generic type arguments.
 #[generate_macro(customize(root = "$crate"))]

--- a/mlx-tests/tests/test_module.rs
+++ b/mlx-tests/tests/test_module.rs
@@ -30,5 +30,5 @@ fn test_nested_module() {
     let mut m = M::new();
     let x = mlx_rs::random::uniform::<_, f32>(1.0, 2.0, &[1, 5], None).unwrap();
     let y = m.forward(&x).unwrap();
-    assert_ne!(y.sum(None, None).unwrap(), mlx_rs::array!(0.0));
+    assert_ne!(y.sum(None).unwrap(), mlx_rs::array!(0.0));
 }

--- a/mlx-tests/tests/test_module_parameters.rs
+++ b/mlx-tests/tests/test_module_parameters.rs
@@ -29,7 +29,26 @@ struct NestedStructModule {
     nested: StructModule,
 
     #[param]
-    neste_no_param: UnitStructModule,
+    nested_no_param: UnitStructModule,
+}
+
+#[test]
+fn test_module_num_parameters() {
+    let m = StructModule {
+        a: Param::new(array!(1.0)),
+        b: Param::new(array!(2.0)),
+        c: Param::new(None),
+    };
+
+    assert_eq!(m.num_parameters(), 2);
+
+    let m = StructModule {
+        a: Param::new(array!(1.0)),
+        b: Param::new(array!(2.0)),
+        c: Param::new(Some(array!(3.0))),
+    };
+
+    assert_eq!(m.num_parameters(), 3);
 }
 
 #[test]
@@ -159,6 +178,13 @@ fn test_module_trainable_parameters_partial_freeze() {
 }
 
 #[test]
+fn test_unit_struct_module_num_parameters() {
+    let m = UnitStructModule;
+
+    assert_eq!(m.num_parameters(), 0);
+}
+
+#[test]
 fn test_unit_struct_module_parameters() {
     let m = UnitStructModule;
 
@@ -203,6 +229,31 @@ fn test_unit_struct_module_unfreeze_parameters() {
 }
 
 #[test]
+fn test_nested_module_num_parameters() {
+    let m = NestedStructModule {
+        a: Param::new(array!(1.0)),
+        nested: StructModule {
+            a: Param::new(array!(2.0)),
+            b: Param::new(array!(3.0)),
+            c: Param::new(None),
+        },
+        nested_no_param: UnitStructModule,
+    };
+    assert_eq!(m.num_parameters(), 3);
+
+    let m = NestedStructModule {
+        a: Param::new(array!(1.0)),
+        nested: StructModule {
+            a: Param::new(array!(2.0)),
+            b: Param::new(array!(3.0)),
+            c: Param::new(Some(array!(4.0))),
+        },
+        nested_no_param: UnitStructModule,
+    };
+    assert_eq!(m.num_parameters(), 4);
+}
+
+#[test]
 fn test_nested_module_parameters() {
     let m = NestedStructModule {
         a: Param::new(array!(1.0)),
@@ -211,7 +262,7 @@ fn test_nested_module_parameters() {
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
-        neste_no_param: UnitStructModule,
+        nested_no_param: UnitStructModule,
     };
 
     let flattened = m.parameters().flatten();
@@ -230,7 +281,7 @@ fn test_nested_module_parameters_mut() {
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
-        neste_no_param: UnitStructModule,
+        nested_no_param: UnitStructModule,
     };
 
     let flattened = m.parameters_mut().flatten();
@@ -249,7 +300,7 @@ fn test_nested_module_recursive_freeze() {
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
-        neste_no_param: UnitStructModule,
+        nested_no_param: UnitStructModule,
     };
 
     m.freeze_parameters(true);
@@ -268,7 +319,7 @@ fn test_nested_module_freeze_submodule() {
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
-        neste_no_param: UnitStructModule,
+        nested_no_param: UnitStructModule,
     };
 
     m.nested.freeze_parameters(true);
@@ -290,7 +341,7 @@ fn test_nested_module_unfreeze_submodule() {
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
-        neste_no_param: UnitStructModule,
+        nested_no_param: UnitStructModule,
     };
 
     m.nested.freeze_parameters(true);
@@ -314,7 +365,7 @@ fn test_nested_module_recursive_unfreeze() {
             b: Param::new(array!(3.0)),
             c: Param::new(None),
         },
-        neste_no_param: UnitStructModule,
+        nested_no_param: UnitStructModule,
     };
 
     m.freeze_parameters(true);

--- a/mlx-tests/tests/test_optimizers.rs
+++ b/mlx-tests/tests/test_optimizers.rs
@@ -88,7 +88,7 @@ fn test_sgd_converges() {
     // It sometimes doesn't converge that fast, so we take the average loss
     // across multiple trials
     let avg_loss = total_loss / NUM_TRIALS as f32;
-    assert!(avg_loss < 0.1, "avg loss: {}", avg_loss);
+    assert!(avg_loss < 0.1, "avg loss: {avg_loss}");
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn test_rmsprop_converges() {
     // It sometimes doesn't converge that fast, so we take the average loss
     // across multiple trials
     let avg_loss = total_loss / NUM_TRIALS as f32;
-    assert!(avg_loss < 0.1, "avg loss: {}", avg_loss);
+    assert!(avg_loss < 0.1, "avg loss: {avg_loss}");
 }
 
 /* -------------------------------------------------------------------------- */

--- a/mlx-tests/tests/test_optimizers.rs
+++ b/mlx-tests/tests/test_optimizers.rs
@@ -192,12 +192,12 @@ fn test_ada_delta() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), mlx_rs::Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(-0.348_337_02),
         0.006966740489006043
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(-4.180_044),
         0.08360088348388672
     );
@@ -206,12 +206,12 @@ fn test_ada_delta() {
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), mlx_rs::Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(0.522_678_4),
         0.010453567504882813
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(6.272_14),
         0.12544280052185058
     );
@@ -229,12 +229,12 @@ fn test_ada_delta() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), mlx_rs::Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(-0.348_442_4),
         0.348442405462265
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(-4.181_308_7),
         0.08362617492675782
     );
@@ -250,14 +250,14 @@ fn test_adagrad() {
     let a = mlx_rs::random::normal::<f32>(&[4, 3], None, None, None).unwrap();
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
-    assert_array_eq!(a.mean(None, None).unwrap(), array!(-0.045_843_333), ATOL);
-    assert_array_eq!(a.sum(None, None).unwrap(), array!(-0.550_12), ATOL);
+    assert_array_eq!(a.mean(None).unwrap(), array!(-0.045_843_333), ATOL);
+    assert_array_eq!(a.sum(None).unwrap(), array!(-0.550_12), ATOL);
 
     let a_grad = mlx_rs::random::normal::<f32>(&[4, 3], None, None, None).unwrap();
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
-    assert_array_eq!(a_grad.mean(None, None).unwrap(), array!(0.232_503_94), ATOL);
-    assert_array_eq!(a_grad.sum(None, None).unwrap(), array!(2.790_047_2), ATOL);
+    assert_array_eq!(a_grad.mean(None).unwrap(), array!(0.232_503_94), ATOL);
+    assert_array_eq!(a_grad.sum(None).unwrap(), array!(2.790_047_2), ATOL);
 
     let mut a_model = SimpleModel {
         a: Param::new(a.clone()),
@@ -270,16 +270,8 @@ fn test_adagrad() {
     optimizer.update(&mut a_model, a_grad_params).unwrap();
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
-    assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
-        array!(-0.062_509_984),
-        ATOL
-    );
-    assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
-        array!(-0.750_119_8),
-        ATOL
-    );
+    assert_array_eq!(a_model.a.mean(None).unwrap(), array!(-0.062_509_984), ATOL);
+    assert_array_eq!(a_model.a.sum(None).unwrap(), array!(-0.750_119_8), ATOL);
 
     assert_save_and_load(optimizer, AdaGrad::new(0.1)).unwrap();
 }
@@ -293,12 +285,12 @@ fn test_adam() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(0.112_293_06),
         0.002245861142873764
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(1.347_516_7),
         0.02695033311843872
     );
@@ -307,12 +299,12 @@ fn test_adam() {
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(0.305_597_72),
         0.0061119544506073
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(3.667_172_7),
         0.0733434534072876
     );
@@ -329,12 +321,12 @@ fn test_adam() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(0.112_292_78),
         0.0022458556294441224
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(1.347_513_3),
         0.026950266361236572
     );
@@ -351,12 +343,12 @@ fn test_adamw() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(-0.363_391_88),
         0.007267837524414063
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(-4.360_702_5),
         0.08721405029296875
     );
@@ -365,12 +357,12 @@ fn test_adamw() {
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(0.221_754_48),
         0.0044350895285606385
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(2.661_053_7),
         0.05322107315063477
     );
@@ -387,12 +379,12 @@ fn test_adamw() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(-0.468_437_6),
         0.009368752241134645
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(-5.621_251),
         0.11242502212524415
     );
@@ -409,12 +401,12 @@ fn test_adamax() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(-0.303_923_6),
         0.006078472137451172
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(-3.647_083_3),
         0.07294166564941407
     );
@@ -423,12 +415,12 @@ fn test_adamax() {
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(-0.242_717_24),
         0.004854344725608826
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(-2.912_606_7),
         0.05825213432312012
     );
@@ -445,12 +437,12 @@ fn test_adamax() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(-0.303_923_6),
         0.006078472137451172
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(-3.647_083_3),
         0.07294166564941407
     );
@@ -544,12 +536,12 @@ fn test_lion() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(0.177_692_23),
         0.003553844690322876
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(2.132_306_8),
         0.042646136283874515
     );
@@ -558,12 +550,12 @@ fn test_lion() {
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(-0.021_187_237),
         0.00042374473065137863
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(-0.254_246_83),
         0.005084936618804932
     );
@@ -580,12 +572,12 @@ fn test_lion() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(0.211_025_57),
         0.004220511317253113
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(2.532_306_7),
         0.05064613342285156
     );
@@ -602,12 +594,12 @@ fn test_lion1() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(-0.184_610_6),
         0.0036922121047973633
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(-2.215_327_3),
         0.04430654525756836
     );
@@ -616,12 +608,12 @@ fn test_lion1() {
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(-0.036_004_007),
         0.0007200801372528076
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(-0.432_048_08),
         0.008640961647033691
     );
@@ -638,12 +630,12 @@ fn test_lion1() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(-0.182_764_5),
         0.003655290007591248
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(-2.193_174),
         0.04386347770690918
     );
@@ -662,12 +654,12 @@ fn test_adafactor() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(-0.520_713_7),
         0.010414273738861083
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(-6.248_564),
         0.12497127532958985
     );
@@ -676,12 +668,12 @@ fn test_adafactor() {
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(0.433_303_65),
         0.008666073083877564
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(5.199_643_6),
         0.10399287223815919
     );
@@ -698,16 +690,16 @@ fn test_adafactor() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     println!(
-        "a_model.a.mean(None, None).unwrap(): {:?}",
-        a_model.a.mean(None, None).unwrap()
+        "a_model.a.mean(None).unwrap(): {:?}",
+        a_model.a.mean(None).unwrap()
     );
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(-0.526_828_47),
         0.010536569356918336
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(-6.321_941_4),
         0.12643882751464844
     );
@@ -722,26 +714,22 @@ fn test_adafactor1() {
     assert_eq!(a.shape(), &[4, 3]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(0.400_818_17),
         0.008016363382339478
     );
-    assert_array_eq!(
-        a.sum(None, None).unwrap(),
-        array!(4.809_818),
-        0.09619635581970215
-    );
+    assert_array_eq!(a.sum(None).unwrap(), array!(4.809_818), 0.09619635581970215);
 
     let a_grad = mlx_rs::random::normal::<f32>(&[4, 3], None, None, None).unwrap();
     assert_eq!(a_grad.shape(), &[4, 3]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(0.214_474_72),
         0.004289494454860688
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(2.573_696_6),
         0.05147393226623535
     );
@@ -758,12 +746,12 @@ fn test_adafactor1() {
     assert_eq!(a_model.a.shape(), &[4, 3]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(0.399_430_7),
         0.007988613843917847
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(4.793_168),
         0.09586336135864258
     );
@@ -776,12 +764,12 @@ fn test_adafactor2() {
     assert_eq!(a.shape(), &[10]);
     assert_eq!(a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a.mean(None, None).unwrap(),
+        a.mean(None).unwrap(),
         array!(0.489_024_55),
         0.00978049099445343
     );
     assert_array_eq!(
-        a.sum(None, None).unwrap(),
+        a.sum(None).unwrap(),
         array!(4.890_245_4),
         0.09780490875244141
     );
@@ -790,12 +778,12 @@ fn test_adafactor2() {
     assert_eq!(a_grad.shape(), &[10]);
     assert_eq!(a_grad.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_grad.mean(None, None).unwrap(),
+        a_grad.mean(None).unwrap(),
         array!(0.681_890_2),
         0.013637803792953491
     );
     assert_array_eq!(
-        a_grad.sum(None, None).unwrap(),
+        a_grad.sum(None).unwrap(),
         array!(6.818_902),
         0.1363780403137207
     );
@@ -812,12 +800,12 @@ fn test_adafactor2() {
     assert_eq!(a_model.a.shape(), &[10]);
     assert_eq!(a_model.a.dtype(), Dtype::Float32);
     assert_array_eq!(
-        a_model.a.mean(None, None).unwrap(),
+        a_model.a.mean(None).unwrap(),
         array!(0.483_533_05),
         0.009670661091804504
     );
     assert_array_eq!(
-        a_model.a.sum(None, None).unwrap(),
+        a_model.a.sum(None).unwrap(),
         array!(4.835_330_5),
         0.09670660972595214
     );


### PR DESCRIPTION
This commit improves support on complex arrays by including `mlx_real` & `mlx_imag` functions that is implemented in `mlx-c` library.

```rust
let array = Array::from_complex64(complex::new(0.0, 1.0));

// array.real() now should return array(0, dtype=float32)
// array.imag() now should return array(1, dtype=float32)
```