### PR TITLE
Add missing #[param] annotations to QuantizedEmbedding

### DIFF
--- a/mlx-rs/src/nn/quantized.rs
+++ b/mlx-rs/src/nn/quantized.rs
@@ -70,12 +70,15 @@ pub struct QuantizedEmbedding {
     pub bits: i32,
 
     /// Scales
+    #[param]
     pub scales: Param<Array>,
 
     /// Biases
+    #[param]
     pub biases: Param<Array>,
 
     /// Inner embedding
+    #[param]
     pub inner: Embedding,
 }
 


### PR DESCRIPTION
Because QuantizedEmbedding struct is missing `#[param]` annotation on its `scales`, `biases` and `inner` it causes `Embedding` quantization to miss these parameters entirely when loading quantized model weights.