### PR TITLE
fast: add scaled_dot_product_attention_pad_to_fused helper

### DIFF
--- a/mlx-rs/examples/sdpa_pad_to_fused_bench.rs
+++ b/mlx-rs/examples/sdpa_pad_to_fused_bench.rs
@@ -1,0 +1,78 @@
+//! Benchmark `scaled_dot_product_attention_pad_to_fused` vs the
+//! plain `scaled_dot_product_attention` at non-fused head_dims.
+//! Demonstrates the speedup the helper unlocks for models like
+//! Qwen3-VL (head_dim=72) at long-context prefill.
+//!
+//! Run with:
+//!   cargo run --release --example sdpa_pad_to_fused_bench
+
+use std::time::Instant;
+
+use mlx_rs::random::normal;
+use mlx_rs::transforms as mlx_transforms;
+use mlx_rs::Array;
+use mlx_rs::fast::{
+    scaled_dot_product_attention,
+    scaled_dot_product_attention_pad_to_fused,
+};
+
+fn sync(a: &Array) {
+    let _ = mlx_transforms::eval([a]);
+}
+
+fn bench(
+    label: &str,
+    runs: usize,
+    f: impl Fn() -> mlx_rs::error::Result<Array>,
+) {
+    // 10 warmup iterations with sync after each — flushes any
+    // benefit from the previous bench's GPU state.
+    for _ in 0..10 {
+        let r = f().expect("warmup");
+        sync(&r);
+    }
+    // Measured loop: sync after EACH op so we measure end-to-end
+    // dispatch + kernel time per call, not graph-batched throughput.
+    let t0 = Instant::now();
+    for _ in 0..runs {
+        let a = f().expect("run");
+        sync(&a);
+    }
+    let elapsed = t0.elapsed();
+    println!(
+        "  {:<48} {} runs in {:?} ({:?} / run)",
+        label, runs, elapsed, elapsed / runs as u32,
+    );
+}
+
+fn run_case(name: &str, b: i32, h: i32, l: i32, d: i32) {
+    let scale = (d as f32).powf(-0.5);
+    println!("\n=== {name}: [B={b}, H={h}, L={l}, head_dim={d}] ===");
+
+    let q = normal::<f32>(&[b, h, l, d], None, None, None).expect("q");
+    let k = normal::<f32>(&[b, h, l, d], None, None, None).expect("k");
+    let v = normal::<f32>(&[b, h, l, d], None, None, None).expect("v");
+    sync(&q); sync(&k); sync(&v);
+
+    let runs = 50;
+    bench("plain SDPA", runs, || {
+        scaled_dot_product_attention(&q, &k, &v, scale, None, None)
+    });
+    bench("padded SDPA", runs, || {
+        scaled_dot_product_attention_pad_to_fused(&q, &k, &v, scale, None, None)
+    });
+}
+
+fn main() {
+    // The hot case: Qwen3-VL vision tower head_dim=72 at long-context
+    // prefill — falls outside MLX's fused {64, 80, 128} set, hits the
+    // general-purpose fallback. Helper pads to 80 → fused kernel.
+    run_case("Qwen3-VL vision @ L=1024",  1, 16, 1024, 72);
+    run_case("Qwen3-VL vision @ L=4096",  1, 16, 4096, 72);
+    run_case("90-dim transformer @ L=2048", 1, 32, 2048, 90);
+
+    // Passthrough cases: head_dim already in fused set, helper is a
+    // no-op. Confirms the helper does NOT regress the fast path.
+    run_case("Step-Audio-2 encoder (head_dim=64)", 1, 20, 1500, 64);
+    run_case("Llama-style head_dim=128", 1, 32, 2048, 128);
+}

--- a/mlx-rs/src/fast.rs
+++ b/mlx-rs/src/fast.rs
@@ -175,6 +175,198 @@ pub fn scaled_dot_product_attention_device<'a>(
     })
 }
 
+// Head-dim sets supported by MLX's fused SDPA Metal kernels. Source:
+// mlx/backend/metal/scaled_dot_product_attention.cpp lines 618-624 in
+// upstream mlx (commented "sdpa_full_supported_head_dim" and
+// "sdpa_vector_supported_head_dim"). Anything outside these sets falls
+// back to a general-purpose attention path that materializes the
+// (Q, K) score matrix — significantly slower at long sequence
+// lengths. See [`scaled_dot_product_attention_pad_to_fused`] which
+// pads/slices to bring the call into one of these sets.
+//
+// Vector kernel fires when query sequence length == 1 (decode step).
+const SDPA_VECTOR_HEAD_DIMS: [i32; 4] = [64, 96, 128, 256];
+// Full kernel fires for Q > 1 (prefill / encoder).
+const SDPA_FULL_HEAD_DIMS: [i32; 3] = [64, 80, 128];
+
+/// Smallest fused head_dim ≥ `d` for the given query length, or `None`
+/// if no fused kernel can fit `d` (i.e. d > 256 for decode, d > 128
+/// for prefill).
+fn next_fused_head_dim(d: i32, q_seq_len: i32) -> Option<i32> {
+    let table: &[i32] = if q_seq_len == 1 {
+        &SDPA_VECTOR_HEAD_DIMS
+    } else {
+        &SDPA_FULL_HEAD_DIMS
+    };
+    table.iter().copied().find(|&t| t >= d)
+}
+
+/// Like [`scaled_dot_product_attention`] but transparently pads the
+/// `head_dim` of `queries`/`keys`/`values` up to the smallest
+/// supported fused-kernel size when the input `head_dim` falls
+/// outside MLX's fused SDPA tables.
+///
+/// This mirrors the `ensure_fused_sdpa` pattern used by MLX's Python
+/// VLM examples (see `mlx_vlm/models/base.py::ensure_fused_sdpa`):
+/// pad q/k/v with zeros on the last axis to the next supported
+/// head_dim, run the fused kernel, slice the output's last axis back
+/// to the original size. The padded tail contributes zero to the
+/// attention scores (q·k^T = 0 in the padded slots) and zero to the
+/// post-softmax weighted-V sum, so the result is mathematically
+/// equivalent to running attention at the original head_dim.
+///
+/// # When this matters
+///
+/// MLX dispatches fused Metal kernels for two head-dim sets:
+/// - **Prefill (Q > 1):** {64, 80, 128}
+/// - **Decode (Q = 1):** {64, 96, 128, 256}
+///
+/// Outside those sets, MLX falls back to materializing the full
+/// score matrix and running general softmax/matmul — measurably
+/// slower at long sequence lengths. Common cases hit by the
+/// fallback:
+///
+/// | Model | head_dim | Pad to | Path |
+/// |-------|---------:|-------:|------|
+/// | Qwen3-VL vision tower | 72 | 80 | prefill |
+/// | LLaMA-style 90-dim | 90 | 128 | prefill |
+///
+/// # Cost of the helper
+///
+/// One `mlx::ops::pad` per input (zero-fill, last axis only) and one
+/// last-axis slice on the output. The pad and slice run on the GPU
+/// stream and overlap with the SDPA kernel; on long-sequence prefill
+/// the saved fused-kernel work dominates the pad/slice overhead.
+///
+/// **Pad-ratio caveat:** the helper grows the head_dim by `pad_to /
+/// head_dim`. For small ratios (e.g. 72→80 = 1.11×) the fused kernel
+/// is reliably faster than the fallback. For larger ratios (e.g.
+/// 90→128 = 1.42×) the extra kernel work can outweigh the gain.
+/// Real measurements on Apple M4 Max:
+///
+/// | Shape (B, H, L, D) | Plain SDPA | Padded SDPA | Δ |
+/// |--------------------|-----------:|------------:|--:|
+/// | (1, 16, 1024, 72)  | 1.31 ms    | 0.87 ms     | **1.51× faster** |
+/// | (1, 16, 4096, 72)  | 13.9 ms    | 9.87 ms     | **1.41× faster** |
+/// | (1, 32, 2048, 90)  | 7.62 ms    | 7.98 ms     | 0.96× slower (90→128 pad too wide) |
+///
+/// If your `head_dim` lands in the gap between supported sizes by
+/// more than ~25 %, bench your specific shape before relying on this
+/// helper.
+///
+/// Pass-through behavior: if the input head_dim is already in the
+/// fused set OR if no supported size fits (head_dim > 128 in prefill,
+/// head_dim > 256 in decode), this calls
+/// [`scaled_dot_product_attention`] without any padding — the result
+/// is exactly what the un-padded call would have produced.
+///
+/// # Shape contract
+///
+/// Identical to [`scaled_dot_product_attention`]: `queries` shaped
+/// `[B, H_q, L_q, D]`, `keys`/`values` shaped `[B, H_kv, L_kv, D]`.
+/// `H_kv` may be smaller than `H_q` for grouped-query / multi-query
+/// attention. The returned tensor is shaped `[B, H_q, L_q, D]`.
+///
+/// # Example
+///
+/// ```rust, ignore
+/// // head_dim = 72 (e.g. Qwen3-VL vision tower) → padded to 80,
+/// // fused prefill kernel fires, output sliced back to 72.
+/// let out = scaled_dot_product_attention_pad_to_fused(
+///     &queries, &keys, &values, scale, None, None,
+/// )?;
+/// ```
+#[generate_macro(customize(root = "$crate::fast"))]
+#[default_device]
+pub fn scaled_dot_product_attention_pad_to_fused_device<'a>(
+    queries: impl AsRef<Array>,
+    keys: impl AsRef<Array>,
+    values: impl AsRef<Array>,
+    scale: f32,
+    #[optional] mask: impl IntoOption<ScaledDotProductAttentionMask<'a>>,
+    #[optional] sinks: impl Into<Option<&'a Array>>,
+    #[optional] stream: impl AsRef<Stream>,
+) -> Result<Array> {
+    let q = queries.as_ref();
+    let k = keys.as_ref();
+    let v = values.as_ref();
+
+    let q_shape = q.shape();
+    let ndim = q_shape.len();
+    if ndim < 2 {
+        return Err(crate::error::Exception::custom(
+            "scaled_dot_product_attention_pad_to_fused: queries must be at least 2-D",
+        ));
+    }
+    let q_seq_len = q_shape[ndim - 2];
+    let head_dim = q_shape[ndim - 1];
+
+    // Same head_dim across q/k/v? Pure assertion — MLX would error
+    // anyway; we just want to keep the dispatch decision clean.
+    if k.shape()[k.shape().len() - 1] != head_dim || v.shape()[v.shape().len() - 1] != head_dim {
+        return Err(crate::error::Exception::custom(
+            "scaled_dot_product_attention_pad_to_fused: q/k/v head_dim mismatch",
+        ));
+    }
+
+    let stream_ref = stream.as_ref();
+    let mask_opt = mask.into_option();
+    let sinks_opt: Option<&Array> = sinks.into();
+
+    let target = next_fused_head_dim(head_dim, q_seq_len);
+    let pad_to = match target {
+        Some(t) if t > head_dim => t,
+        _ => {
+            // Already in a fused set OR head_dim too big to fit one —
+            // either way the un-padded call is the right thing.
+            return scaled_dot_product_attention_device(
+                q,
+                k,
+                v,
+                scale,
+                mask_opt,
+                sinks_opt,
+                stream_ref,
+            );
+        }
+    };
+
+    let pad_amount = pad_to - head_dim;
+    // Pad widths: zero on every axis except the last; on the last,
+    // pad `pad_amount` on the high side. PadWidth::Widths takes a
+    // slice of (low, high) pairs; build it on the stack.
+    let mut widths: smallvec::SmallVec<[(i32, i32); crate::constants::DEFAULT_STACK_VEC_LEN]> =
+        smallvec::SmallVec::with_capacity(ndim);
+    for _ in 0..(ndim - 1) {
+        widths.push((0, 0));
+    }
+    widths.push((0, pad_amount));
+    let widths_slice: &[(i32, i32)] = &widths;
+
+    let zero_q = Array::from_int(0).as_dtype(q.dtype())?;
+    let zero_kv_q = Array::from_int(0).as_dtype(k.dtype())?;
+    let zero_kv_v = Array::from_int(0).as_dtype(v.dtype())?;
+
+    let q_padded = crate::ops::pad_device(q, widths_slice, zero_q, None, stream_ref)?;
+    let k_padded = crate::ops::pad_device(k, widths_slice, zero_kv_q, None, stream_ref)?;
+    let v_padded = crate::ops::pad_device(v, widths_slice, zero_kv_v, None, stream_ref)?;
+
+    let attn = scaled_dot_product_attention_device(
+        &q_padded,
+        &k_padded,
+        &v_padded,
+        scale,
+        mask_opt,
+        sinks_opt,
+        stream_ref,
+    )?;
+
+    // Slice the last axis back to the original head_dim. attn shape:
+    // [..., L_q, pad_to] → [..., L_q, head_dim].
+    use crate::ops::indexing::IndexOp;
+    Ok(attn.index((.., .., .., 0..head_dim)))
+}
+
 /// Root Mean Square normalization (RMS norm).
 ///
 /// The normalization is with respect to the last axis of the input `x`.
@@ -378,6 +570,90 @@ mod tests {
                 assert_eq!(result.dtype(), dtype);
             }
         }
+    }
+
+    #[test]
+    fn test_next_fused_head_dim_decode() {
+        // Decode (Q=1) supports {64, 96, 128, 256}
+        assert_eq!(next_fused_head_dim(64, 1), Some(64));
+        assert_eq!(next_fused_head_dim(72, 1), Some(96));
+        assert_eq!(next_fused_head_dim(80, 1), Some(96));
+        assert_eq!(next_fused_head_dim(96, 1), Some(96));
+        assert_eq!(next_fused_head_dim(100, 1), Some(128));
+        assert_eq!(next_fused_head_dim(128, 1), Some(128));
+        assert_eq!(next_fused_head_dim(192, 1), Some(256));
+        assert_eq!(next_fused_head_dim(256, 1), Some(256));
+        // Out of range — caller falls through to unpadded path.
+        assert_eq!(next_fused_head_dim(300, 1), None);
+    }
+
+    #[test]
+    fn test_next_fused_head_dim_prefill() {
+        // Prefill (Q>1) supports {64, 80, 128}
+        assert_eq!(next_fused_head_dim(64, 1024), Some(64));
+        assert_eq!(next_fused_head_dim(72, 1024), Some(80));
+        assert_eq!(next_fused_head_dim(80, 1024), Some(80));
+        assert_eq!(next_fused_head_dim(90, 1024), Some(128));
+        assert_eq!(next_fused_head_dim(128, 1024), Some(128));
+        // Out of range.
+        assert_eq!(next_fused_head_dim(192, 1024), None);
+        assert_eq!(next_fused_head_dim(256, 1024), None);
+    }
+
+    /// Mathematical equivalence: padding zeros on the head_dim axis is
+    /// a no-op for the attention output. q·k^T contributions from the
+    /// padded slots are zero (zero × anything = zero), softmax is
+    /// shift-invariant, and the post-softmax weighted-V sum reads
+    /// zero from the padded V slots. Slicing the output back to the
+    /// original head_dim must therefore produce a result numerically
+    /// identical (up to fp16/fp32 noise) to the unpadded call.
+    #[test]
+    fn test_pad_to_fused_matches_unpadded_at_head_dim_72() {
+        crate::random::seed(7272).unwrap();
+        let b = 2;
+        let n_q = 16;
+        let t_q = 128;
+        let t_kv = 128;
+        let d = 72; // Qwen3-VL vision tower head_dim — falls back without padding.
+        let q = normal::<f32>(&[b, n_q, t_q, d], None, None, None).unwrap();
+        let k = normal::<f32>(&[b, n_q, t_kv, d], None, None, None).unwrap();
+        let v = normal::<f32>(&[b, n_q, t_kv, d], None, None, None).unwrap();
+        let scale = (d as f32).powf(-0.5);
+
+        let unpadded = scaled_dot_product_attention(&q, &k, &v, scale, None, None).unwrap();
+        let padded = scaled_dot_product_attention_pad_to_fused(&q, &k, &v, scale, None, None)
+            .unwrap();
+
+        assert_eq!(padded.shape(), unpadded.shape());
+        assert_eq!(padded.dtype(), unpadded.dtype());
+        // Cosine similarity check — the two paths use different
+        // kernels so we expect bit-equivalent up to rounding noise.
+        let diff = (&padded - &unpadded).abs().unwrap();
+        let max_abs = diff.max(None).unwrap().item::<f32>();
+        assert!(
+            max_abs < 1e-4,
+            "padded SDPA diverged from unpadded by {max_abs} > 1e-4",
+        );
+    }
+
+    #[test]
+    fn test_pad_to_fused_passthrough_when_already_fused() {
+        // head_dim=64 is already in both vector and full sets — the
+        // helper must not allocate a pad/slice round-trip.
+        crate::random::seed(64).unwrap();
+        let q = normal::<f32>(&[1, 8, 128, 64], None, None, None).unwrap();
+        let k = normal::<f32>(&[1, 8, 128, 64], None, None, None).unwrap();
+        let v = normal::<f32>(&[1, 8, 128, 64], None, None, None).unwrap();
+        let scale = 0.125;
+
+        let unpadded = scaled_dot_product_attention(&q, &k, &v, scale, None, None).unwrap();
+        let padded = scaled_dot_product_attention_pad_to_fused(&q, &k, &v, scale, None, None)
+            .unwrap();
+
+        let diff = (&padded - &unpadded).abs().unwrap();
+        let max_abs = diff.max(None).unwrap().item::<f32>();
+        // Bit-identical — same kernel, same inputs.
+        assert!(max_abs == 0.0, "passthrough diverged: max_abs={max_abs}");
     }
 
     // Test adapted from Python test `test_fast_sdpa.py/test_sdpa_attention_sinks`


### PR DESCRIPTION
## Summary

Adds `mlx_rs::fast::scaled_dot_product_attention_pad_to_fused` — a wrapper that automatically pads `head_dim` up to the smallest fused-kernel size when the input falls outside MLX's supported sets, runs the fused SDPA, then slices the output back. Mirrors the `ensure_fused_sdpa` pattern from MLX's Python VLM examples ([`mlx_vlm/models/base.py`](https://github.com/Blaizzy/mlx-vlm/blob/main/mlx_vlm/models/base.py)).

## Why

MLX dispatches optimized Metal SDPA kernels for two head_dim sets (see [`mlx/backend/metal/scaled_dot_product_attention.cpp:618-624`](https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/scaled_dot_product_attention.cpp)):

- **Prefill** (Q > 1): `{64, 80, 128}`
- **Decode**  (Q = 1): `{64, 96, 128, 256}`

Outside those sets, MLX falls back to a general-purpose attention that materializes the full (Q, K) score matrix — measurably slower at long sequence lengths. Real models that hit the fallback:

- **Qwen3-VL vision tower**: `head_dim = 1152 / 16 = 72` → fallback at prefill.
- Several non-power-of-two LLaMA / DiT variants in the 90-110 range.

## Implementation

Pure pre-existing-op composition — no new C bindings or kernels. Pads q/k/v on the last axis to the next supported size, dispatches the regular `scaled_dot_product_attention`, slices the result back. The padded slots contribute zero to the dot product (q·k^T = 0) and zero to the post-softmax weighted-V sum, so the result is mathematically equivalent up to fp16/fp32 rounding.

Pass-through behavior: when `head_dim` is already in the fused set, OR when no supported size fits (head_dim > 256 in decode, > 128 in prefill), this calls plain `scaled_dot_product_attention` with no pad/slice round-trip.

## Validation

10 `fast::tests` pass under `cargo test --release -p mlx-rs --lib fast::tests -- --test-threads=1`, including new tests:

- `test_next_fused_head_dim_decode` — covers the `{64, 96, 128, 256}` lookup.
- `test_next_fused_head_dim_prefill` — covers the `{64, 80, 128}` lookup.
- `test_pad_to_fused_matches_unpadded_at_head_dim_72` — numerically asserts the padded path produces the same output as the unpadded call (max abs diff < 1e-4) on a Qwen3-VL-shaped tensor.
- `test_pad_to_fused_passthrough_when_already_fused` — confirms bit-identical output when head_dim=64 (no pad triggered).

## Benchmark

`cargo run --release -p mlx-rs --example sdpa_pad_to_fused_bench` on Apple M4 Max (sync after each call to measure end-to-end dispatch + kernel time):

| Shape `(B, H, L, D)`                     | Plain SDPA | Padded SDPA | Δ |
|------------------------------------------|-----------:|------------:|---|
| Qwen3-VL vision @ L=1024, D=72           | 1.31 ms    | 0.87 ms     | **1.51× faster** |
| Qwen3-VL vision @ L=4096, D=72           | 13.9 ms    | 9.87 ms     | **1.41× faster** |
| 90-dim transformer @ L=2048, D=90        | 7.62 ms    | 7.98 ms     | 0.96× slower (90→128 pad ratio too wide) |
| Step-Audio-2 encoder, D=64               | 1.36 ms    | 1.36 ms     | passthrough |
| Llama-style, D=128                       | 7.56 ms    | 7.49 ms     | passthrough |

**Pad-ratio caveat:** the helper grows head_dim by `pad_to / head_dim`. For ratios ≤ 1.25× (e.g. 72→80) the fused kernel reliably wins. For larger ratios (e.g. 90→128 = 1.42×) the extra kernel work can outweigh the gain. Documented in the function rustdoc with a recommendation to bench specific shapes.

## Discovery context

Found while wiring Qwen3-VL multimodal support in a downstream mlx-rs consumer. The vision tower's `head_dim = 72` was hitting MLX's fallback path; padding to 80 lifted the entire forward back onto the fused kernel. With this helper, the Rust API reaches parity with the Python VLM idiom and the speedup is available to any caller without re-implementing the trick.

## Related

Same author's previous PR #347 (`fast::rms_norm: accept Option<&Array> for weight`) is also in flight — the discovery here came from the same investigation. They're independent and can land in either order.

This PR addresses one part of the perf-investigation surface in #339 (flash attention wiring for ASR/FLUX encoder paths). For Step-Audio-2 (head_dim=64) the helper is a no-op (already fused). For the vision-tower-style shapes in the issue's benchmark table, the helper closes a meaningful gap without the complexity of integrating the OminiX flash-attention kernel.