### PR TITLE
Fix: Add missing Float64 pattern in safetensors conversion

### DIFF
--- a/mlx-rs/src/array/safetensors.rs
+++ b/mlx-rs/src/array/safetensors.rs
@@ -85,6 +85,10 @@ impl<'a> TryFrom<&'a Array> for TensorView<'a> {
                     let data = value.as_slice::<f32>();
                     cast_slice(data)
                 },
+                Dtype::Float64 => {
+                    let data = value.as_slice::<f64>();
+                    cast_slice(data)
+                },
                 Dtype::Bfloat16 => {
                     let data = value.as_slice::<half::bf16>();
                     let bits: &[u16] = transmute(data);


### PR DESCRIPTION
## Description

Fixes compilation error where the `TryFrom<&Array> for TensorView` implementation was missing a match arm for `Dtype::Float64`.

## Changes

- Added `Dtype::Float64` case in `mlx-rs/src/array/safetensors.rs` match statement
- Handles `f64` arrays in safetensors conversion using `cast_slice`

## Testing

- [x] Code compiles with `cargo check --features safetensors`
- [x] Follows same pattern as existing Float32 case

## Fixes

Closes #294

## Impact

This enables compilation of mlx-rs with the `safetensors` feature, which is critical for loading HuggingFace models.

## Checklist

- [x] Code compiles without errors
- [x] Follows existing code patterns
- [x] Minimal change to fix the issue