### PR TITLE
Add safe trim support to ConcatKeyValueCache

### DIFF
--- a/mlx-lm/src/cache.rs
+++ b/mlx-lm/src/cache.rs
@@ -1,4 +1,9 @@
-use mlx_rs::{error::Exception, ops::concatenate_axis, Array};
+use mlx_rs::{
+    error::Exception,
+    ops::{concatenate_axis, indexing::IndexOp},
+    transforms::eval,
+    Array,
+};
 
 // TODO: somehow move quantized methods to a separate trait?
 pub trait KeyValueCache {
@@ -68,6 +73,50 @@ impl ConcatKeyValueCache {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn trim_to(&mut self, token_count: i32) -> Result<(), Exception> {
+        let token_count = token_count.max(0);
+        match (&self.keys, &self.values) {
+            (Some(keys), Some(values)) => {
+                let current = keys.shape()[keys.shape().len() - 2];
+                if token_count >= current {
+                    self.offset = current;
+                    return Ok(());
+                }
+
+                let trimmed_keys = slice_kv_prefix(keys, token_count)?;
+                let trimmed_values = slice_kv_prefix(values, token_count)?;
+                eval([&trimmed_keys, &trimmed_values])?;
+                let trimmed_keys = trimmed_keys.deep_clone();
+                let trimmed_values = trimmed_values.deep_clone();
+
+                self.keys = Some(trimmed_keys);
+                self.values = Some(trimmed_values);
+                self.offset = token_count;
+                Ok(())
+            }
+            _ => {
+                self.offset = 0;
+                Ok(())
+            }
+        }
+    }
+
+    pub fn trimmed_to(&self, token_count: i32) -> Result<Self, Exception> {
+        let mut clone = self.clone();
+        clone.trim_to(token_count)?;
+        Ok(clone)
+    }
+}
+
+fn slice_kv_prefix(array: &Array, token_count: i32) -> Result<Array, Exception> {
+    match array.shape().len() {
+        4 => Ok(array.index((.., .., ..token_count, ..))),
+        3 => Ok(array.index((.., ..token_count, ..))),
+        other => Err(Exception::custom(format!(
+            "unsupported KV cache rank {other} for prefix trim"
+        ))),
+    }
 }
 
 impl KeyValueCache for ConcatKeyValueCache {
@@ -106,3 +155,82 @@ impl KeyValueCache for ConcatKeyValueCache {
 
 /// TODO: A generic KV Cache
 pub struct DefaultKeyValueCache {}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConcatKeyValueCache, KeyValueCache};
+    use mlx_rs::Array;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn test_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("cache test lock poisoned")
+    }
+
+    #[test]
+    fn trimmed_cache_keeps_prefix_and_offset() {
+        let _guard = test_guard();
+        let mut cache = ConcatKeyValueCache::new();
+        let keys = Array::from_slice(&[1f32, 2., 3., 4., 5., 6.], &[1, 1, 3, 2]);
+        let values = Array::from_slice(&[7f32, 8., 9., 10., 11., 12.], &[1, 1, 3, 2]);
+        let _ = cache.update_and_fetch(keys, values).expect("seed cache");
+
+        let trimmed = cache.trimmed_to(2).expect("trimmed clone");
+        assert_eq!(trimmed.offset(), 2);
+
+        let mut trimmed = trimmed;
+        let append_keys = Array::from_slice(&[13f32, 14.], &[1, 1, 1, 2]);
+        let append_values = Array::from_slice(&[15f32, 16.], &[1, 1, 1, 2]);
+        let (keys, values) = trimmed
+            .update_and_fetch(append_keys, append_values)
+            .expect("append after trim");
+
+        assert_eq!(keys.shape(), &[1, 1, 3, 2]);
+        assert_eq!(values.shape(), &[1, 1, 3, 2]);
+        assert_eq!(keys.as_slice::<f32>(), &[1., 2., 3., 4., 13., 14.]);
+        assert_eq!(values.as_slice::<f32>(), &[7., 8., 9., 10., 15., 16.]);
+    }
+
+    #[test]
+    fn trim_to_larger_offset_is_noop() {
+        let _guard = test_guard();
+        let mut cache = ConcatKeyValueCache::new();
+        let keys = Array::from_slice(&[1f32, 2., 3., 4.], &[1, 1, 2, 2]);
+        let values = Array::from_slice(&[5f32, 6., 7., 8.], &[1, 1, 2, 2]);
+        let _ = cache.update_and_fetch(keys, values).expect("seed cache");
+
+        cache.trim_to(8).expect("trim beyond end");
+        assert_eq!(cache.offset(), 2);
+    }
+
+    #[test]
+    fn trimmed_to_does_not_mutate_original_cache() {
+        let _guard = test_guard();
+        let mut cache = ConcatKeyValueCache::new();
+        let keys = Array::from_slice(&[1f32, 2., 3., 4., 5., 6.], &[1, 1, 3, 2]);
+        let values = Array::from_slice(&[7f32, 8., 9., 10., 11., 12.], &[1, 1, 3, 2]);
+        let _ = cache.update_and_fetch(keys, values).expect("seed cache");
+
+        let trimmed = cache.trimmed_to(2).expect("trimmed clone");
+
+        assert_eq!(cache.offset(), 3);
+        assert_eq!(trimmed.offset(), 2);
+
+        let mut original = cache;
+        let mut trimmed = trimmed;
+        let append_keys = Array::from_slice(&[13f32, 14.], &[1, 1, 1, 2]);
+        let append_values = Array::from_slice(&[15f32, 16.], &[1, 1, 1, 2]);
+
+        let (original_keys, _) = original
+            .update_and_fetch(append_keys.deep_clone(), append_values.deep_clone())
+            .expect("append original");
+        let (trimmed_keys, _) = trimmed
+            .update_and_fetch(append_keys, append_values)
+            .expect("append trimmed");
+
+        assert_eq!(original_keys.as_slice::<f32>(), &[1., 2., 3., 4., 5., 6., 13., 14.]);
+        assert_eq!(trimmed_keys.as_slice::<f32>(), &[1., 2., 3., 4., 13., 14.]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `trim_to()` and `trimmed_to()` to `ConcatKeyValueCache`
- keep the implementation scoped to the existing append-only cache type
- add cache tests for trim, append-after-trim, and non-mutating `trimmed_to()` behavior
- serialize the cache tests internally so they run reliably on MLX/Metal

## Why
`ConcatKeyValueCache` currently only supports append. Downstream consumers that want to reuse a shared prompt prefix can detect the overlap, but they cannot safely trim back to an intermediate KV state and continue decoding from there.

This change adds a focused cache primitive for that use case without changing model code or introducing a broader cache abstraction.

## Validation
- `cargo test -p mlx-lm cache::tests -- --nocapture`

Downstream local validation in `mesh-llm` after wiring this patch into the MLX worker:
- real Llama chat-prefix smoke reused a shared 220-token prefix safely
- clean cache-only benchmark on `Llama-3.2-1B-Instruct-bf16` improved the MLX cache-sensitive cases:
  - `cache-base`: `ttft 291.8 ms -> 285.4 ms`, `total 6441.5 ms -> 4216.4 ms`
  - `cache-extend`: `ttft 280.4 ms -> 185.2 ms`, `total 5926.2 ms -> 4044.6 ms`

## Notes
- the trim implementation materializes the sliced prefix before `deep_clone()` to avoid the crash seen with cloning an unevaluated slice directly
- this PR only adds the cache primitive and tests; consumer-side prefix-reuse logic stays downstream
