### PR TITLE
Prevent premature destructuring of closures & Add atan2

### DIFF
--- a/mlx-rs/src/ops/arithmetic.rs
+++ b/mlx-rs/src/ops/arithmetic.rs
@@ -742,6 +742,22 @@ pub fn atan_device(a: impl AsRef<Array>, #[optional] stream: impl AsRef<Stream>)
     })
 }
 
+/// Element-wise inverse tangent of b/a choosing the quadrant correctly.
+#[generate_macro]
+#[default_device]
+pub fn atan2_device(
+    a: impl AsRef<Array>,
+    b: impl AsRef<Array>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    let a = a.as_ref();
+    let b = b.as_ref();
+
+    Array::try_from_op(|res| unsafe {
+        mlx_sys::mlx_arctan2(res, a.as_ptr(), b.as_ptr(), stream.as_ref().as_ptr())
+    })
+}
+
 /// Element-wise inverse hyperbolic tangent.
 #[generate_macro]
 #[default_device]

--- a/mlx-rs/src/utils/mod.rs
+++ b/mlx-rs/src/utils/mod.rs
@@ -256,7 +256,11 @@ where
     let payload = raw as *mut std::ffi::c_void;
 
     unsafe {
-        mlx_sys::mlx_closure_new_func_payload(Some(trampoline::<F>), payload, Some(noop_dtor))
+        mlx_sys::mlx_closure_new_func_payload(
+            Some(trampoline::<F>),
+            payload,
+            Some(closure_dtor::<F>),
+        )        
     }
 }
 
@@ -272,7 +276,7 @@ where
         mlx_sys::mlx_closure_new_func_payload(
             Some(trampoline_fallible::<F>),
             payload,
-            Some(noop_dtor),
+            Some(closure_dtor::<F>),
         )
     }
 }
@@ -315,10 +319,13 @@ where
         let arrays = match mlx_vector_array_values(vector_array) {
             Ok(arrays) => arrays,
             Err(_) => {
+                let _ = Box::into_raw(closure); // prevent premature drop
                 return FAILURE;
             }
         };
         let result = closure(&arrays);
+        let _ = Box::into_raw(closure); // prevent premature drop
+
         // We should probably keep using new_mlx_vector_array here instead of VectorArray
         // since we probably don't want to drop the arrays in the closure
         *ret = new_mlx_vector_array(result);
@@ -341,11 +348,14 @@ where
         let arrays = match mlx_vector_array_values(vector_array) {
             Ok(arrays) => arrays,
             Err(e) => {
+                let _ = Box::into_raw(closure); // prevent premature drop
                 set_closure_error(e);
                 return FAILURE;
             }
         };
         let result = closure(&arrays);
+        let _ = Box::into_raw(closure); // prevent premature drop
+
         match result {
             Ok(result) => {
                 *ret = new_mlx_vector_array(result);
@@ -359,7 +369,16 @@ where
     }
 }
 
-extern "C" fn noop_dtor(_data: *mut std::ffi::c_void) {}
+// extern "C" fn noop_dtor(_data: *mut std::ffi::c_void) {}
+
+extern "C" fn closure_dtor<F>(payload: *mut std::ffi::c_void) {
+    if payload.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(payload as *mut F));
+    }
+}
 
 pub(crate) fn get_mut_or_insert_with<'a, T>(
     map: &'a mut HashMap<Rc<str>, T>,


### PR DESCRIPTION
The major bug I encountered for implementing complex rust closure with captures (e.g. custom metal kernel functionality) was related to using the move keyword for my custom closure and passing it to new_mlx_closure-related functions. By acquiring the mlx_closure with either two of the functions in `src/utils/mod.rs`, the implementation uses:
```rust
    let mut closure = Box::from_raw(raw_closure);
```
This closure is almost guaranteed to be dropped at the end of its scope. This behavior makes the generated mlx_closure  unsafe to be reused multiple times, because if the Rust closure holds moved variables, it is deallocated immediately, and my kernel will be lost after single run.

Therefore, I propose adding guards to prevent the premature destruction of the closure. For example:
```rust
extern "C" fn trampoline<'a, F>(
    ret: *mut mlx_vector_array,
    vector_array: mlx_vector_array,
    payload: *mut std::ffi::c_void,
) -> i32
where
    F: FnMut(&[Array]) -> Vec<Array> + 'a,
{
    unsafe {
        let raw_closure: *mut F = payload as *mut _;
        // Let the box take care of freeing the closure
        let mut closure = Box::from_raw(raw_closure);
        let arrays = match mlx_vector_array_values(vector_array) {
            Ok(arrays) => arrays,
            Err(_) => {
                let _ = Box::into_raw(closure); // prevent premature drop 
                return FAILURE;
            }
        };
        let result = closure(&arrays);
        let _ = Box::into_raw(closure); // prevent premature drop 

        // We should probably keep using new_mlx_vector_array here instead of VectorArray
        // since we probably don't want to drop the arrays in the closure
        *ret = new_mlx_vector_array(result);

        SUCCESS
    }
}
```

Additionally, I suggest adding a manual closure destructor to be called at the end of the mlx_closure's lifetime:
```rust
// extern "C" fn noop_dtor(_data: *mut std::ffi::c_void) {}

extern "C" fn closure_dtor<F>(payload: *mut std::ffi::c_void) {
    if payload.is_null() { return; }
    unsafe {
        drop(Box::from_raw(payload as *mut F));
    }
}
```

I believe this change could also relax the strict pure-function requirement for closure-related functions and compilation. I think I can make PR on FastKernel in the late next month. 