### PR TITLE
Add qwen2 model support

### DIFF
--- a/mlx-lm/src/cache.rs
+++ b/mlx-lm/src/cache.rs
@@ -1,4 +1,9 @@
-use mlx_rs::{error::Exception, ops::concatenate_axis, Array};
+use mlx_rs::{
+    error::Exception,
+    ops::{concatenate_axis, indexing::IndexOp},
+    transforms::eval,
+    Array,
+};
 
 // TODO: somehow move quantized methods to a separate trait?
 pub trait KeyValueCache {
@@ -68,6 +73,50 @@ impl ConcatKeyValueCache {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn trim_to(&mut self, token_count: i32) -> Result<(), Exception> {
+        let token_count = token_count.max(0);
+        match (&self.keys, &self.values) {
+            (Some(keys), Some(values)) => {
+                let current = keys.shape()[keys.shape().len() - 2];
+                if token_count >= current {
+                    self.offset = current;
+                    return Ok(());
+                }
+
+                let trimmed_keys = slice_kv_prefix(keys, token_count)?;
+                let trimmed_values = slice_kv_prefix(values, token_count)?;
+                eval([&trimmed_keys, &trimmed_values])?;
+                let trimmed_keys = trimmed_keys.deep_clone();
+                let trimmed_values = trimmed_values.deep_clone();
+
+                self.keys = Some(trimmed_keys);
+                self.values = Some(trimmed_values);
+                self.offset = token_count;
+                Ok(())
+            }
+            _ => {
+                self.offset = 0;
+                Ok(())
+            }
+        }
+    }
+
+    pub fn trimmed_to(&self, token_count: i32) -> Result<Self, Exception> {
+        let mut clone = self.clone();
+        clone.trim_to(token_count)?;
+        Ok(clone)
+    }
+}
+
+fn slice_kv_prefix(array: &Array, token_count: i32) -> Result<Array, Exception> {
+    match array.shape().len() {
+        4 => Ok(array.index((.., .., ..token_count, ..))),
+        3 => Ok(array.index((.., ..token_count, ..))),
+        other => Err(Exception::custom(format!(
+            "unsupported KV cache rank {other} for prefix trim"
+        ))),
+    }
 }
 
 impl KeyValueCache for ConcatKeyValueCache {
@@ -106,3 +155,82 @@ impl KeyValueCache for ConcatKeyValueCache {
 
 /// TODO: A generic KV Cache
 pub struct DefaultKeyValueCache {}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConcatKeyValueCache, KeyValueCache};
+    use mlx_rs::Array;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn test_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("cache test lock poisoned")
+    }
+
+    #[test]
+    fn trimmed_cache_keeps_prefix_and_offset() {
+        let _guard = test_guard();
+        let mut cache = ConcatKeyValueCache::new();
+        let keys = Array::from_slice(&[1f32, 2., 3., 4., 5., 6.], &[1, 1, 3, 2]);
+        let values = Array::from_slice(&[7f32, 8., 9., 10., 11., 12.], &[1, 1, 3, 2]);
+        let _ = cache.update_and_fetch(keys, values).expect("seed cache");
+
+        let trimmed = cache.trimmed_to(2).expect("trimmed clone");
+        assert_eq!(trimmed.offset(), 2);
+
+        let mut trimmed = trimmed;
+        let append_keys = Array::from_slice(&[13f32, 14.], &[1, 1, 1, 2]);
+        let append_values = Array::from_slice(&[15f32, 16.], &[1, 1, 1, 2]);
+        let (keys, values) = trimmed
+            .update_and_fetch(append_keys, append_values)
+            .expect("append after trim");
+
+        assert_eq!(keys.shape(), &[1, 1, 3, 2]);
+        assert_eq!(values.shape(), &[1, 1, 3, 2]);
+        assert_eq!(keys.as_slice::<f32>(), &[1., 2., 3., 4., 13., 14.]);
+        assert_eq!(values.as_slice::<f32>(), &[7., 8., 9., 10., 15., 16.]);
+    }
+
+    #[test]
+    fn trim_to_larger_offset_is_noop() {
+        let _guard = test_guard();
+        let mut cache = ConcatKeyValueCache::new();
+        let keys = Array::from_slice(&[1f32, 2., 3., 4.], &[1, 1, 2, 2]);
+        let values = Array::from_slice(&[5f32, 6., 7., 8.], &[1, 1, 2, 2]);
+        let _ = cache.update_and_fetch(keys, values).expect("seed cache");
+
+        cache.trim_to(8).expect("trim beyond end");
+        assert_eq!(cache.offset(), 2);
+    }
+
+    #[test]
+    fn trimmed_to_does_not_mutate_original_cache() {
+        let _guard = test_guard();
+        let mut cache = ConcatKeyValueCache::new();
+        let keys = Array::from_slice(&[1f32, 2., 3., 4., 5., 6.], &[1, 1, 3, 2]);
+        let values = Array::from_slice(&[7f32, 8., 9., 10., 11., 12.], &[1, 1, 3, 2]);
+        let _ = cache.update_and_fetch(keys, values).expect("seed cache");
+
+        let trimmed = cache.trimmed_to(2).expect("trimmed clone");
+
+        assert_eq!(cache.offset(), 3);
+        assert_eq!(trimmed.offset(), 2);
+
+        let mut original = cache;
+        let mut trimmed = trimmed;
+        let append_keys = Array::from_slice(&[13f32, 14.], &[1, 1, 1, 2]);
+        let append_values = Array::from_slice(&[15f32, 16.], &[1, 1, 1, 2]);
+
+        let (original_keys, _) = original
+            .update_and_fetch(append_keys.deep_clone(), append_values.deep_clone())
+            .expect("append original");
+        let (trimmed_keys, _) = trimmed
+            .update_and_fetch(append_keys, append_values)
+            .expect("append trimmed");
+
+        assert_eq!(original_keys.as_slice::<f32>(), &[1., 2., 3., 4., 5., 6., 13., 14.]);
+        assert_eq!(trimmed_keys.as_slice::<f32>(), &[1., 2., 3., 4., 13., 14.]);
+    }
+}

--- a/mlx-lm/src/lib.rs
+++ b/mlx-lm/src/lib.rs
@@ -7,7 +7,7 @@ pub mod utils;
 
 use mlx_rs::Array;
 
-use crate::models::qwen3;
+use crate::models::{qwen2, qwen3};
 
 pub struct ModelInputBuilder<'a, C, T> {
     pub y: &'a Array,
@@ -20,6 +20,18 @@ pub trait ModelInput<'a, C, T> {
 }
 
 impl<'a, C> ModelInput<'a, C, Option<Array>> for qwen3::ModelInput<'a, C> {
+    fn from_model_input_builder(builder: ModelInputBuilder<'a, C, Option<Array>>) -> Self {
+        let ModelInputBuilder { y, cache, state } = builder;
+
+        Self {
+            inputs: y,
+            mask: state.as_ref(),
+            cache,
+        }
+    }
+}
+
+impl<'a, C> ModelInput<'a, C, Option<Array>> for qwen2::ModelInput<'a, C> {
     fn from_model_input_builder(builder: ModelInputBuilder<'a, C, Option<Array>>) -> Self {
         let ModelInputBuilder { y, cache, state } = builder;
 

--- a/mlx-lm/src/models/mod.rs
+++ b/mlx-lm/src/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod llama;
+pub mod qwen2;
 pub mod qwen3;

--- a/mlx-lm/src/models/qwen2.rs
+++ b/mlx-lm/src/models/qwen2.rs
@@ -1,0 +1,176 @@
+use std::path::Path;
+
+use mlx_rs::{error::Exception, module::ModuleParametersExt};
+use serde::Deserialize;
+use tokenizers::Tokenizer;
+
+use crate::{error::Error, models::llama, utils::rope::FloatOrString};
+
+pub type Attention = llama::Attention;
+pub type Mlp = llama::Mlp;
+pub type TransformerBlock = llama::TransformerBlock;
+pub type Qwen2Model = llama::LlamaModel;
+pub type Model = llama::Model;
+pub type ModelInput<'a, C> = llama::ModelInput<'a, C>;
+pub type Generate<'a, C> = llama::Generate<'a, C>;
+pub type GenerateState<'a> = llama::GenerateState<'a>;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelArgs {
+    pub model_type: String,
+    pub hidden_size: i32,
+    pub num_hidden_layers: i32,
+    pub intermediate_size: i32,
+    pub num_attention_heads: i32,
+    pub rms_norm_eps: f32,
+    pub vocab_size: i32,
+    pub num_key_value_heads: i32,
+    #[serde(default = "default_max_position_embeddings")]
+    pub max_position_embeddings: i32,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f32,
+    #[serde(default)]
+    pub rope_traditional: bool,
+    #[serde(default)]
+    pub rope_scaling: Option<std::collections::HashMap<String, FloatOrString>>,
+    #[serde(default = "default_true")]
+    pub tie_word_embeddings: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_max_position_embeddings() -> i32 {
+    32768
+}
+
+fn default_rope_theta() -> f32 {
+    1_000_000.0
+}
+
+impl From<ModelArgs> for llama::ModelArgs {
+    fn from(value: ModelArgs) -> Self {
+        let head_dim = value.hidden_size / value.num_attention_heads;
+        Self {
+            model_type: value.model_type,
+            hidden_size: value.hidden_size,
+            num_hidden_layers: value.num_hidden_layers,
+            intermediate_size: value.intermediate_size,
+            num_attention_heads: value.num_attention_heads,
+            rms_norm_eps: value.rms_norm_eps,
+            vocab_size: value.vocab_size,
+            num_key_value_heads: value.num_key_value_heads,
+            max_position_embeddings: value.max_position_embeddings,
+            rope_theta: value.rope_theta,
+            head_dim,
+            tie_word_embeddings: value.tie_word_embeddings,
+            attention_bias: true,
+            mlp_bias: false,
+            rope_scaling: value.rope_scaling,
+        }
+    }
+}
+
+pub fn load_qwen2_tokenizer(model_dir: impl AsRef<Path>) -> Result<Tokenizer, Error> {
+    llama::load_llama_tokenizer(model_dir)
+}
+
+pub fn get_qwen2_model_args(model_dir: impl AsRef<Path>) -> Result<ModelArgs, Error> {
+    let model_args_filename = model_dir.as_ref().join("config.json");
+    let file = std::fs::File::open(model_args_filename)?;
+    let model_args: ModelArgs = serde_json::from_reader(file)?;
+
+    Ok(model_args)
+}
+
+pub fn load_qwen2_model(model_dir: impl AsRef<Path>) -> Result<Model, Error> {
+    let model_dir = model_dir.as_ref();
+    let model_args = get_qwen2_model_args(model_dir)?;
+    let mut model = Model::new(model_args.into())?;
+
+    let weights_index = model_dir.join("model.safetensors.index.json");
+    if weights_index.exists() {
+        let json = std::fs::read_to_string(weights_index)?;
+        let weight_map: llama::WeightMap = serde_json::from_str(&json)?;
+
+        let weight_files: std::collections::HashSet<&String> =
+            weight_map.weight_map.values().collect();
+        for weight_file in weight_files {
+            let weights_filename = model_dir.join(weight_file);
+            model.load_safetensors(weights_filename)?;
+        }
+    } else {
+        let weights_filename = model_dir.join("model.safetensors");
+        model.load_safetensors(weights_filename)?;
+    }
+
+    Ok(model)
+}
+
+pub fn sample(logits: &mlx_rs::Array, temp: f32) -> Result<mlx_rs::Array, Exception> {
+    llama::sample(logits, temp)
+}
+
+#[cfg(test)]
+mod tests {
+    use mlx_rs::{
+        ops::indexing::{IndexOp, NewAxis},
+        transforms::eval,
+        Array,
+    };
+
+    use crate::{
+        cache::ConcatKeyValueCache,
+        models::qwen2::{load_qwen2_model, load_qwen2_tokenizer},
+    };
+
+    const CACHED_TEST_MODEL_DIR: &str =
+        "/Users/jdumay/.cache/huggingface/hub/models--mlx-community--Qwen2.5-0.5B-Instruct-bf16/snapshots/56d07e766edd7159fbe12ed12d9cf114bf38bf1e";
+
+    #[test]
+    #[ignore = "requires local model files"]
+    fn test_load_qwen2_model() {
+        let model = super::load_qwen2_model(CACHED_TEST_MODEL_DIR).unwrap();
+        assert_eq!(model.model_type(), "qwen2");
+    }
+
+    #[test]
+    #[ignore = "requires local model files"]
+    fn test_load_tokenizer() {
+        let tokenizer = load_qwen2_tokenizer(CACHED_TEST_MODEL_DIR).unwrap();
+        let _encoding = tokenizer.encode("Hello, world!", true).unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires local model files"]
+    fn test_load_and_run_qwen2_with_concat_cache() {
+        let tokenizer = load_qwen2_tokenizer(CACHED_TEST_MODEL_DIR).unwrap();
+        let mut model = load_qwen2_model(CACHED_TEST_MODEL_DIR).unwrap();
+
+        let encoding = tokenizer.encode("hello", true).unwrap();
+        let prompt_tokens = Array::from(encoding.get_ids()).index(NewAxis);
+        let mut cache = Vec::new();
+
+        let mut tokens = Vec::new();
+        let generate = super::Generate::<ConcatKeyValueCache>::new(
+            &mut model,
+            &mut cache,
+            0.0,
+            &prompt_tokens,
+        );
+        for (token, ntoks) in generate.zip(0..10) {
+            let token = token.unwrap();
+            tokens.push(token.clone());
+
+            if ntoks == 0 {
+                eval(&tokens).unwrap();
+            }
+        }
+
+        eval(&tokens).unwrap();
+        let slice: Vec<u32> = tokens.drain(..).map(|t| t.item::<u32>()).collect();
+        let s = tokenizer.decode(&slice, true).unwrap();
+        assert!(!s.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- add a native `qwen2` model module to `mlx-lm`
- reuse the existing llama runtime shape where the architecture already matches
- validate against the local Qwen2.5 0.5B bf16 checkpoint

## Validation
- `cargo test -p mlx-lm qwen2 --no-run`
- `cargo test -p mlx-lm test_load_and_run_qwen2_with_concat_cache -- --ignored --nocapture --test-threads=1`